### PR TITLE
Use dropOptionsWithArg for apt-get

### DIFF
--- a/src/Hadolint/Rules.hs
+++ b/src/Hadolint/Rules.hs
@@ -325,7 +325,12 @@ aptGetVersionPinned = instructionRule code severity message check
     versionFixed package = "=" `isInfixOf` package
 
 aptGetPackages :: [String] -> [String]
-aptGetPackages args = concat [filter noOption cmd | cmd <- bashCommands args, isAptGetInstall cmd]
+aptGetPackages args =
+    concat
+        [ filter noOption (dropOptionsWithArg ["-t", "--target-release"] cmd)
+        | cmd <- bashCommands args
+        , isAptGetInstall cmd
+        ]
   where
     noOption arg = arg `notElem` options && not ("--" `isPrefixOf` arg)
     options = ["apt-get", "install", "-d", "-f", "-m", "-q", "-y", "-qq"]

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -261,6 +261,18 @@ main =
                 ruleCatchesNot
                     aptGetVersionPinned
                     "RUN apt-get -y --no-install-recommends install nodejs=0.10"
+            it "apt-get tolerate target-release" $
+                let dockerfile =
+                        [ "RUN set -e &&\\"
+                        , " echo \"deb http://http.debian.net/debian jessie-backports main\" \
+                          \> /etc/apt/sources.list.d/jessie-backports.list &&\\"
+                        , " apt-get update &&\\"
+                        , " apt-get install -y --no-install-recommends -t jessie-backports \
+                          \openjdk-8-jdk=8u131-b11-1~bpo8+1 &&\\"
+                        , " rm -rf /var/lib/apt/lists/*"
+                        ]
+                in ruleCatchesNot aptGetVersionPinned $ unlines dockerfile
+
             it "has maintainer" $ ruleCatches hasNoMaintainer "FROM debian\nMAINTAINER Lukas"
             it "has maintainer first" $ ruleCatches hasNoMaintainer "MAINTAINER Lukas\nFROM DEBIAN"
             it "has no maintainer" $ ruleCatchesNot hasNoMaintainer "FROM debian"


### PR DESCRIPTION
to be able to tolerate "target-release" option.

<!--
If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

### What I did

Ignore `--target-release` and `-t` in `apt-get`.

Fixes #177.

### How I did it

Use `dropOptionsWithArg` for `apt-get` to be able to tolerate `--target-release` option. It is used for `apk add` already.

### How to verify it

I have added a test.