### PR TITLE
DL4000 now enforces deprecation of MAINTAINER

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Please [create an issue][] if you have an idea for a good rule.
 | [DL3015](https://github.com/hadolint/hadolint/wiki/DL3015)   | Avoid additional packages by specifying --no-install-recommends.                                                                                    |
 | [DL3016](https://github.com/hadolint/hadolint/wiki/DL3016)   | Pin versions in `npm`.                                                                                                                              |
 | [DL3020](https://github.com/hadolint/hadolint/wiki/DL3020)   | Use `COPY` instead of `ADD` for files and folders.                                                                                                  |
-| [DL4000](https://github.com/hadolint/hadolint/wiki/DL4000)   | Specify a maintainer of the Dockerfile.                                                                                                             |
+| [DL4000](https://github.com/hadolint/hadolint/wiki/DL4000)   | MAINTAINER is deprecated.                                                                                                             |
 | [DL4001](https://github.com/hadolint/hadolint/wiki/DL4001)   | Either use Wget or Curl but not both.                                                                                                               |
 | [DL4003](https://github.com/hadolint/hadolint/wiki/DL4003)   | Multiple `CMD` instructions found.                                                                                                                  |
 | [DL4004](https://github.com/hadolint/hadolint/wiki/DL4004)   | Multiple `ENTRYPOINT` instructions found.                                                                                                           |


### PR DESCRIPTION
### What I did

Update `README.md` to reflect change to DL4000 rule.

### How I did it

N/A.

### How to verify it

N/A.