### PR TITLE
Fix/allow arguments with npm

### DIFF
--- a/src/Hadolint/Rules.hs
+++ b/src/Hadolint/Rules.hs
@@ -388,8 +388,8 @@ npmVersionPinned = instructionRule code severity message check
     packages :: [String] -> [String]
     packages args = concat [filter noOption cmd | cmd <- bashCommands args, isNpmInstall cmd]
       where
-        noOption arg = arg `notElem` options
-        options = ["npm", "install", "--global"]
+        noOption arg = arg `notElem` options && not ("--" `isPrefixOf` arg)
+        options = ["npm", "install", "-g", "-f"]
     isNpmInstall :: [String] -> Bool
     isNpmInstall cmd = ["npm", "install"] `isInfixOf` cmd
     versionFixed :: String -> Bool

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -160,6 +160,8 @@ main =
         --
         describe "npm pinning" $ do
             it "version pinned in package.json" $ ruleCatchesNot npmVersionPinned "RUN npm install"
+            it "version pinned in package.json with arguments" $
+                ruleCatchesNot npmVersionPinned "RUN npm install --progress=false"
             it "version pinned" $ ruleCatchesNot npmVersionPinned "RUN npm install express@4.1.1"
             it "version pinned with scope" $
                 ruleCatchesNot npmVersionPinned "RUN npm install @myorg/privatepackage@\">=0.1.0\""
@@ -167,6 +169,8 @@ main =
                 ruleCatchesNot npmVersionPinned "RUN npm install express@\"4.1.1\" sax@0.1.1"
             it "version pinned with --global" $
                 ruleCatchesNot npmVersionPinned "RUN npm install --global express@\"4.1.1\""
+            it "version pinned with -g" $
+                ruleCatchesNot npmVersionPinned "RUN npm install -g express@\"4.1.1\""
             it "commit pinned for git+ssh" $
                 ruleCatchesNot
                     npmVersionPinned


### PR DESCRIPTION
### What I did
_npm pinning_ now accepts all `--` arguments (like we have it for `apt-get`) and `-` arguments `g` (short for `global`) and `f` (short for `force`).

- fixes #151
- fixes #152
- fixes #153

### How I did it
It's mimicking `apt-get install` version pinning.

### How to verify it
There are new tests.