### PR TITLE
add Gitlab CI example

### DIFF
--- a/docs/INTEGRATION.md
+++ b/docs/INTEGRATION.md
@@ -23,6 +23,20 @@ script:
   - git ls-files --exclude='Dockerfile*' --ignored | xargs --max-lines=1 ${HADOLINT}
 ```
 
+## Gitlab CI
+
+Add the following job to your projects `.gitlab-ci.yml`:
+
+```
+lint_dockerfile:
+  stage: lint
+  image: docker:latest
+  services:
+    - docker:dind
+  script:
+    - docker run --rm -i hadolint/hadolint < Dockerfile
+```
+
 ## Editors
 
 Using hadolint in your terminal is not always the most convinient way, but it

--- a/docs/INTEGRATION.md
+++ b/docs/INTEGRATION.md
@@ -27,7 +27,7 @@ script:
 
 Add the following job to your projects `.gitlab-ci.yml`:
 
-```
+```yaml
 lint_dockerfile:
   stage: lint
   image: docker:latest


### PR DESCRIPTION
### What I did

Add a example to use hadolint Docker container with Gitlab CI.

### How I did it

By adding a new section to the integration manual :-)

### How to verify it

Add the job mentioned to any .gitlab-ci.yml configuration in a project where a Dockerfile exists
