### PR TITLE
Add support for "pip install ."

### DIFF
--- a/src/Hadolint/Rules.hs
+++ b/src/Hadolint/Rules.hs
@@ -387,7 +387,8 @@ pipVersionPinned = instructionRule code severity message check
         "Pin versions in pip. Instead of `pip install <package>` use `pip install \
         \<package>==<version>`"
     check (Run args) =
-        not (isPipInstall args && not (isRecursiveInstall args)) || all versionFixed (packages args)
+        not (isPipInstall args) ||
+        (isRecursiveInstall args || isSetupPyInstall args || all versionFixed (packages args))
     check _ = True
     isVersionedGit :: String -> Bool
     isVersionedGit package = "git+http" `isInfixOf` package && "@" `isInfixOf` package
@@ -402,6 +403,8 @@ pipVersionPinned = instructionRule code severity message check
         ["pip3", "install"] `isInfixOf` cmd || ["pip2", "install"] `isInfixOf` cmd
     isRecursiveInstall :: [String] -> Bool
     isRecursiveInstall cmd = ["-r"] `isInfixOf` cmd
+    isSetupPyInstall :: [String] -> Bool
+    isSetupPyInstall cmd = ["."] `isInfixOf` cmd
     -- | Returns all the packages after pip install
     packages :: [String] -> [String]
     packages args = concat [filter noOption cmd | cmd <- bashCommands args, isPipInstall cmd]

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -145,6 +145,8 @@ main =
                 ruleCatchesNot pipVersionPinned "RUN pip3 install MySQL_python==1.2.2"
             it "pip install requirements" $
                 ruleCatchesNot pipVersionPinned "RUN pip install -r requirements.txt"
+            it "pip install use setup.py" $
+                ruleCatchesNot pipVersionPinned "RUN pip install ."
             it "pip version not pinned" $
                 ruleCatches pipVersionPinned "RUN pip install MySQL_python"
             it "pip version pinned" $


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

### What I did

Hadolint will no longer complain about violation of  [DL3013](https://github.com/hadolint/hadolint/wiki/DL3013) for `pip install .`

Closes #88.

### How I did it

Added a new function to check that check that `.` is part of `pip install` command. Hope that will not easy other checks as soon as `.` cannot be part of any package name.

Simplified a logic in the check.

### How to verify it

I have added test for it and old ones are not failing.