### PR TITLE
Fix rules reporting -1 as line number

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -10,9 +10,8 @@ RUN apt-get update \
     ca-certificates=20161130+nmu1 \
     git=1:2.11.* \
     netbase=5.4 \
+ && curl -sSL https://get.haskellstack.org/ | sh \
  && rm -rf /var/lib/apt/lists/*
-
-RUN curl -sSL https://get.haskellstack.org/ | sh
 
 WORKDIR /opt/hadolint/
 COPY stack.yaml package.yaml /opt/hadolint/

--- a/package.yaml
+++ b/package.yaml
@@ -38,6 +38,7 @@ library:
     - text
     - bytestring
     - dlist
+    - containers
 executables:
   hadolint:
     main: Main.hs

--- a/package.yaml
+++ b/package.yaml
@@ -37,7 +37,6 @@ library:
     - aeson
     - text
     - bytestring
-    - dlist
     - containers
 executables:
   hadolint:

--- a/src/Hadolint/Formatter/Checkstyle.hs
+++ b/src/Hadolint/Formatter/Checkstyle.hs
@@ -9,7 +9,7 @@ module Hadolint.Formatter.Checkstyle
 import qualified Data.ByteString.Builder as Builder
 import qualified Data.ByteString.Lazy.Char8 as B
 import Data.Char
-import Data.DList (toList)
+import Data.Foldable (toList)
 import Data.List (groupBy)
 import Data.Monoid ((<>), mconcat)
 import Hadolint.Formatter.Format

--- a/src/Hadolint/Formatter/Checkstyle.hs
+++ b/src/Hadolint/Formatter/Checkstyle.hs
@@ -79,7 +79,7 @@ escape = concatMap doEscape
         if isOk c
             then [c]
             else "&#" ++ show (ord c) ++ ";"
-    isOk x = any ($x) [isAsciiUpper, isAsciiLower, isDigit, (`elem` [' ', '.', '/'])]
+    isOk x = any (\check -> check x) [isAsciiUpper, isAsciiLower, isDigit, (`elem` [' ', '.', '/'])]
 
 formatResult :: Result -> Builder.Builder
 formatResult (Result errors checks) =

--- a/src/Hadolint/Formatter/Codeclimate.hs
+++ b/src/Hadolint/Formatter/Codeclimate.hs
@@ -9,8 +9,8 @@ module Hadolint.Formatter.Codeclimate
 
 import Data.Aeson hiding (Result)
 import qualified Data.ByteString.Lazy as B
-import Data.DList (DList)
 import Data.Monoid ((<>))
+import Data.Sequence (Seq)
 import GHC.Generics
 import Hadolint.Formatter.Format (Result(..), formatErrorReason)
 import Hadolint.Rules (Metadata(..), RuleCheck(..))
@@ -59,14 +59,13 @@ errorToIssue err =
     Issue
     { checkName = "DL1000"
     , description = formatErrorReason err
-    , location = LocPos (sourceName pos) Pos{..}
+    , location = LocPos (sourceName pos) Pos {..}
     , impact = severityText ErrorC
     }
   where
     pos = errorPos err
     line = sourceLine pos
     column = sourceColumn pos
-
 
 checkToIssue :: RuleCheck -> Issue
 checkToIssue RuleCheck {..} =
@@ -85,7 +84,7 @@ severityText severity =
         InfoC -> "info"
         StyleC -> "minor"
 
-formatResult :: Result -> DList Issue
+formatResult :: Result -> Seq Issue
 formatResult (Result errors checks) = allIssues
   where
     allIssues = errorMessages <> checkMessages

--- a/src/Hadolint/Formatter/Format.hs
+++ b/src/Hadolint/Formatter/Format.hs
@@ -6,18 +6,18 @@ module Hadolint.Formatter.Format
     , toResult
     ) where
 
-import Data.DList (DList, fromList, singleton)
 import Data.List (sort)
 import Data.Monoid (Monoid)
 import Data.Semigroup
+import Data.Sequence (Seq, fromList, singleton)
 import Hadolint.Rules
 import ShellCheck.Interface
 import Text.Parsec.Error
        (ParseError, errorMessages, showErrorMessages)
 
 data Result = Result
-    { errors :: DList ParseError
-    , checks :: DList RuleCheck
+    { errors :: Seq ParseError
+    , checks :: Seq RuleCheck
     } deriving (Eq)
 
 instance Semigroup Result where

--- a/src/Hadolint/Formatter/TTY.hs
+++ b/src/Hadolint/Formatter/TTY.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE NamedFieldPuns #-}
+
 module Hadolint.Formatter.TTY
     ( printResult
     , formatError
@@ -26,13 +27,10 @@ formatChecks = fmap formatCheck
         formatPos source line ++ code meta ++ " " ++ message meta
 
 formatPos :: Filename -> Linenumber -> String
-formatPos source line =
-    if line >= 0
-        then source ++ ":" ++ show line ++ " "
-        else source ++ " "
+formatPos source line = source ++ ":" ++ show line ++ " "
 
 printResult :: Result -> IO ()
-printResult Result{errors, checks} = printErrors >> printChecks
+printResult Result {errors, checks} = printErrors >> printChecks
   where
     printErrors = mapM_ putStrLn (formatErrors errors)
     printChecks = mapM_ putStrLn (formatChecks checks)


### PR DESCRIPTION
There were certain rules that were not reporting the line number where we detected the failure. Most of them were checking duplicated "stuff" across different rules. I made a change so that all but the first place where we detect a duplicate are reported as faulty.

fixes #201 