### PR TITLE
Build in Ubuntu 16.04 (xenial)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -128,12 +128,12 @@ before_install:
     fi
 
 install:
-  - LC_ALL= travis_retry stack --no-terminal --install-ghc $ARGS test --only-dependencies
-  - LC_ALL= stack --no-terminal $ARGS install --ghc-options='-fPIC'
+  - travis_retry stack --no-terminal --install-ghc $ARGS test --only-dependencies
+  - stack --no-terminal $ARGS install --ghc-options='-fPIC'
 
 script:
-  - LC_ALL= stack --no-terminal $ARGS test
-  - LC_ALL= hadolint docker/Dockerfile
+  - stack --no-terminal $ARGS test
+  - hadolint docker/Dockerfile
 
 after_success:
   - mkdir -p ./releases/

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,10 @@ matrix:
     # The Stack builds. We can pass in arbitrary Stack arguments via the ARGS
     # variable, such as using --stack-yaml to point to a different file.
     - env: &lts-latest ARGS="--resolver lts"
+      dist: xenial
 
     - env: &lts-fixed ARGS="--resolver lts-11.12"
+      dist: xenial
       addons:
         artifacts: {paths: [./releases]}
       before_deploy:
@@ -42,6 +44,7 @@ matrix:
 
     # Nightly builds are allowed to fail
     - env: &nightly ARGS="--resolver nightly"
+      dist: xenial
 
     # Build on OS X in addition to Linux
     - env: *lts-latest


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

### What I did

Yet another experiment to fix #173. This time I was able to reproduce issue from Travis in ubuntu:14.04 docker image, and solve it by switching to 16.04. 

Just for evidence, I have tried all combination of `LC_*` with different versions of `gcc` an `clang` without any success. 

### How to verify it

Merge it and then run artifact from master branch of Travis second build in Debian Buster

```bash
$ docker run --rm -it -w /test debian:buster bash
```
and then in a container
```bash
 apt update && apt install wget locales
echo "en_US.UTF-8" >> /etc/locale.gen
locale-gen

# Pokus
export LANG=en_US.UTF-8
export LANGUAGE=
export LC_CTYPE="en_US.UTF-8"
export LC_NUMERIC="en_US.UTF-8"
export LC_TIME="en_US.UTF-8"
export LC_COLLATE="en_US.UTF-8"
export LC_MONETARY="en_US.UTF-8"
export LC_MESSAGES="en_US.UTF-8"
export LC_PAPER="en_US.UTF-8"
export LC_NAME="en_US.UTF-8"
export LC_ADDRESS="en_US.UTF-8"
export LC_TELEPHONE="en_US.UTF-8"
export LC_MEASUREMENT="en_US.UTF-8"
export LC_IDENTIFICATION="en_US.UTF-8"
export LC_ALL=

wget LINK_FROM_TRAVIS_MASTER_BUILD_DEPLOYMENT -O hadolint && chmod +x hadolint && ./hadolint --version
```
should show version and not core dump-ed
