### PR TITLE
Linting and version check

### DIFF
--- a/.remarkrc.yaml
+++ b/.remarkrc.yaml
@@ -1,0 +1,9 @@
+plugins:
+  preset-lint-consistent:
+  preset-lint-markdown-style-guide:
+  preset-lint-recommended:
+  validate-links:
+  # Customized settings
+  lint-list-item-indent: mixed
+  lint-maximum-line-length: 100
+  lint-emphasis-marker: '_'

--- a/.travis.yml
+++ b/.travis.yml
@@ -68,10 +68,6 @@ matrix:
       sudo: required
       services:
         - docker
-      addons:
-        apt:
-          packages:
-            - docker-ce
       before_install: true
       install:
         # Build image

--- a/.travis.yml
+++ b/.travis.yml
@@ -100,6 +100,8 @@ matrix:
       script:
         # Lint Markdown files
         - docker run --rm -i -v $PWD:/lint/input:ro zemanlx/remark-lint:0.1.0 --frail .
+        # Lint Haskell files
+        - curl -sL https://raw.github.com/ndmitchell/hlint/master/misc/travis.sh | sh -s .
   allow_failures:
     - env: ARGS="--resolver nightly"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -102,6 +102,15 @@ matrix:
         - docker run --rm -i -v $PWD:/lint/input:ro zemanlx/remark-lint:0.1.0 --frail .
         # Lint Haskell files
         - curl -sL https://raw.github.com/ndmitchell/hlint/master/misc/travis.sh | sh -s .
+        # Hardcoded version check - a version in package.yaml has to higher(before release)
+        #   or same as git tag (after release).
+        - |
+          GIT_VERSION=$(git describe | grep -oE "[0-9]+\.[0-9]+\.[0-9]+")
+          HARDCODED_VERSION=$(grep version package.yaml | grep -oE "[0-9]+\.[0-9]+\.[0-9]+")
+          echo "${GIT_VERSION}\n${HARDCODED_VERSION}" | sort --check --version-sort \
+            || ( echo "Update version in package.yaml and then tag git commit." && false )
+      after_success: true
+
   allow_failures:
     - env: ARGS="--resolver nightly"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -89,6 +89,17 @@ matrix:
           $(docker run --rm -i hadolint:$(git describe --tags --dirty) hadolint --version)
       after_success: true
 
+    - env: Version_Check_and_Linting
+      sudo: required
+      services:
+        - docker
+      before_install: true
+      install:
+        # Pull Markdown linting image
+        - docker pull zemanlx/remark-lint:0.1.0
+      script:
+        # Lint Markdown files
+        - docker run --rm -i -v $PWD:/lint/input:ro zemanlx/remark-lint:0.1.0 --frail .
   allow_failures:
     - env: ARGS="--resolver nightly"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ matrix:
     # variable, such as using --stack-yaml to point to a different file.
     - env: ARGS="--resolver lts"
 
-    - env: &lts-fixed ARGS="--resolver lts-10.0"
+    - env: &lts-fixed ARGS="--resolver lts-10.7"
       addons:
         artifacts: {paths: [./releases]}
       before_deploy:

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ common rules are listed, there are dozens more)
 Please [create an issue][] if you have an idea for a good rule.
 
 | Rule                                                         | Description                                                                                                                                         |
-|--------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------|
+|:-------------------------------------------------------------|:----------------------------------------------------------------------------------------------------------------------------------------------------|
 | [DL3000](https://github.com/hadolint/hadolint/wiki/DL3000)   | Use absolute WORKDIR.                                                                                                                               |
 | [DL3001](https://github.com/hadolint/hadolint/wiki/DL3001)   | For some bash commands it makes no sense running them in a Docker container like ssh, vim, shutdown, service, ps, free, top, kill, mount, ifconfig. |
 | [DL3002](https://github.com/hadolint/hadolint/wiki/DL3002)   | Do not switch to root USER.                                                                                                                         |
@@ -121,7 +121,7 @@ Please [create an issue][] if you have an idea for a good rule.
 | [DL3018](https://github.com/hadolint/hadolint/wiki/DL3018)   | Pin versions in apk add. Instead of `apk add <package>` use `apk add <package>=<version>`.                                                          |
 | [DL3019](https://github.com/hadolint/hadolint/wiki/DL3019)   | Use the `--no-cache` switch to avoid the need to use `--update` and remove `/var/cache/apk/*` when done installing packages.                        |
 | [DL3020](https://github.com/hadolint/hadolint/wiki/DL3020)   | Use `COPY` instead of `ADD` for files and folders.                                                                                                  |
-| [DL3021](https://github.com/hadolint/hadolint/wiki/DL3021)   | `COPY` with more than 2 arguments requires the last argument to end with `/`                                                                                                |
+| [DL3021](https://github.com/hadolint/hadolint/wiki/DL3021)   | `COPY` with more than 2 arguments requires the last argument to end with `/`                                                                        |
 | [DL3022](https://github.com/hadolint/hadolint/wiki/DL3022)   | `COPY --from` should reference a previously defined `FROM` alias                                                                                    |
 | [DL3023](https://github.com/hadolint/hadolint/wiki/DL3023)   | `COPY --from` cannot reference its own `FROM` alias                                                                                                 |
 | [DL3024](https://github.com/hadolint/hadolint/wiki/DL3024)   | `FROM` aliases (stage names) must be unique                                                                                                         |
@@ -209,8 +209,7 @@ Run integration tests.
 ### AST
 
 Dockerfile syntax is fully described in the [Dockerfile reference][]. Just take
-a look at [Syntax.hs](https://www.stackage.org/haddock/nightly-2018-01-07/language-docker-2.0.1/Language-Docker-Syntax.html)
-in the `language-docker` project to see the AST definition.
+a look at [Syntax.hs][] in the `language-docker` project to see the AST definition.
 
 ## Alternatives
 
@@ -223,7 +222,7 @@ in the `language-docker` project to see the AST definition.
 [appveyor-img]: https://ci.appveyor.com/api/projects/status//github/hadolint/hadolint?svg=true&branch=master
 [appveyor]: https://ci.appveyor.com/project/hadolint/hadolint/branch/master
 [license-img]: https://img.shields.io/badge/license-GPL--3-blue.svg
-[license]: https://tldrlegal.com/license/gnu-general-public-license-v3-(gpl-3)
+[license]: https://tldrlegal.com/l/gpl-3.0
 [release-img]: https://img.shields.io/github/release/hadolint/hadolint.svg
 [release]: https://github.com/hadolint/hadolint/releases/latest
 [downloads-img]: https://img.shields.io/github/downloads/hadolint/hadolint/total.svg
@@ -235,3 +234,4 @@ in the `language-docker` project to see the AST definition.
 [integration]: docs/INTEGRATION.md
 [create an issue]: https://github.com/hadolint/hadolint/issues/new
 [dockerfile reference]: http://docs.docker.com/engine/reference/builder/
+[syntax.hs]: https://www.stackage.org/haddock/nightly-2018-01-07/language-docker-2.0.1/Language-Docker-Syntax.html

--- a/docker/.remarkrc.yaml
+++ b/docker/.remarkrc.yaml
@@ -1,0 +1,11 @@
+plugins:
+  preset-lint-consistent:
+  preset-lint-markdown-style-guide:
+  preset-lint-recommended:
+  validate-links:
+
+  # Customized settings
+  lint-list-item-indent: mixed
+  # Docker Hub is not able to unwrap lines
+  lint-maximum-line-length: false
+  lint-emphasis-marker: '_'

--- a/docs/INTEGRATION.md
+++ b/docs/INTEGRATION.md
@@ -15,7 +15,7 @@ env:
   HADOLINT: "${HOME}/hadolint"
 install:
   # Download hadolint binary and set it as executable
-  - curl -sL -o ${HADOLINT} "https://github.com/hadolint/hadolint/releases/download/v1.2.4/hadolint-$(uname -s)-$(uname -m)"
+  - curl -sL -o ${HADOLINT} "https://github.com/hadolint/hadolint/releases/download/v1.5.0/hadolint-$(uname -s)-$(uname -m)"
     && chmod 700 ${HADOLINT}
 script:
   # List files which name starts with 'Dockerfile'

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -3,7 +3,7 @@
 Only `master` branch is used for releases.
 
 1.  Create branch to update release number in `package.yaml` and
-    [integration](docs/INTEGRATION.md) guide and merge it when it pass CI.
+    [integration](INTEGRATION.md) guide and merge it when it pass CI.
 
 1.  Write a **draft** of release where _tag version_ and _release title_ are
     the same as a version of `hadolint`, eg `v1.2.3`.

--- a/package.yaml
+++ b/package.yaml
@@ -38,7 +38,7 @@ executables:
     source-dirs: app
     dependencies:
       - hadolint
-      - optparse-applicative <=0.14.0.0
+      - optparse-applicative
       - gitrev >=1.3.1
       - filepath
       - directory >= 1.3.0

--- a/stack.yaml
+++ b/stack.yaml
@@ -4,4 +4,4 @@ packages:
 - .
 extra-deps:
 - language-docker-2.0.0
-resolver: lts-10.0
+resolver: lts-10.7


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

### What I did

New build in Travis will check for Haskell (hlint) and Markdown (remark) linting issues. I have also added a check if a version in `package.yaml` is equal or higher than a version in `git describe` to avoid situation when we forgot to update a version number in `package.yaml` before release. This, of course, won't stop us to do it, but at least alerts us when we forgot.

Out of scope changes:
- removed docker update - no longer needed for a multistage build. Travis is now using `17.09-ce` by default. It saves us some time.
- update to LTS-10.7 and removed optparse-applicative restriction. I have never seen it failing because of any new version of that package. 

### How to verify it

Travis baby.