### PR TITLE
Tune for Docker Hub

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,2 @@
-docker/Dockerfile
+tests
+.stack-work

--- a/docker/README.md
+++ b/docker/README.md
@@ -4,40 +4,35 @@
 
 This is Docker image for the [hadolint](https://github.com/hadolint/hadolint).
 
-Images are based on [glibc-busybox](https://hub.docker.com/_/busybox/) and
-include only `hadolint` static binary.
+Images are based on [glibc-busybox](https://hub.docker.com/_/busybox/) and include only `hadolint` static binary.
 
 ## Supported tags
 
--   `hadolint/hadolint:latest` tracks master branch
+- `hadolint/hadolint:latest` tracks master branch
+- `hadolint/hadolint:VERSION` refers release version, eg. `v1.2.3`
+- `hadolint/hadolint:EXTENDED_VERSION` refers to the same version as `hadolint --version` with short git sha, eg. `v1.2.2-65-g94e9c5d`
 
--   `hadolint/hadolint:VERSION` refers release version, eg. `v1.2.3`
-
--   `hadolint/hadolint:EXTENDED_VERSION` refers to the same version as
-    `hadolint --version` with short git sha, eg. `v1.2.2-65-g94e9c5d`
-
-Check out [Docker Hub](https://hub.docker.com/r/hadolint/hadolint/tags/)
-for available tags.
+Check out [Docker Hub](https://hub.docker.com/r/hadolint/hadolint/tags/) for available tags.
 
 ## Usage
 
 To use this image, pull from Docker Hub, run the following command:
 
 ```bash
-docker pull hadolint/hadolint:latest
+docker pull hadolint/hadolint
 ```
 
 Verify the install
 
 ```bash
-docker run --rm -it hadolint/hadolint:latest hadolint --version
+docker run --rm hadolint/hadolint hadolint --version
 Haskell Dockerfile Linter v1.2.2-65-g94e9c5d
 ```
 
 or use a particular version number:
 
 ```bash
-docker run --rm --it hadolint/hadolint:v1.2.3 hadolint --version
+docker run --rm hadolint/hadolint:v1.2.3 hadolint --version
 ```
 
 Lint your `Dockerfile`:

--- a/docker/hooks/push
+++ b/docker/hooks/push
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+echo "=> Fetch unshallow origin"
+git fetch --unshallow origin || true
+
 echo "=> Tag the image"
 docker tag "${IMAGE_NAME}" "${DOCKER_REPO}:$(git describe --long --always)"
 


### PR DESCRIPTION
### What I did

I have found out that Docker Hub actually use hooks and with a bit of hacking it also serves the build context and README in a right way. What is different compared to Docker Cloud is that it get a shallow clone of repo. 

Even though Docker prefer to use of Docker Cloud, build status log and information are taken from Docker Hub even those that are shown on Docker Store :disappointed: 

- Get unshallow clone to get a version
- Remove unnecessary tags and options from commands
- Change markdown to long lines

### How to verify it

See my fork's docker hub [zemanlx/hadolint](https://hub.docker.com/r/zemanlx/hadolint/)