### PR TITLE
Use scratch as base image for distro

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -26,7 +26,6 @@ RUN curl -sSL https://github.com/upx/upx/releases/download/v3.94/upx-3.94-amd64_
   | tar -x --xz --strip-components 1 upx-3.94-amd64_linux/upx \
   && ./upx --best --ultra-brute /root/.local/bin/hadolint
 
-FROM debian:stretch-slim AS distro
-ENV LC_ALL=C.UTF-8
+FROM scratch AS distro
 COPY --from=builder /root/.local/bin/hadolint /bin/
 CMD ["/bin/hadolint", "-"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,10 +1,10 @@
-[![Docker Pulls](https://img.shields.io/docker/pulls/hadolint/hadolint.svg)]() [![Docker Automated buil](https://img.shields.io/docker/automated/hadolint/hadolint.svg)]() [![Docker Build Status](https://img.shields.io/docker/build/hadolint/hadolint.svg)]()
+[![Docker Pulls](https://img.shields.io/docker/pulls/hadolint/hadolint.svg)]() [![Docker Automated Build](https://img.shields.io/docker/automated/hadolint/hadolint.svg)]() [![Docker Build Status](https://img.shields.io/docker/build/hadolint/hadolint.svg)]()
 
 # Hadolint Docker
 
 This is Docker image for the [hadolint](https://github.com/hadolint/hadolint).
 
-Images are based on [Debian](https://hub.docker.com/_/debian/) and include only `hadolint` static binary.
+Images include only `hadolint` static binary.
 
 ## Supported tags
 


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

### What I did

#205 solved our issue with UTF characters so we can go back to minimal size image.

### How to verify it


```bash
# Create nasty dockerfile
echo -e "FROM scratch\nLABEL nasty=مقرف讨厌противныйน่ารังเกียจ\n" > Dockerfile.utf

# Build image
docker build --tag hadolint:$(git describe --tags --dirty) --file docker/Dockerfile .

# Run it
docker run --rm -i hadolint:$(git describe --tags --dirty) < Dockerfile.utf
```