### PR TITLE
Upgrade ShellCheck to 0.4.7

### DIFF
--- a/hadolint.cabal
+++ b/hadolint.cabal
@@ -23,7 +23,7 @@ library
                      , bytestring >=0.10
                      , split >= 0.2
                      , language-docker >= 1.0.0
-                     , ShellCheck >= 0.4.6
+                     , ShellCheck >= 0.4.7
   default-language:    Haskell2010
 
 executable hadolint
@@ -49,7 +49,7 @@ test-suite hadolint-unit-tests
                      , bytestring >=0.10
                      , split >= 0.2
                      , language-docker >= 1.0.0
-                     , ShellCheck >= 0.4.6
+                     , ShellCheck >= 0.4.7
                      , HUnit >= 1.2
                      , hspec
                      , hadolint

--- a/src/Hadolint/Bash.hs
+++ b/src/Hadolint/Bash.hs
@@ -9,7 +9,8 @@ shellcheck bashScript = map comment $ crComments $ runIdentity $ checkScript si 
   where
     comment (PositionedComment _ _ c) = c
     si = mockedSystemInterface [("", "")]
-    spec = CheckSpec filename script exclusions (Just Bash)
+    spec = CheckSpec filename script sourced exclusions (Just Bash)
     script = "#!/bin/bash\n" ++ bashScript
     filename = "" -- filename can be ommited because we only want the parse results back
+    sourced = False
     exclusions = []

--- a/stack.yaml
+++ b/stack.yaml
@@ -4,4 +4,5 @@ packages:
 - .
 extra-deps:
 - language-docker-1.0.0
+- ShellCheck-0.4.7
 resolver: lts-9.18


### PR DESCRIPTION
### What I did
Upgraded ShellCheck to 0.4.7 which is adding `--check-sourced` option and changing the type of [CheckSpec](https://github.com/koalaman/shellcheck/commit/8dd40efb440db9ad189ed49695550596ed20100b#diff-6369a4e9c22ed3b4605c0454805c6e5fR36) to support it.

Fixes #143.
 
### How I did it

The new version is not in LTS stack, therefore, I have had to specify it explicitly in `stack.yaml`. I have set `sourced` to `False` as this is default in ShellCheck and we are not sourcing.

### How to verify it

`stack test` as usual.
