### PR TITLE
Building debian slim image

### DIFF
--- a/docker/Dockerfile-debian-slim
+++ b/docker/Dockerfile-debian-slim
@@ -1,0 +1,10 @@
+ARG image_name
+FROM $image_name as builder
+FROM debian:stretch-slim
+
+RUN apt-get update \
+ && apt-get install --no-install-recommends -y git=1:2.11.*
+
+COPY --from=builder /bin/hadolint /bin/hadolint
+
+CMD ["/bin/hadolint", "-"]

--- a/docker/hooks/build
+++ b/docker/hooks/build
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -x
 
 echo "=> Building main container"
 docker build \
@@ -7,6 +7,6 @@ docker build \
 
 echo "=> Building debian container"
 docker build \
-    --build-arg image_name $IMAGE_NAME \
-    --tag ${IMAGE_NAME/:/:debian-slim}
+    --build-arg image_name=$IMAGE_NAME \
+    --tag ${IMAGE_NAME/:/:debian-slim-} \
     --file Dockerfile-debian-slim ..

--- a/docker/hooks/build
+++ b/docker/hooks/build
@@ -1,6 +1,12 @@
 #!/bin/bash
 
-echo "=> Building the container"
+echo "=> Building main container"
 docker build \
   --tag $IMAGE_NAME \
   --file Dockerfile ..
+
+echo "=> Building debian container"
+docker build \
+    --build-arg image_name $IMAGE_NAME \
+    --tag ${IMAGE_NAME/:/:debian-slim}
+    --file Dockerfile-debian-slim ..

--- a/docker/hooks/build
+++ b/docker/hooks/build
@@ -1,4 +1,4 @@
-#!/bin/bash -x
+#!/bin/bash
 
 echo "=> Building main container"
 docker build \

--- a/docs/INTEGRATION.md
+++ b/docs/INTEGRATION.md
@@ -37,6 +37,15 @@ lint_dockerfile:
     - docker run --rm -i hadolint/hadolint < Dockerfile
 ```
 
+Alternatively if you would rather run the hadolint image directly, there is a `debian-slim` variant available:
+```yaml
+lint_dockerfile:
+  stage: lint
+  image: hadolint/debian-slim-<version>
+  script:
+    - hadolint < Dockerfile
+```
+
 ## Editors
 
 Using hadolint in your terminal is not always the most convinient way, but it


### PR DESCRIPTION
### What I did
Builds a debian slim image based off the main hadolint image, the debian slim images are named `hadolint/hadolint:debian-slim-<version>`
### How I did it
The debian slim Dockerfile uses the hadolint image as the base image and then copies the binary from it in the main stage that uses the debian slim image
### How to verify it
After build:
```bash
docker run --rm -i hadolint/hadolint:debian-slim-latest < Dockerfile
```