### PR TITLE
Add `-qq` option as alternative to `-y` in `apt-get`

### DIFF
--- a/src/Hadolint/Rules.hs
+++ b/src/Hadolint/Rules.hs
@@ -213,7 +213,7 @@ aptGetVersionPinned = instructionRule code severity message check
 aptGetPackages :: [String] -> [String]
 aptGetPackages args = concat [filter noOption cmd | cmd <- bashCommands args, isAptGetInstall cmd]
     where noOption arg = arg `notElem` options && not ("--" `isPrefixOf` arg)
-          options = [ "-f" , "install" , "apt-get" , "-d" , "-f" , "-m" , "-q" , "-y" ]
+          options = [ "apt-get" , "install" , "-d" , "-f" , "-m" , "-q" , "-y", "-qq" ]
 
 aptGetCleanup = instructionRule code severity message check
     where code = "DL3009"
@@ -348,7 +348,7 @@ aptGetYes = instructionRule code severity message check
           message = "Use the `-y` switch to avoid manual input `apt-get -y install <package>`"
           check (Run args) = not (isAptGetInstall args) || hasYesOption args
           check _ = True
-          hasYesOption cmd = ["-y"] `isInfixOf` cmd || ["--yes"] `isInfixOf` cmd || startsWithYesFlag cmd
+          hasYesOption cmd = ["-y"] `isInfixOf` cmd || ["--yes"] `isInfixOf` cmd || ["-qq"] `isInfixOf` cmd || startsWithYesFlag cmd
           startsWithYesFlag cmd = True `elem` ["-y" `isInfixOf` arg | arg <- cmd]
 
 aptGetNoRecommends = instructionRule code severity message check

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -116,6 +116,7 @@ main = hspec $ do
   describe "other rules" $ do
     it "apt-get auto yes" $ ruleCatches aptGetYes "RUN apt-get install python"
     it "apt-get yes shortflag" $ ruleCatchesNot aptGetYes "RUN apt-get install -yq python"
+    it "apt-get yes quiet level 2 implies -y" $ ruleCatchesNot aptGetYes "RUN apt-get install -qq python"
     it "apt-get yes different pos" $ ruleCatchesNot aptGetYes "RUN apt-get install -y python"
     it "apt-get with auto yes" $ ruleCatchesNot aptGetYes "RUN apt-get -y install python"
     it "apt-get with auto expanded yes" $ ruleCatchesNot aptGetYes "RUN apt-get --yes install python"


### PR DESCRIPTION
### What I did
Added `-qq` option as alternative to `-y` in `apt-get`.

Note that quiet level 2 implies -y.
> man apt-get

Fixes #131.
 
### How I did it

Added `-qq` as accepted option to `aptGetPackages` and as an alternative to `-y` in `aptGetYes`.

### How to verify it

There is a test for it.