### PR TITLE
Permit squishing of single-letter options to apt-get install

### DIFF
--- a/src/Hadolint/Rules.hs
+++ b/src/Hadolint/Rules.hs
@@ -349,8 +349,8 @@ aptGetPackages args =
         , isAptGetInstall cmd
         ]
   where
-    noOption arg = arg `notElem` options && not ("--" `isPrefixOf` arg)
-    options = ["apt-get", "install", "-d", "-f", "-m", "-q", "-y", "-qq"]
+    noOption arg = arg `notElem` words && not ("-" `isPrefixOf` arg)
+    words = ["apt-get", "install"]
 
 aptGetCleanup dockerfile = instructionRuleState code severity message check Nothing dockerfile
   where

--- a/src/Hadolint/Rules.hs
+++ b/src/Hadolint/Rules.hs
@@ -349,8 +349,7 @@ aptGetPackages args =
         , isAptGetInstall cmd
         ]
   where
-    noOption arg = arg `notElem` words && not ("-" `isPrefixOf` arg)
-    words = ["apt-get", "install"]
+    noOption arg = arg `notElem` ["apt-get", "install"] && not ("-" `isPrefixOf` arg)
 
 aptGetCleanup dockerfile = instructionRuleState code severity message check Nothing dockerfile
   where

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -120,7 +120,7 @@ main =
             it "apt-get pinned chained" $
                 let dockerfile =
                         [ "RUN apt-get update \\"
-                        , " && apt-get -y --no-install-recommends install nodejs=0.10 \\"
+                        , " && apt-get -yqq --no-install-recommends install nodejs=0.10 \\"
                         , " && rm -rf /var/lib/apt/lists/*"
                         ]
                 in ruleCatchesNot aptGetVersionPinned $ unlines dockerfile


### PR DESCRIPTION
Fixes #188

### What I did
Modified aptGetPackages to treat any word in the command that starts with a "-" as an option.

### How to verify it
Existing test case modified to include squished option "-yqq".
