### PR TITLE
Lower severity for using root

### DIFF
--- a/src/Hadolint/Rules.hs
+++ b/src/Hadolint/Rules.hs
@@ -152,7 +152,7 @@ invalidCmd = instructionRule code severity message check
 
 noRootUser = instructionRule code severity message check
     where code = "DL3002"
-          severity = ErrorC
+          severity = WarningC
           message = "Do not switch to root USER"
           check (User user) =
             not


### PR DESCRIPTION
### What I did

Lower severity for using `root`.
Closes #29.
 