### PR TITLE
Transfer from lukasmartinelli to organisation

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,1 @@
-Dockerfile
+docker/Dockerfile

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,12 +1,10 @@
-* [x] This is a bug report
-* [ ] This is a feature request
-* [ ] I searched existing issues before opening this one
+- [x] This is a bug report
+- [ ] This is a feature request
+- [ ] I searched existing issues before opening this one
 
 ### Expected behavior
 
-
 ### Actual behavior
-
 
 ### Steps to reproduce the behavior
 

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -19,7 +19,7 @@ REMOVE SENSITIVE DATA BEFORE POSTING (replace those parts with "REDACTED")
 -->
 
 **Output of `hadolint --version` or
-  `docker run --rm lukasmartinelli/hadolint hadolint --version`:**
+  `docker run --rm hadolint/hadolint hadolint --version`:**
 
 ```bash
 (paste your output here)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,8 +5,8 @@ If this is a bug fix, make sure your description includes "fixes #xxxx", or
 Please provide the following information:
 -->
 
-**- What I did**
+### What I did
 
-**- How I did it**
+### How I did it
 
-**- How to verify it**
+### How to verify it

--- a/.travis.yml
+++ b/.travis.yml
@@ -75,12 +75,15 @@ matrix:
       before_install: true
       install:
         # Build image
-        - travis_wait 30 docker build -t hadolint:$(git describe --tags --dirty) .
+        - travis_wait 30 docker build
+          --tag hadolint:$(git describe --tags --dirty)
+          --file docker/Dockerfile .
       script:
         # List images
         - docker image ls
         # Lint its own Dockerfile
-        - docker run --rm -i hadolint:$(git describe --tags --dirty) < Dockerfile
+        - docker run --rm -i hadolint:$(git describe --tags --dirty) <
+          docker/Dockerfile
         # Check that version in hadolint in the same as its `git describe`
         - grep $(git describe --dirty) <<<
           $(docker run --rm -i hadolint:$(git describe --tags --dirty) hadolint --version)
@@ -109,7 +112,7 @@ install:
 
 script:
   - stack --no-terminal $ARGS test
-  - hadolint Dockerfile
+  - hadolint docker/Dockerfile
 
 after_success:
   - mkdir -p ./releases/

--- a/README.md
+++ b/README.md
@@ -1,7 +1,10 @@
-# Haskell Dockerfile Linter [![Linux/OSX Build Status](https://travis-ci.org/lukasmartinelli/hadolint.svg?branch=master)](https://travis-ci.org/lukasmartinelli/hadolint) [![Windows Build status](https://ci.appveyor.com/api/projects/status/t6m5vpv6mud7yi89/branch/master?svg=true)](https://ci.appveyor.com/project/lukasmartinelli/hadolint/branch/master) [![GPL-3 licensed](https://img.shields.io/badge/license-GPL--3-blue.svg)](https://tldrlegal.com/license/gnu-general-public-license-v3-(gpl-3))
+[![Linux/OSX Build Status][travis-img]][travis]
+[![Windows Build status][appveyor-img]][appveyor]
+[![GPL-3 licensed][license-img]][license]
 
 <img align="right" alt="pipecat" width="150" src="http://hadolint.lukasmartinelli.ch/img/cat_container.png" />
 
+# Haskell Dockerfile Linter
 A smarter Dockerfile linter that helps you build [best practice Docker images](https://docs.docker.com/engine/articles/dockerfile_best-practices/).
 The linter is parsing the Dockerfile into an AST and performs rules on top of the AST.
 It is standing on the shoulders of [Shellcheck](https://github.com/koalaman/shellcheck) to lint the Bash
@@ -24,13 +27,15 @@ Docker comes to the rescue to provide an easy way how to run `hadolint` on most 
 Just pipe your `Dockerfile` to `docker run`:
 
 ```
-docker run --rm -i lukasmartinelli/hadolint < Dockerfile
+docker run --rm -i hadolint/hadolint < Dockerfile
 ```
 
 ## Install
 
-You can [**download prebuilt binaries for OSX, Windows and Linux from the latest release page**](https://github.com/lukasmartinelli/hadolint/releases/latest
-). However they may not run on your system configuration since I am not able to provide completely statically linked binaries. Fall back to `brew`, source installation or Docker if it doesn't work for you.
+You can download prebuilt binaries for OSX, Windows and Linux from the latest
+[release page][]. However, they may not run on your system configuration since
+I am not able to provide completely statically linked binaries. Fall back to
+`brew`, source installation or Docker if it doesn't work for you.
 
 If you are on OSX you can use [brew](http://brew.sh/) to install hadolint.
 
@@ -42,77 +47,80 @@ You can also build `hadolint` locally. You need [Haskell](https://www.haskell.or
 the [stack build tool](http://docs.haskellstack.org/en/stable/install_and_upgrade.html) to build the binary.
 
 ```bash
-git clone https://github.com/lukasmartinelli/hadolint
+git clone https://github.com/hadolint/hadolint
 cd hadolint
 stack build
 ```
 
 ## Rules
 
-Incomplete list of implemented rules. Click on the error code to get more detailed information.
+An incomplete list of implemented rules. Click on the error code to get more
+detailed information.
 
-- Rules with the prefix `DL` originate from **hadolint**. Take a look into `Rules.hs` to find the implementation of the rules.
-- Rules with the `SC` prefix originate from **ShellCheck** (Only the most common rules are listed, there are dozens more)
+-   Rules with the prefix `DL` originate from **hadolint**. Take a look at
+`Rules.hs` to find the implementation of the rules.
 
-Please [create an issue](https://github.com/lukasmartinelli/hadolint/issues/new) if you have an idea for a good rule.
+-   Rules with the `SC` prefix originate from **ShellCheck** (Only the most
+common rules are listed, there are dozens more)
 
-| Rule                                                              | Description
-| ----------------------------------------------------------------- | --------------------------------------------------------------------------------------------------
-| [DL3000](https://github.com/lukasmartinelli/hadolint/wiki/DL3000) | Use absolute WORKDIR.
-| [DL3001](https://github.com/lukasmartinelli/hadolint/wiki/DL3001) | For some bash commands it makes no sense running them in a Docker container like ssh, vim, shutdown, service, ps, free, top, kill, mount, ifconfig.
-| [DL3002](https://github.com/lukasmartinelli/hadolint/wiki/DL3002) | Do not switch to root USER.
-| [DL3003](https://github.com/lukasmartinelli/hadolint/wiki/DL3003) | Use WORKDIR to switch to a directory.
-| [DL3004](https://github.com/lukasmartinelli/hadolint/wiki/DL3004) | Do not use sudo as it leads to unpredictable behavior. Use a tool like gosu to enforce root.
-| [DL3005](https://github.com/lukasmartinelli/hadolint/wiki/DL3005) | Do not use apt-get upgrade or dist-upgrade.
-| [DL3007](https://github.com/lukasmartinelli/hadolint/wiki/DL3007) | Using latest is prone to errors if the image will ever update. Pin the version explicitly to a release tag.
-| [DL3006](https://github.com/lukasmartinelli/hadolint/wiki/DL3006) | Always tag the version of an image explicitly.
-| [DL3008](https://github.com/lukasmartinelli/hadolint/wiki/DL3008) | Pin versions in apt get install.
-| [DL3009](https://github.com/lukasmartinelli/hadolint/wiki/DL3009) | Delete the apt-get lists after installing something.
-| [DL3010](https://github.com/lukasmartinelli/hadolint/wiki/DL3010) | Use ADD for extracting archives into an image.
-| [DL3011](https://github.com/lukasmartinelli/hadolint/wiki/DL3011) | Valid UNIX ports range from 0 to 65535.
-| [DL3012](https://github.com/lukasmartinelli/hadolint/wiki/DL3012) | Provide an email address or URL as maintainer.
-| [DL3013](https://github.com/lukasmartinelli/hadolint/wiki/DL3013) | Pin versions in pip.
-| [DL3014](https://github.com/lukasmartinelli/hadolint/wiki/DL3014) | Use the `-y` switch.
-| [DL3015](https://github.com/lukasmartinelli/hadolint/wiki/DL3015) | Avoid additional packages by specifying --no-install-recommends.
-| [DL3016](https://github.com/lukasmartinelli/hadolint/wiki/DL3016) | Pin versions in `npm`.
-| [DL3020](https://github.com/lukasmartinelli/hadolint/wiki/DL3020) | Use `COPY` instead of `ADD` for files and folders.
-| [DL4000](https://github.com/lukasmartinelli/hadolint/wiki/DL4000) | Specify a maintainer of the Dockerfile.
-| [DL4001](https://github.com/lukasmartinelli/hadolint/wiki/DL4001) | Either use Wget or Curl but not both.
-| [DL4003](https://github.com/lukasmartinelli/hadolint/wiki/DL4003) | Multiple `CMD` instructions found.
-| [DL4004](https://github.com/lukasmartinelli/hadolint/wiki/DL4004) | Multiple `ENTRYPOINT` instructions found.
-| [DL4005](https://github.com/lukasmartinelli/hadolint/wiki/DL4005) | Use `SHELL` to change the default shell.
-| [SC1000](https://github.com/koalaman/shellcheck/wiki/SC1000)      | `$` is not used specially and should therefore be escaped.
-| [SC1001](https://github.com/koalaman/shellcheck/wiki/SC1001)      | This `\c` will be a regular `'c'`  in this context.
-| [SC1007](https://github.com/koalaman/shellcheck/wiki/SC1007)      | Remove space after `=` if trying to assign a value (or for empty string, use `var='' ...`).
-| [SC1010](https://github.com/koalaman/shellcheck/wiki/SC1010)      | Use semicolon or linefeed before `done` (or quote to make it literal).
-| [SC1018](https://github.com/koalaman/shellcheck/wiki/SC1018)      | This is a unicode non-breaking space. Delete it and retype as space.
-| [SC1035](https://github.com/koalaman/shellcheck/wiki/SC1035)      | You need a space here
-| [SC1045](https://github.com/koalaman/shellcheck/wiki/SC1045)      | It's not `foo &; bar`, just `foo & bar`.
-| [SC1065](https://github.com/koalaman/shellcheck/wiki/SC1065)      | Trying to declare parameters? Don't. Use `()` and refer to params as `$1`, `$2` etc.
-| [SC1066](https://github.com/koalaman/shellcheck/wiki/SC1066)      | Don't use $ on the left side of assignments.
-| [SC1068](https://github.com/koalaman/shellcheck/wiki/SC1068)      | Don't put spaces around the `=` in assignments.
-| [SC1077](https://github.com/koalaman/shellcheck/wiki/SC1077)      | For command expansion, the tick should slant left (\` vs ´).
-| [SC1078](https://github.com/koalaman/shellcheck/wiki/SC1078)      | Did you forget to close this double quoted string?
-| [SC1079](https://github.com/koalaman/shellcheck/wiki/SC1079)      | This is actually an end quote, but due to next char it looks suspect.
-| [SC1081](https://github.com/koalaman/shellcheck/wiki/SC1081)      | Scripts are case sensitive. Use `if`, not `If`.
-| [SC1083](https://github.com/koalaman/shellcheck/wiki/SC1083)      | This `{/}` is literal. Check expression (missing `;/\n`?) or quote it.
-| [SC1086](https://github.com/koalaman/shellcheck/wiki/SC1086)      | Don't use `$` on the iterator name in for loops.
-| [SC1087](https://github.com/koalaman/shellcheck/wiki/SC1087)      | Braces are required when expanding arrays, as in `${array[idx]}`.
-| [SC1095](https://github.com/koalaman/shellcheck/wiki/SC1095)      | You need a space or linefeed between the function name and body.
-| [SC1097](https://github.com/koalaman/shellcheck/wiki/SC1097)      | Unexpected `==`. For assignment, use `=`. For comparison, use `[/[[`.
-| [SC1098](https://github.com/koalaman/shellcheck/wiki/SC1098)      | Quote/escape special characters when using `eval`, e.g. `eval "a=(b)"`.
-| [SC1099](https://github.com/koalaman/shellcheck/wiki/SC1099)      | You need a space before the `#`.
-| [SC2002](https://github.com/koalaman/shellcheck/wiki/SC2002)      | Useless cat. Consider `cmd < file | ..` or `cmd file | ..` instead.
-| [SC2015](https://github.com/koalaman/shellcheck/wiki/SC2015)      | Note that `A && B || C` is not if-then-else. C may run when A is true.
-| [SC2026](https://github.com/koalaman/shellcheck/wiki/SC2026)      | This word is outside of quotes. Did you intend to 'nest '"'single quotes'"' instead'?
-| [SC2028](https://github.com/koalaman/shellcheck/wiki/SC2028)      | `echo` won't expand escape sequences. Consider `printf`.
-| [SC2035](https://github.com/koalaman/shellcheck/wiki/SC2035)      | Use `./*glob*` or `-- *glob*` so names with dashes won't become options.
-| [SC2046](https://github.com/koalaman/shellcheck/wiki/SC2046)      | Quote this to prevent word splitting
-| [SC2086](https://github.com/koalaman/shellcheck/wiki/SC2086)      | Double quote to prevent globbing and word splitting.
-| [SC2140](https://github.com/koalaman/shellcheck/wiki/SC2140)      | Word is on the form `"A"B"C"` (B indicated). Did you mean `"ABC"` or `"A\"B\"C"`?
-| [SC2154](https://github.com/koalaman/shellcheck/wiki/SC2154)      | var is referenced but not assigned.
-| [SC2164](https://github.com/koalaman/shellcheck/wiki/SC2164)      | Use `cd ... || exit` in case `cd` fails.
+Please [create an issue][] if you have an idea for a good rule.
 
+| Rule                                                         | Description                                                                                                                                         |
+|--------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------|
+| [DL3000](https://github.com/hadolint/hadolint/wiki/DL3000)   | Use absolute WORKDIR.                                                                                                                               |
+| [DL3001](https://github.com/hadolint/hadolint/wiki/DL3001)   | For some bash commands it makes no sense running them in a Docker container like ssh, vim, shutdown, service, ps, free, top, kill, mount, ifconfig. |
+| [DL3002](https://github.com/hadolint/hadolint/wiki/DL3002)   | Do not switch to root USER.                                                                                                                         |
+| [DL3003](https://github.com/hadolint/hadolint/wiki/DL3003)   | Use WORKDIR to switch to a directory.                                                                                                               |
+| [DL3004](https://github.com/hadolint/hadolint/wiki/DL3004)   | Do not use sudo as it leads to unpredictable behavior. Use a tool like gosu to enforce root.                                                        |
+| [DL3005](https://github.com/hadolint/hadolint/wiki/DL3005)   | Do not use apt-get upgrade or dist-upgrade.                                                                                                         |
+| [DL3007](https://github.com/hadolint/hadolint/wiki/DL3007)   | Using latest is prone to errors if the image will ever update. Pin the version explicitly to a release tag.                                         |
+| [DL3006](https://github.com/hadolint/hadolint/wiki/DL3006)   | Always tag the version of an image explicitly.                                                                                                      |
+| [DL3008](https://github.com/hadolint/hadolint/wiki/DL3008)   | Pin versions in apt-get install.                                                                                                                    |
+| [DL3009](https://github.com/hadolint/hadolint/wiki/DL3009)   | Delete the apt-get lists after installing something.                                                                                                |
+| [DL3010](https://github.com/hadolint/hadolint/wiki/DL3010)   | Use ADD for extracting archives into an image.                                                                                                      |
+| [DL3011](https://github.com/hadolint/hadolint/wiki/DL3011)   | Valid UNIX ports range from 0 to 65535.                                                                                                             |
+| [DL3012](https://github.com/hadolint/hadolint/wiki/DL3012)   | Provide an email address or URL as maintainer.                                                                                                      |
+| [DL3013](https://github.com/hadolint/hadolint/wiki/DL3013)   | Pin versions in pip.                                                                                                                                |
+| [DL3014](https://github.com/hadolint/hadolint/wiki/DL3014)   | Use the `-y` switch.                                                                                                                                |
+| [DL3015](https://github.com/hadolint/hadolint/wiki/DL3015)   | Avoid additional packages by specifying --no-install-recommends.                                                                                    |
+| [DL3016](https://github.com/hadolint/hadolint/wiki/DL3016)   | Pin versions in `npm`.                                                                                                                              |
+| [DL3020](https://github.com/hadolint/hadolint/wiki/DL3020)   | Use `COPY` instead of `ADD` for files and folders.                                                                                                  |
+| [DL4000](https://github.com/hadolint/hadolint/wiki/DL4000)   | Specify a maintainer of the Dockerfile.                                                                                                             |
+| [DL4001](https://github.com/hadolint/hadolint/wiki/DL4001)   | Either use Wget or Curl but not both.                                                                                                               |
+| [DL4003](https://github.com/hadolint/hadolint/wiki/DL4003)   | Multiple `CMD` instructions found.                                                                                                                  |
+| [DL4004](https://github.com/hadolint/hadolint/wiki/DL4004)   | Multiple `ENTRYPOINT` instructions found.                                                                                                           |
+| [DL4005](https://github.com/hadolint/hadolint/wiki/DL4005)   | Use `SHELL` to change the default shell.                                                                                                            |
+| [SC1000](https://github.com/koalaman/shellcheck/wiki/SC1000) | `$` is not used specially and should therefore be escaped.                                                                                          |
+| [SC1001](https://github.com/koalaman/shellcheck/wiki/SC1001) | This `\c` will be a regular `'c'`  in this context.                                                                                                 |
+| [SC1007](https://github.com/koalaman/shellcheck/wiki/SC1007) | Remove space after `=` if trying to assign a value (or for empty string, use `var='' ...`).                                                         |
+| [SC1010](https://github.com/koalaman/shellcheck/wiki/SC1010) | Use semicolon or linefeed before `done` (or quote to make it literal).                                                                              |
+| [SC1018](https://github.com/koalaman/shellcheck/wiki/SC1018) | This is a unicode non-breaking space. Delete it and retype as space.                                                                                |
+| [SC1035](https://github.com/koalaman/shellcheck/wiki/SC1035) | You need a space here                                                                                                                               |
+| [SC1045](https://github.com/koalaman/shellcheck/wiki/SC1045) | It's not `foo &; bar`, just `foo & bar`.                                                                                                            |
+| [SC1065](https://github.com/koalaman/shellcheck/wiki/SC1065) | Trying to declare parameters? Don't. Use `()` and refer to params as `$1`, `$2` etc.                                                                |
+| [SC1066](https://github.com/koalaman/shellcheck/wiki/SC1066) | Don't use $ on the left side of assignments.                                                                                                        |
+| [SC1068](https://github.com/koalaman/shellcheck/wiki/SC1068) | Don't put spaces around the `=` in assignments.                                                                                                     |
+| [SC1077](https://github.com/koalaman/shellcheck/wiki/SC1077) | For command expansion, the tick should slant left (\` vs ´).                                                                                        |
+| [SC1078](https://github.com/koalaman/shellcheck/wiki/SC1078) | Did you forget to close this double-quoted string?                                                                                                  |
+| [SC1079](https://github.com/koalaman/shellcheck/wiki/SC1079) | This is actually an end quote, but due to next char, it looks suspect.                                                                              |
+| [SC1081](https://github.com/koalaman/shellcheck/wiki/SC1081) | Scripts are case sensitive. Use `if`, not `If`.                                                                                                     |
+| [SC1083](https://github.com/koalaman/shellcheck/wiki/SC1083) | This `{/}` is literal. Check expression (missing `;/\n`?) or quote it.                                                                              |
+| [SC1086](https://github.com/koalaman/shellcheck/wiki/SC1086) | Don't use `$` on the iterator name in for loops.                                                                                                    |
+| [SC1087](https://github.com/koalaman/shellcheck/wiki/SC1087) | Braces are required when expanding arrays, as in `${array[idx]}`.                                                                                   |
+| [SC1095](https://github.com/koalaman/shellcheck/wiki/SC1095) | You need a space or linefeed between the function name and body.                                                                                    |
+| [SC1097](https://github.com/koalaman/shellcheck/wiki/SC1097) | Unexpected `==`. For assignment, use `=`. For comparison, use `[/[[`.                                                                               |
+| [SC1098](https://github.com/koalaman/shellcheck/wiki/SC1098) | Quote/escape special characters when using `eval`, e.g. `eval "a=(b)"`.                                                                             |
+| [SC1099](https://github.com/koalaman/shellcheck/wiki/SC1099) | You need a space before the `#`.                                                                                                                    |
+| [SC2002](https://github.com/koalaman/shellcheck/wiki/SC2002) | Useless cat. Consider `cmd < file | ..` or `cmd file | ..` instead.                                                                                 |
+| [SC2015](https://github.com/koalaman/shellcheck/wiki/SC2015) | Note that `A && B || C` is not if-then-else. C may run when A is true.                                                                              |
+| [SC2026](https://github.com/koalaman/shellcheck/wiki/SC2026) | This word is outside of quotes. Did you intend to 'nest '"'single quotes'"' instead'?                                                               |
+| [SC2028](https://github.com/koalaman/shellcheck/wiki/SC2028) | `echo` won't expand escape sequences. Consider `printf`.                                                                                            |
+| [SC2035](https://github.com/koalaman/shellcheck/wiki/SC2035) | Use `./*glob*` or `-- *glob*` so names with dashes won't become options.                                                                            |
+| [SC2046](https://github.com/koalaman/shellcheck/wiki/SC2046) | Quote this to prevent word splitting                                                                                                                |
+| [SC2086](https://github.com/koalaman/shellcheck/wiki/SC2086) | Double quote to prevent globbing and word splitting.                                                                                                |
+| [SC2140](https://github.com/koalaman/shellcheck/wiki/SC2140) | Word is in the form `"A"B"C"` (B indicated). Did you mean `"ABC"` or `"A\"B\"C"`?                                                                   |
+| [SC2154](https://github.com/koalaman/shellcheck/wiki/SC2154) | var is referenced but not assigned.                                                                                                                 |
+| [SC2164](https://github.com/koalaman/shellcheck/wiki/SC2164) | Use `cd ... || exit` in case `cd` fails.                                                                                                            |
 
 ## Develop
 
@@ -123,7 +131,7 @@ if you would tear my code apart in a review.
 
 1. Clone repository
     ```bash
-    git clone --recursive git@github.com:lukasmartinelli/hadolint.git
+    git clone --recursive git@github.com:hadolint/hadolint.git
     ```
 2. Install the dependencies
     ```bash
@@ -169,3 +177,5 @@ Dockerfile syntax is fully described in the [Dockerfile reference](http://docs.d
 - https://github.com/RedCoolBeans/dockerlint/
 - https://github.com/projectatomic/dockerfile_lint/
 - http://dockerfile-linter.com/
+<!-- References -->
+[release page]: https://github.com/hadolint/hadolint/releases/latest

--- a/README.md
+++ b/README.md
@@ -2,17 +2,19 @@
 [![Windows Build status][appveyor-img]][appveyor]
 [![GPL-3 licensed][license-img]][license]
 
-<img align="right" alt="pipecat" width="150" src="http://hadolint.lukasmartinelli.ch/img/cat_container.png" />
+<img align="right" alt="pipecat" width="150"
+src="http://hadolint.lukasmartinelli.ch/img/cat_container.png" />
 
 # Haskell Dockerfile Linter
-A smarter Dockerfile linter that helps you build [best practice Docker images](https://docs.docker.com/engine/articles/dockerfile_best-practices/).
-The linter is parsing the Dockerfile into an AST and performs rules on top of the AST.
-It is standing on the shoulders of [Shellcheck](https://github.com/koalaman/shellcheck) to lint the Bash
-code inside `RUN` instructions.
 
-[:globe_with_meridians: **Check the online version on hadolint.lukasmartinelli.ch**](http://hadolint.lukasmartinelli.ch/.)
+A smarter Dockerfile linter that helps you build [best practice][] Docker
+images. The linter is parsing the Dockerfile into an AST and performs rules on
+top of the AST. It is standing on the shoulders of [ShellCheck][] to lint
+the Bash code inside `RUN` instructions.
 
-[![Screenshot](screenshot.png)](http://hadolint.lukasmartinelli.ch/)
+<!-- [:globe_with_meridians: **Check the online version on
+ hadolint.lukasmartinelli.ch**](http://hadolint.lukasmartinelli.ch/.)
+[![Screenshot](screenshot.png)](http://hadolint.lukasmartinelli.ch/) -->
 
 ## How to use
 
@@ -23,10 +25,11 @@ hadolint <Dockerfile>
 hadolint --ignore DL3003 --ignore DL3006 <Dockerfile> # exclude specific rules
 ```
 
-Docker comes to the rescue to provide an easy way how to run `hadolint` on most platforms.
+Docker comes to the rescue to provide an easy way how to run `hadolint` on most
+platforms.
 Just pipe your `Dockerfile` to `docker run`:
 
-```
+```bash
 docker run --rm -i hadolint/hadolint < Dockerfile
 ```
 
@@ -43,8 +46,8 @@ If you are on OSX you can use [brew](http://brew.sh/) to install hadolint.
 brew install hadolint
 ```
 
-You can also build `hadolint` locally. You need [Haskell](https://www.haskell.org/platform/) and
-the [stack build tool](http://docs.haskellstack.org/en/stable/install_and_upgrade.html) to build the binary.
+You can also build `hadolint` locally. You need [Haskell][] and the [stack][]
+build tool to build the binary.
 
 ```bash
 git clone https://github.com/hadolint/hadolint
@@ -124,16 +127,19 @@ Please [create an issue][] if you have an idea for a good rule.
 
 ## Develop
 
-This is my first Haskell program. If you are an experienced Haskeller I would be really thankful
-if you would tear my code apart in a review.
+This is my first Haskell program. If you are an experienced Haskeller I would
+be really thankful if you would tear my code apart in a review.
 
 ### Setup
 
-1. Clone repository
+1.  Clone repository
+
     ```bash
     git clone --recursive git@github.com:hadolint/hadolint.git
     ```
-2. Install the dependencies
+
+1.  Install the dependencies
+
     ```bash
     stack install
     ```
@@ -159,23 +165,36 @@ stack test
 
 Run integration tests.
 
-```
+```bash
 ./integration_test.sh
 ```
 
 ### Parsing
 
-The Dockerfile is parsed using [Parsec](https://wiki.haskell.org/Parsec) and is using the lexer `Lexer.hs` and parser `Parser.hs`.
+The Dockerfile is parsed using [Parsec](https://wiki.haskell.org/Parsec) and is
+using the lexer `Lexer.hs` and parser `Parser.hs`.
 
 ### AST
 
-Dockerfile syntax is fully described in the [Dockerfile reference](http://docs.docker.com/engine/reference/builder/).  Just take a look at `Syntax.hs` to see the AST definition.
-
+Dockerfile syntax is fully described in the [Dockerfile reference][]. Just take
+a look at `Syntax.hs` to see the AST definition.
 
 ## Alternatives
 
-- https://github.com/RedCoolBeans/dockerlint/
-- https://github.com/projectatomic/dockerfile_lint/
-- http://dockerfile-linter.com/
+- RedCoolBeans/[dockerlint](https://github.com/RedCoolBeans/dockerlint/)
+- projectatomic/[dockerfile_lint](https://github.com/projectatomic/dockerfile_lint/)
+
 <!-- References -->
+[travis-img]: https://travis-ci.org/hadolint/hadolint.svg?branch=master
+[travis]: https://travis-ci.org/hadolint/hadolint
+[appveyor-img]: https://ci.appveyor.com/api/projects/status//github/hadolint/hadolint?svg=true&branch=master
+[appveyor]: https://ci.appveyor.com/project/hadolint/hadolint/branch/master
+[license-img]: https://img.shields.io/badge/license-GPL--3-blue.svg
+[license]: https://tldrlegal.com/license/gnu-general-public-license-v3-(gpl-3)
+[best practice]: https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices
+[shellcheck]: https://github.com/koalaman/shellcheck
 [release page]: https://github.com/hadolint/hadolint/releases/latest
+[haskell]: https://www.haskell.org/platform/
+[stack]: http://docs.haskellstack.org/en/stable/install_and_upgrade.html
+[create an issue]: https://github.com/hadolint/hadolint/issues/new
+[dockerfile reference]: http://docs.docker.com/engine/reference/builder/

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,7 +16,7 @@ build_script:
 
 test_script:
   - stack test
-  - hadolint.exe Dockerfile
+  - hadolint.exe docker\Dockerfile
 
 after_test:
   - rename hadolint.exe hadolint-Windows-x86_64.exe

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -15,9 +15,12 @@ RUN apt-get update \
 RUN curl -sSL https://get.haskellstack.org/ | sh
 
 WORKDIR /opt/hadolint/
+COPY hadolint.cabal stack.yaml /opt/hadolint/ 
+RUN stack --no-terminal --install-ghc test --only-dependencies
+
 COPY . /opt/hadolint
 RUN scripts/fetch_version.sh \
-  && stack install --install-ghc --ghc-options="-fPIC"
+  && stack install --ghc-options="-fPIC"
 
 # COMPRESS WITH UPX
 RUN curl -sSL https://github.com/upx/upx/releases/download/v3.94/upx-3.94-amd64_linux.tar.xz \

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,56 @@
+[![Docker Pulls](https://img.shields.io/docker/pulls/hadolint/hadolint.svg)]() [![Docker Automated buil](https://img.shields.io/docker/automated/hadolint/hadolint.svg)]() [![Docker Build Status](https://img.shields.io/docker/build/hadolint/hadolint.svg)]()
+
+# Hadolint Docker
+
+This is Docker image for the [hadolint](https://github.com/hadolint/hadolint).
+
+Images are based on [glibc-busybox](https://hub.docker.com/_/busybox/) and
+include only `hadolint` static binary.
+
+## Supported tags
+
+-   `hadolint/hadolint:latest` tracks master branch
+
+-   `hadolint/hadolint:VERSION` refers release version, eg. `v1.2.3`
+
+-   `hadolint/hadolint:EXTENDED_VERSION` refers to the same version as
+    `hadolint --version` with short git sha, eg. `v1.2.2-65-g94e9c5d`
+
+Check out [Docker Hub](https://hub.docker.com/r/hadolint/hadolint/tags/)
+for available tags.
+
+## Usage
+
+To use this image, pull from Docker Hub, run the following command:
+
+```bash
+docker pull hadolint/hadolint:latest
+```
+
+Verify the install
+
+```bash
+docker run --rm -it hadolint/hadolint:latest hadolint --version
+Haskell Dockerfile Linter v1.2.2-65-g94e9c5d
+```
+
+or use a particular version number:
+
+```bash
+docker run --rm --it hadolint/hadolint:v1.2.3 hadolint --version
+```
+
+Lint your `Dockerfile`:
+
+```bash
+docker run --rm -i hadolint/hadolint < Dockerfile
+```
+
+To exclude specific rules:
+
+```bash
+docker run --rm -i hadolint/hadolint hadolint \
+  --ignore DL3003 \
+  --ignore DL3006 \
+  - < Dockerfile
+```

--- a/docker/hooks/build
+++ b/docker/hooks/build
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+echo "=> Building the container"
+docker build \
+  --tag $IMAGE_NAME \
+  --file Dockerfile ..

--- a/docker/hooks/push
+++ b/docker/hooks/push
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+echo "=> Tag the image"
+docker tag "${IMAGE_NAME}" "${DOCKER_REPO}:$(git describe --long --always)"
+
+echo "=> Push the image"
+docker push "${DOCKER_REPO}"

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -2,22 +2,23 @@
 
 Only `master` branch is used for releases.
 
-1. Write a **draft** of release where _tag version_ and _release title_ are
-  the same as a version of `hadolint`, eg `v1.2.3`.
-  ![draft](https://user-images.githubusercontent.com/18702153/32983073-f7477820-cc86-11e7-92c6-fabfc1223a25.png)
+1.  Write a **draft** of release where _tag version_ and _release title_ are
+    the same as a version of `hadolint`, eg `v1.2.3`.
+    ![draft](https://user-images.githubusercontent.com/18702153/32983073-f7477820-cc86-11e7-92c6-fabfc1223a25.png)
 
-2. Create an annotated tag with tag name as a message and push it back to
- in a tag message.
-  ```bash
-  export TAG=v1.2.3
-  git tag -a "$TAG" -m "$TAG" && git push origin "$TAG"
-  ```
+1.  Create an annotated tag with tag name as a message and push it back to
     `hadolint/hadolint` remote. Release notes should be in the draft not
+    in a tag message.
 
-3. Tag creation will trigger build in _Travis_ and _AppVeyor_ which will upload
-  binaries to GitHub release draft with the same name as is the name of the tag
-  (created in step 1).
-  ![draft_binaries](https://user-images.githubusercontent.com/18702153/32983247-7692d528-cc89-11e7-9340-2af1434a6bdf.png)
+    ```bash
+    export TAG=v1.2.3
+    git tag -a "$TAG" -m "$TAG" && git push origin "$TAG"
+    ```
 
-4. Edit release notes, mention all new features and important fixes and
-  publish it.
+1.  Tag creation will trigger build in _Travis_ and _AppVeyor_ which will upload
+    binaries to GitHub release draft with the same name as is the name
+    of the tag (created in step 1).
+    ![draft_binaries](https://user-images.githubusercontent.com/18702153/32983247-7692d528-cc89-11e7-9340-2af1434a6bdf.png)
+
+1.  Edit release notes, mention all new features and important fixes and
+    publish it.

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -7,12 +7,12 @@ Only `master` branch is used for releases.
   ![draft](https://user-images.githubusercontent.com/18702153/32983073-f7477820-cc86-11e7-92c6-fabfc1223a25.png)
 
 2. Create an annotated tag with tag name as a message and push it back to
- `lukasmartinelli/hadolint` remote. Release notes should be in the draft not
  in a tag message.
   ```bash
   export TAG=v1.2.3
   git tag -a "$TAG" -m "$TAG" && git push origin "$TAG"
   ```
+    `hadolint/hadolint` remote. Release notes should be in the draft not
 
 3. Tag creation will trigger build in _Travis_ and _AppVeyor_ which will upload
   binaries to GitHub release draft with the same name as is the name of the tag

--- a/hadolint.cabal
+++ b/hadolint.cabal
@@ -1,7 +1,7 @@
 name:                hadolint
 version:             1.2.3
 synopsis:            Dockerfile Linter JavaScript API
-homepage:            https://github.com/lukasmartinelli/hadolint
+homepage:            https://github.com/hadolint/hadolint
 license:             GPL-3
 license-file:        LICENSE
 author:              Lukas Martinelli
@@ -58,4 +58,4 @@ test-suite hadolint-unit-tests
 
 source-repository head
   type:     git
-  location: git@github.com:lukasmartinelli/hadolint.git
+  location: git@github.com:hadolint/hadolint.git

--- a/scripts/fetch_version.sh
+++ b/scripts/fetch_version.sh
@@ -6,8 +6,8 @@
 set -evuo pipefail
 
 # Get remote URL which can have two formats
-# git@github.com:lukasmartinelli/hadolint.git
-# https://github.com/lukasmartinelli/hadolint 
+# git@github.com:hadolint/hadolint.git
+# https://github.com/hadolint/hadolint
 
 url=$(git remote get-url origin)
 # if URL is for SSH, change it to HTTPS format

--- a/scripts/fetch_version.sh
+++ b/scripts/fetch_version.sh
@@ -11,7 +11,7 @@ set -evuo pipefail
 
 url=$(git remote get-url origin)
 # if URL is for SSH, change it to HTTPS format
-if [[ $url =~ "git@" ]]; then 
+if [[ $url =~ "git@" ]]; then
   url=https://github.com/$(cut -f 2 -d ":" <<< "$url")
 fi
 

--- a/src/Hadolint/Rules.hs
+++ b/src/Hadolint/Rules.hs
@@ -29,8 +29,8 @@ instance Ord Check where
 link :: Metadata -> String
 link (Metadata code _ _)
     | "SC" `isPrefixOf` code  = "https://github.com/koalaman/shellcheck/wiki/" ++ code
-    | "DL" `isPrefixOf` code  = "https://github.com/lukasmartinelli/hadolint/wiki/" ++ code
-    | otherwise               = "https://github.com/lukasmartinelli/hadolint"
+    | "DL" `isPrefixOf` code  = "https://github.com/hadolint/hadolint/wiki/" ++ code
+    | otherwise               = "https://github.com/hadolint/hadolint"
 
 -- a Rule takes a Dockerfile and returns the executed checks
 type Rule =  Dockerfile -> [Check]


### PR DESCRIPTION
## What I did

- Replaced `lukasmartinelli` username by `hadolint` organisation in all documents and source code.
- Commented reference to http://hadolint.lukasmartinelli.ch/ as it is not working for some time. Happy to uncomment when @lukasmartinelli fix it.
- Linted all markdown files.
- Moved `Dockerfile` to `docker` folder with `README.md` for Docker Hub/Store and setup build hooks
  that will add extra tags to the image. See [README](https://github.com/zemanlx/hadolint/blob/ca864fb2f4ae1e20012c1be9580790cd65a4a2af/docker/README.md) for Docker Hub.
- Updated (security) `curl` package.

Fixes #121.

## How I did it

Numerous tests on my own fork. Unfortunately, all new features and fixes for old bugs of Docker Hub are deployed only to Docker Cloud what complicates a bit how images can be built. Hub and Cloud share the repository together with Docker store. 

What is in the Cloud and not in the Hub:
- Separate definition for `Dockerfile` location and context
- Support for custom README (with specific content and Docker flavour of markdown)
- Support for custom [build/push](https://docs.docker.com/docker-cloud/builds/advanced/) steps

## How to verify it

Look at my fork's Docker [Hub](https://hub.docker.com/r/zemanlx/hadolint/) and [Store](https://store.docker.com/community/images/zemanlx/hadolint)

## TODO

1. Disable automated build on Docker Hub by unticking this option
![image](https://user-images.githubusercontent.com/18702153/33504498-8d1f037e-d6df-11e7-9f1e-14e6c84980dc.png)

2. @lukasmartinelli needs to enable automated build in [Docker Cloud in hadolint/hadolint](https://cloud.docker.com/swarm/hadolint/repository/docker/hadolint/hadolint/builds/edit) repository and set build rules **exactly** like this
![image](https://user-images.githubusercontent.com/18702153/33505214-6382464a-d6e2-11e7-9e7a-f6c76dc7d4ff.png)
If you add anything to `Dockerfile location` or `Build Context` it will fail or use the wrong/root `README.md`.