### PR TITLE
Version pinning for alpine apk

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,9 @@ Please [create an issue][] if you have an idea for a good rule.
 | [DL3014](https://github.com/hadolint/hadolint/wiki/DL3014)   | Use the `-y` switch.                                                                                                                                |
 | [DL3015](https://github.com/hadolint/hadolint/wiki/DL3015)   | Avoid additional packages by specifying --no-install-recommends.                                                                                    |
 | [DL3016](https://github.com/hadolint/hadolint/wiki/DL3016)   | Pin versions in `npm`.                                                                                                                              |
+| [DL3017](https://github.com/hadolint/hadolint/wiki/DL3017)   | Do not use `apk upgrade`.                                                                                                                           |
+| [DL3018](https://github.com/hadolint/hadolint/wiki/DL3018)   | Pin versions in apk add. Instead of `apk add <package>` use `apk add <package>=<version>`.                                                          |
+| [DL3019](https://github.com/hadolint/hadolint/wiki/DL3019)   | Use the `--no-cache` switch to avoid the need to use `--update` and remove `/var/cache/apk/*` when done installing packages.                        |
 | [DL3020](https://github.com/hadolint/hadolint/wiki/DL3020)   | Use `COPY` instead of `ADD` for files and folders.                                                                                                  |
 | [DL4000](https://github.com/hadolint/hadolint/wiki/DL4000)   | MAINTAINER is deprecated.                                                                                                             |
 | [DL4001](https://github.com/hadolint/hadolint/wiki/DL4001)   | Either use Wget or Curl but not both.                                                                                                               |
@@ -198,4 +201,3 @@ a look at `Syntax.hs` to see the AST definition.
 [stack]: http://docs.haskellstack.org/en/stable/install_and_upgrade.html
 [create an issue]: https://github.com/hadolint/hadolint/issues/new
 [dockerfile reference]: http://docs.docker.com/engine/reference/builder/
-

--- a/src/Hadolint/Rules.hs
+++ b/src/Hadolint/Rules.hs
@@ -224,6 +224,12 @@ aptGetCleanup = instructionRule code severity message check
           hasCleanup cmd = ["rm", "-rf", "/var/lib/apt/lists/*"] `isInfixOf` cmd
           hasUpdate cmd = ["apt-get", "update"] `isInfixOf` cmd
 
+dropOptionsWithArg :: [String] -> [String] -> [String]
+dropOptionsWithArg os [] = []
+dropOptionsWithArg os (x:xs)
+    | x `elem` os = dropOptionsWithArg os (drop 1 xs)
+    | otherwise  = x : dropOptionsWithArg os xs
+
 useAdd = instructionRule code severity message check
     where code = "DL3010"
           severity = InfoC

--- a/src/Hadolint/Rules.hs
+++ b/src/Hadolint/Rules.hs
@@ -72,6 +72,7 @@ rules = [ absoluteWorkdir
         , apkAddNoCache
         , useAdd
         , pipVersionPinned
+        , npmVersionPinned
         , invalidPort
         , aptGetNoRecommends
         , aptGetYes

--- a/src/Hadolint/Rules.hs
+++ b/src/Hadolint/Rules.hs
@@ -69,6 +69,7 @@ rules = [ absoluteWorkdir
         , aptGetVersionPinned
         , aptGetCleanup
         , apkAddVersionPinned
+        , apkAddNoCache
         , useAdd
         , pipVersionPinned
         , invalidPort
@@ -259,6 +260,14 @@ apkAddPackages args =
         ]
     where noOption arg = arg `notElem` options && not ("--" `isPrefixOf` arg)
           options = ["apk", "add", "-q", "-p", "-v", "-f", "-t"]
+
+apkAddNoCache = instructionRule code severity message check
+    where code = "DL3019"
+          severity = InfoC
+          message = "Use the `--no-cache` switch to avoid the need to use `--update` and remove `/var/cache/apk/*` when done installing packages"
+          check (Run args) = not (isApkAdd args) || hasNoCacheOption args
+          check _ = True
+          hasNoCacheOption cmd = ["--no-cache"] `isInfixOf` cmd
 
 useAdd = instructionRule code severity message check
     where code = "DL3010"

--- a/src/Hadolint/Rules.hs
+++ b/src/Hadolint/Rules.hs
@@ -62,7 +62,8 @@ rules = [ absoluteWorkdir
         , noRootUser
         , noCd
         , noSudo
-        , noUpgrade
+        , noAptGetUpgrade
+        , noApkUpgrade
         , noLatestTag
         , noUntagged
         , aptGetVersionPinned
@@ -176,7 +177,7 @@ noSudo = instructionRule code severity message check
           check (Run args) = not $ usingProgram "sudo" args
           check _ = True
 
-noUpgrade = instructionRule code severity message check
+noAptGetUpgrade = instructionRule code severity message check
     where code = "DL3005"
           severity = ErrorC
           message = "Do not use apt-get upgrade or dist-upgrade."
@@ -229,6 +230,13 @@ dropOptionsWithArg os [] = []
 dropOptionsWithArg os (x:xs)
     | x `elem` os = dropOptionsWithArg os (drop 1 xs)
     | otherwise  = x : dropOptionsWithArg os xs
+
+noApkUpgrade = instructionRule code severity message check
+    where code = "DL3017"
+          severity = ErrorC
+          message = "Do not use apk upgrade"
+          check (Run args) = not $ isInfixOf ["apk", "upgrade"] args
+          check _ = True
 
 useAdd = instructionRule code severity message check
     where code = "DL3010"

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -219,6 +219,8 @@ main = hspec $ do
                          , "libbz2=1.0.6-r5"
                          ]
         in ruleCatches apkAddVersionPinned $ unlines dockerfile
+    it "apk add with --no-cache" $ ruleCatches apkAddNoCache "RUN apk add flex=2.6.4-r1"
+    it "apk add without --no-cache" $ ruleCatchesNot apkAddNoCache "RUN apk add --no-cache flex=2.6.4-r1"
     it "apk add virtual package" $
         let dockerfile = [ "RUN apk add \\"
                          , "--virtual build-dependencies \\"

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -172,7 +172,7 @@ main = hspec $ do
     it "install ssh" $ ruleCatchesNot invalidCmd "RUN apt-get install ssh"
 
   describe "apt-get rules" $ do
-    it "apt upgrade" $ ruleCatches noUpgrade "RUN apt-get update && apt-get upgrade"
+    it "apt upgrade" $ ruleCatches noAptGetUpgrade "RUN apt-get update && apt-get upgrade"
     it "apt-get version pinning" $ ruleCatches aptGetVersionPinned "RUN apt-get update && apt-get install python"
     it "apt-get no cleanup" $ ruleCatches aptGetCleanup "RUN apt-get update && apt-get install python"
     it "apt-get cleanup" $ ruleCatchesNot aptGetCleanup "RUN apt-get update && apt-get install python && rm -rf /var/lib/apt/lists/*"
@@ -194,6 +194,8 @@ main = hspec $ do
 
     it "has deprecated maintainer" $ ruleCatches hasNoMaintainer "FROM busybox\nMAINTAINER hudu@mail.com"
 
+  describe "apk add rules" $ do
+    it "apk upgrade" $ ruleCatches noApkUpgrade "RUN apk update && apk upgrade"
   describe "EXPOSE rules" $ do
     it "has no arg" $ ruleCatches exposeMissingArgs "EXPOSE"
     it "has one arg" $ ruleCatchesNot exposeMissingArgs "EXPOSE 80"


### PR DESCRIPTION
### What I did

Added support for [alpine](https://alpinelinux.org/) `apk` package tool that should be similar to what we have for debian/ubuntu `apt-get`. As a bonus, I have added support for virtual packages so version pinning won't fail because of that.

I have added rules
- Do not use `apk upgrade`. https://github.com/hadolint/hadolint/wiki/DL3017
- Pin versions in apk add. Instead of `apk add <package>` use `apk add <package>=<version>`. https://github.com/hadolint/hadolint/wiki/DL3018
- Use the `--no-cache` switch to avoid the need to use `--update` and remove `/var/cache/apk/*` when done installing packages. https://github.com/hadolint/hadolint/wiki/DL3019

Closes #132. 

### How I did it

- Do not use `apk upgrade` - check if  `apk upgrade`  is part of args  of `RUN` instruction
- Pin versions in apk add. Instead of `apk add <package>` use `apk add <package>=<version>`. - check that command is `apk add`;  extract packages from command and then check if each package is pinned using `=`
- Use the `--no-cache` switch to avoid the need to use `--update` and remove `/var/cache/apk/*` when done installing packages. - check for `--no-cache` in `apk add` command

### How to verify it

I have added tests to `test/Spec.hs`