### PR TITLE
Issue133/add fallback hardcoded version

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Please [create an issue][] if you have an idea for a good rule.
 | [DL3015](https://github.com/hadolint/hadolint/wiki/DL3015)   | Avoid additional packages by specifying --no-install-recommends.                                                                                    |
 | [DL3016](https://github.com/hadolint/hadolint/wiki/DL3016)   | Pin versions in `npm`.                                                                                                                              |
 | [DL3020](https://github.com/hadolint/hadolint/wiki/DL3020)   | Use `COPY` instead of `ADD` for files and folders.                                                                                                  |
-| [DL4000](https://github.com/hadolint/hadolint/wiki/DL4000)   | MAINTAINER is deprecated.                                                                                                             |
+| [DL4000](https://github.com/hadolint/hadolint/wiki/DL4000)   | MAINTAINER is deprecated.                                                                                                                           |
 | [DL4001](https://github.com/hadolint/hadolint/wiki/DL4001)   | Either use Wget or Curl but not both.                                                                                                               |
 | [DL4003](https://github.com/hadolint/hadolint/wiki/DL4003)   | Multiple `CMD` instructions found.                                                                                                                  |
 | [DL4004](https://github.com/hadolint/hadolint/wiki/DL4004)   | Multiple `ENTRYPOINT` instructions found.                                                                                                           |
@@ -198,4 +198,3 @@ a look at `Syntax.hs` to see the AST definition.
 [stack]: http://docs.haskellstack.org/en/stable/install_and_upgrade.html
 [create an issue]: https://github.com/hadolint/hadolint/issues/new
 [dockerfile reference]: http://docs.docker.com/engine/reference/builder/
-


### PR DESCRIPTION
### What I did
Get version from cabal file + `-no-git` as fallback to `gitDescribe`. Fixes #133.  

### How I did it
If `gitDecribe` is not able to return version (return `UNKNOWN`) we fallback to the version from `hadolint.cabal` with suffix `-no-git`.

### How to verify it
rename `.git` and compile and run `hadolint --version` 
