### PR TITLE
Change AppVeyor GitHub Releases key

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,7 +28,7 @@ before_deploy:
 deploy:
   provider: GitHub
   auth_token:
-    secure: VRfoSAuhleshm1Fpe3Kq0ujYytPKodV+fu1kJHiBrZ8d1QW3kOBS89XZ+XVrxdhs
+    secure: ZgaO92N+VQiLolP4K6/T410xutrUTfFdUWcJBueBinWaaM6yEnT0P5FFFTyV8XRf
   artifact: hadolint-Windows-x86_64.exe
   on:
     appveyor_repo_tag: true


### PR DESCRIPTION
### What I did
Changed AppVeyor GitHub Releases key

Old one was for lukasmartinelli personal hadolint, new one is for project hadolint https://ci.appveyor.com/project/hadolint/hadolint

### How I did it
Generated new token and encrypted it in https://ci.appveyor.com/tools/encrypt

### How to verify it
Will test with next version rc.
