### PR TITLE
Release 1.2.4 preparation

### DIFF
--- a/docs/INTEGRATION.md
+++ b/docs/INTEGRATION.md
@@ -15,7 +15,7 @@ env:
   HADOLINT: "${HOME}/hadolint"
 install:
   # Download hadolint binary and set it as executable
-  - curl -sL -o ${HADOLINT} "https://github.com/hadolint/hadolint/releases/download/v1.2.3/hadolint-$(uname -s)-$(uname -m)"
+  - curl -sL -o ${HADOLINT} "https://github.com/hadolint/hadolint/releases/download/v1.2.4/hadolint-$(uname -s)-$(uname -m)"
     && chmod 700 ${HADOLINT}
 script:
   # List files which name starts with 'Dockerfile'

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -2,6 +2,9 @@
 
 Only `master` branch is used for releases.
 
+1.  Create branch to update release number in `hadolint.cabal` and
+    [integration](docs/INTEGRATION.md) guide and merge it when it pass CI.
+
 1.  Write a **draft** of release where _tag version_ and _release title_ are
     the same as a version of `hadolint`, eg `v1.2.3`.
     ![draft](https://user-images.githubusercontent.com/18702153/32983073-f7477820-cc86-11e7-92c6-fabfc1223a25.png)

--- a/hadolint.cabal
+++ b/hadolint.cabal
@@ -1,5 +1,5 @@
 name:                hadolint
-version:             1.2.3
+version:             1.2.4
 synopsis:            Dockerfile Linter JavaScript API
 homepage:            https://github.com/hadolint/hadolint
 license:             GPL-3


### PR DESCRIPTION
### For user
- Added Alpine `apk` support #134
- Added support for `-qq` option in `apt-get` #138
- Added fallback version if binary is compiled without git (`brew` installation) #136
- Added Hadolint Integrations page for Travis and editors #129 
- Improvements in the project README thanks to @proinsias #130 and @samiralajmovic #128
- Fixed _ENV parameters separated by multiple spaces causing parse error_ #50 in #127 

### For developer
- Seperated parsing and used the `language-docker` package
- Used new `lts-9.18 `stack
- Linted all haskell fles using hindent 