### PR TITLE
Set `LC_ALL=` for Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,9 +17,9 @@ matrix:
   include:
     # The Stack builds. We can pass in arbitrary Stack arguments via the ARGS
     # variable, such as using --stack-yaml to point to a different file.
-    - env: ARGS="--resolver lts"
+    - env: &lts-latest ARGS="--resolver lts" LC_ALL=
 
-    - env: &lts-fixed ARGS="--resolver lts-11.12"
+    - env: &lts-fixed ARGS="--resolver lts-11.12" LC_ALL=
       addons:
         artifacts: {paths: [./releases]}
       before_deploy:
@@ -41,10 +41,10 @@ matrix:
           tags: true
 
     # Nightly builds are allowed to fail
-    - env: ARGS="--resolver nightly"
+    - env: &nightly ARGS="--resolver nightly" LC_ALL=
 
     # Build on OS X in addition to Linux
-    - env: ARGS="--resolver lts"
+    - env: *lts-latest
       os: osx
 
     - env: *lts-fixed
@@ -61,7 +61,7 @@ matrix:
         <<: *release_deploy
       os: osx
 
-    - env: ARGS="--resolver nightly"
+    - env: *nightly
       os: osx
 
     - env: Build_Docker_Image
@@ -108,7 +108,7 @@ matrix:
       after_success: true
 
   allow_failures:
-    - env: ARGS="--resolver nightly"
+    - env: *nightly
 
 before_install:
   - export BINARY_NAME="hadolint-$(uname -s)-$(uname -m)"


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

### What I did

Fixes #173 

When `LC_ALL` is set during compilation it causes that binary is crashing as described in #173 (in case `LC_ALL` is not set on end machine).

> Using LC_ALL is strongly discouraged as it overrides everything. Please use it only when testing and never set it in a startup file.
https://wiki.debian.org/Locale

### How I did it

Tested release binaries 1.5.0 and 1.7.0 in Debian Buster with locale as described in #173 and they were crashing. Then I mounted my locally build binary with `LC_ALL` set to "" and that one works :tada: 
