### PR TITLE
Banishing the use of head

### DIFF
--- a/src/Hadolint/Formatter/Checkstyle.hs
+++ b/src/Hadolint/Formatter/Checkstyle.hs
@@ -64,7 +64,9 @@ toXml checks = wrap fileName (foldMap convert checks)
         attr "message" msg <>
         attr "source" source <>
         "/>"
-    fileName = file (head checks)
+    fileName = case checks of
+      [] -> ""
+      h:_ -> file h
 
 attr name value = Builder.string8 name <> "='" <> Builder.string8 (escape value) <> "' "
 


### PR DESCRIPTION
There is no way we can make sure that using `head` is safe, so better
not use it at all. We should in the near future use a custom prelude to
avoid this happening with other similar functions.

Fixes #191 