### PR TITLE
Used the ShellCheck AST to perform bash assertions

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -39,6 +39,7 @@ library:
     - bytestring
     - containers
     - void
+    - mtl
 executables:
   hadolint:
     main: Main.hs

--- a/src/Hadolint/Bash.hs
+++ b/src/Hadolint/Bash.hs
@@ -1,16 +1,101 @@
 module Hadolint.Bash where
 
+import Control.Monad.Writer (Writer, execWriter, tell)
 import Data.Functor.Identity (runIdentity)
+import Data.List (nub)
+import Data.Maybe (mapMaybe)
+import qualified Data.Text as Text
+import qualified ShellCheck.AST
+import ShellCheck.AST (Id(..), Token(..))
+import qualified ShellCheck.ASTLib
 import ShellCheck.Checker
 import ShellCheck.Interface
+import qualified ShellCheck.Parser
 
-shellcheck :: String -> [Comment]
-shellcheck bashScript = map comment $ crComments $ runIdentity $ checkScript si spec
+data ParsedBash = ParsedBash
+    { original :: Text.Text
+    , parsed :: ParseResult
+    }
+
+shellcheck :: ParsedBash -> [Comment]
+shellcheck (ParsedBash txt _) = map comment $ crComments $ runIdentity $ checkScript si spec
   where
     comment (PositionedComment _ _ c) = c
     si = mockedSystemInterface [("", "")]
     spec = CheckSpec filename script sourced exclusions (Just Bash)
-    script = "#!/bin/bash\n" ++ bashScript
+    script = "#!/bin/bash\n" ++ Text.unpack txt
     filename = "" -- filename can be ommited because we only want the parse results back
     sourced = False
     exclusions = []
+
+parseShell :: Text.Text -> ParsedBash
+parseShell txt =
+    ParsedBash
+    { original = txt
+    , parsed =
+          runIdentity $
+          ShellCheck.Parser.parseScript
+              (mockedSystemInterface [("", "")])
+              ParseSpec
+              { psFilename = "" -- There is no filename
+              , psScript = "#!/bin/bash\n" ++ Text.unpack txt
+              , psCheckSourced = False
+              }
+    }
+
+findCommands :: ParsedBash -> [Token]
+findCommands (ParsedBash _ ast) =
+    case prRoot ast of
+        Nothing -> []
+        Just script -> nub . execWriter $ ShellCheck.AST.doAnalysis extract script
+  where
+    extract :: Token -> Writer [Token] ()
+    extract t =
+        case ShellCheck.ASTLib.getCommand t of
+            Nothing -> return ()
+            Just cmd -> tell [cmd]
+
+allCommands :: (Token -> Bool) -> ParsedBash -> Bool
+allCommands check script = all check (findCommands script)
+
+noCommands :: (Token -> Bool) -> ParsedBash -> Bool
+noCommands check = allCommands (not . check)
+
+getCommandName :: Token -> Maybe String
+getCommandName = ShellCheck.ASTLib.getCommandName
+
+findCommandNames :: ParsedBash -> [String]
+findCommandNames = mapMaybe getCommandName . findCommands
+
+cmdHasArgs :: String -> [String] -> Token -> Bool
+cmdHasArgs command arguments token@T_SimpleCommand {}
+    | ShellCheck.ASTLib.getCommandName token /= Just command = False
+    | otherwise = not $ null [arg | arg <- getAllArgs token, arg `elem` arguments]
+cmdHasArgs _ _ _ = False
+
+getAllArgs :: Token -> [String]
+getAllArgs (T_SimpleCommand _ _ (_:allArgs)) = concatMap ShellCheck.ASTLib.oversimplify allArgs
+getAllArgs _ = []
+
+getArgsNoFlags :: Token -> [String]
+getArgsNoFlags cmd@(T_SimpleCommand _ _ (_:allArgs)) = concatMap ShellCheck.ASTLib.oversimplify args
+  where
+    flags = [t | (t, _) <- getAllFlags cmd]
+    args = [a | a <- allArgs, a `notElem` flags]
+getArgsNoFlags _ = []
+
+getAllFlags :: Token -> [(Token, String)]
+getAllFlags cmd@T_SimpleCommand {} = [(t, f) | (t, f) <- ShellCheck.ASTLib.getAllFlags cmd, f /= ""]
+getAllFlags _ = []
+
+hasFlag :: String -> Token -> Bool
+hasFlag flag = any (\(_, f) -> f == flag) . getAllFlags
+
+dropFlagArg :: [String] -> Token -> Token
+dropFlagArg flags cmd@(T_SimpleCommand cid b allArgs) = T_SimpleCommand cid b filterdArgs
+  where
+    filterdArgs = [arg | arg <- allArgs, isNotNextToken arg]
+    isNotNextToken arg = ShellCheck.AST.getId arg `notElem` findTokensToDrop
+    findTokensToDrop = [next (ShellCheck.AST.getId t) | (t, f) <- getAllFlags cmd, f `elem` flags]
+    next (Id i) = Id (i + 2)
+dropFlagArg _ token = token

--- a/src/Hadolint/Rules.hs
+++ b/src/Hadolint/Rules.hs
@@ -517,7 +517,7 @@ pipVersionPinned = instructionRule code severity message check
     packages cmd = stripInstallPrefix (Bash.getArgsNoFlags cmd)
     versionFixed package = hasVersionSymbol package || isVersionedGit package
     isVersionedGit package = "git+http" `isInfixOf` package && "@" `isInfixOf` package
-    versionSymbols = ["==", ">=", "<=", ">", "<", "!="]
+    versionSymbols = ["==", ">=", "<=", ">", "<", "!=", "~=", "==="]
     hasVersionSymbol package = or [s `isInfixOf` package | s <- versionSymbols]
 
 stripInstallPrefix :: [String] -> [String]

--- a/src/Hadolint/Rules.hs
+++ b/src/Hadolint/Rules.hs
@@ -63,8 +63,14 @@ mapInstructions metadata f initialState dockerfile =
     let (_, results) = mapAccumL applyRule initialState dockerfile
     in results
   where
+    applyRule state (InstructionPos (OnBuild i) source linenumber) =
+        applyWithState state source linenumber i -- All rules applying to instructions also apply to ONBUILD,
+                                                 -- so we unwrap the OnBuild constructor and check directly the inner
+                                                 -- instruction
     applyRule state (InstructionPos i source linenumber) =
-        let (newState, res) = f state linenumber i
+        applyWithState state source linenumber i -- Otherwise, normal instructions are not unwrapped
+    applyWithState state source linenumber instruction =
+        let (newState, res) = f state linenumber instruction
         in (newState, RuleCheck metadata source linenumber res)
 
 instructionRule ::

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -359,8 +359,9 @@ main =
                     "RUN npm install git://github.com/npm/npm.git#v1.0.27"
 
       --version range is not supported
-      --it "version pinned with scope" $
-      --  ruleCatchesNot npmVersionPinned "RUN npm install @myorg/privatepackage@\">=0.1.0 <0.2.0\""
+            it "version pinned with scope" $ do
+                ruleCatchesNot npmVersionPinned "RUN npm install @myorg/privatepackage@\">=0.1.0 <0.2.0\""
+                onBuildRuleCatchesNot npmVersionPinned "RUN npm install @myorg/privatepackage@\">=0.1.0 <0.2.0\""
             it "version not pinned" $ do
                 ruleCatches npmVersionPinned "RUN npm install express"
                 onBuildRuleCatches npmVersionPinned "RUN npm install express"

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -94,7 +94,7 @@ main =
                         , "RUN hey!"
                         ]
                 in ruleCatches aptGetCleanup $ Text.unlines dockerFile
-            it "now warn apt-get cleanup in intermediate stage that cleans lists" $
+            it "no warn apt-get cleanup in intermediate stage that cleans lists" $
                 let dockerFile =
                         [ "FROM ubuntu as foo"
                         , "RUN apt-get update && apt-get install python && rm -rf /var/lib/apt/lists/*"

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -198,6 +198,10 @@ main =
                 ruleCatches pipVersionPinned "RUN pip install MySQL_python"
             it "pip version pinned" $
                 ruleCatchesNot pipVersionPinned "RUN pip install MySQL_python==1.2.2"
+            it "pip version pinned with ~= operator" $
+                ruleCatchesNot pipVersionPinned "RUN pip install MySQL_python~=1.2.2"
+            it "pip version pinned with === operator" $
+                ruleCatchesNot pipVersionPinned "RUN pip install MySQL_python===1.2.2"
             it "pip version pinned with flag" $
                 ruleCatchesNot pipVersionPinned "RUN pip install --ignore-installed MySQL_python==1.2.2"
             it "pip version pinned with python -m" $

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -6,6 +6,7 @@ import Hadolint.Formatter.TTY (formatError)
 import Hadolint.Rules
 
 import Language.Docker.Parser
+import Language.Docker.Syntax
 import Data.Semigroup ((<>))
 import qualified Data.Text as Text
 
@@ -23,7 +24,7 @@ main =
                     "FROM hub.docker.io/debian@sha256:\
                     \7959ed6f7e35f8b1aaa06d1d8259d4ee25aa85a086d5c125480c333183f9deeb"
             it "explicit tagged with name" $
-              ruleCatchesNot noLatestTag "FROM debian:jessie AS builder"
+                ruleCatchesNot noLatestTag "FROM debian:jessie AS builder"
             it "local aliases are OK to be untagged" $
                 let dockerFile =
                         [ "FROM golang:1.9.3-alpine3.7 AS build"
@@ -33,7 +34,9 @@ main =
                         , "FROM alpine:3.7"
                         , "RUN baz"
                         ]
-                in ruleCatchesNot noUntagged $ Text.unlines dockerFile
+                in do
+                  ruleCatchesNot noUntagged $ Text.unlines dockerFile
+                  onBuildRuleCatchesNot noUntagged $ Text.unlines dockerFile
             it "other untagged cases are not ok" $
                 let dockerFile =
                         [ "FROM golang:1.9.3-alpine3.7 AS build"
@@ -43,33 +46,49 @@ main =
                         , "FROM alpine:3.7"
                         , "RUN baz"
                         ]
-                in ruleCatches noUntagged $ Text.unlines dockerFile
+                in do
+                  ruleCatches noUntagged $ Text.unlines dockerFile
+                  onBuildRuleCatches noUntagged $ Text.unlines dockerFile
         --
         describe "no root or sudo rules" $ do
-            it "sudo" $ ruleCatches noSudo "RUN sudo apt-get update"
+            it "sudo" $ do
+              ruleCatches noSudo "RUN sudo apt-get update"
+              onBuildRuleCatches noSudo "RUN sudo apt-get update"
             it "no root" $ ruleCatches noRootUser "USER root"
             it "no root" $ ruleCatchesNot noRootUser "USER foo"
             it "no root UID" $ ruleCatches noRootUser "USER 0"
             it "no root:root" $ ruleCatches noRootUser "USER root:root"
             it "no root UID:GID" $ ruleCatches noRootUser "USER 0:0"
-            it "install sudo" $ ruleCatchesNot noSudo "RUN apt-get install sudo"
-            it "sudo chained programs" $
+            it "install sudo" $ do
+                ruleCatchesNot noSudo "RUN apt-get install sudo"
+                onBuildRuleCatchesNot noSudo "RUN apt-get install sudo"
+            it "sudo chained programs" $ do
                 ruleCatches noSudo "RUN apt-get update && sudo apt-get install"
+                onBuildRuleCatches noSudo "RUN apt-get update && sudo apt-get install"
         --
         describe "invalid CMD rules" $ do
-            it "invalid cmd" $ ruleCatches invalidCmd "RUN top"
-            it "install ssh" $ ruleCatchesNot invalidCmd "RUN apt-get install ssh"
+            it "invalid cmd" $ do
+                ruleCatches invalidCmd "RUN top"
+                onBuildRuleCatches invalidCmd "RUN top"
+            it "install ssh" $ do
+                ruleCatchesNot invalidCmd "RUN apt-get install ssh"
+                onBuildRuleCatchesNot invalidCmd "RUN apt-get install ssh"
         --
         describe "apt-get rules" $ do
-            it "apt upgrade" $ ruleCatches noAptGetUpgrade "RUN apt-get update && apt-get upgrade"
-            it "apt-get version pinning" $
+            it "apt upgrade" $ do
+                ruleCatches noAptGetUpgrade "RUN apt-get update && apt-get upgrade"
+                onBuildRuleCatches noAptGetUpgrade "RUN apt-get update && apt-get upgrade"
+            it "apt-get version pinning" $ do
                 ruleCatches aptGetVersionPinned "RUN apt-get update && apt-get install python"
+                onBuildRuleCatches aptGetVersionPinned "RUN apt-get update && apt-get install python"
             it "apt-get no cleanup" $
                 let dockerFile =
                         [ "FROM scratch"
                         , "RUN apt-get update && apt-get install python"
                         ]
-                in ruleCatches aptGetCleanup $ Text.unlines dockerFile
+                in do
+                  ruleCatches aptGetCleanup $ Text.unlines dockerFile
+                  onBuildRuleCatches aptGetCleanup $ Text.unlines dockerFile
             it "apt-get cleanup in stage image" $
                 let dockerFile =
                         [ "FROM ubuntu as foo"
@@ -77,7 +96,9 @@ main =
                         , "FROM scratch"
                         , "RUN echo hey!"
                         ]
-                in ruleCatchesNot aptGetCleanup $ Text.unlines dockerFile
+                in do
+                  ruleCatchesNot aptGetCleanup $ Text.unlines dockerFile
+                  onBuildRuleCatchesNot aptGetCleanup $ Text.unlines dockerFile
             it "apt-get no cleanup in last stage" $
                 let dockerFile =
                         [ "FROM ubuntu as foo"
@@ -85,7 +106,9 @@ main =
                         , "FROM scratch"
                         , "RUN apt-get update && apt-get install python"
                         ]
-                in ruleCatches aptGetCleanup $ Text.unlines dockerFile
+                in do
+                  ruleCatches aptGetCleanup $ Text.unlines dockerFile
+                  onBuildRuleCatches aptGetCleanup $ Text.unlines dockerFile
             it "apt-get no cleanup in intermediate stage" $
                 let dockerFile =
                         [ "FROM ubuntu as foo"
@@ -93,7 +116,9 @@ main =
                         , "FROM foo"
                         , "RUN hey!"
                         ]
-                in ruleCatches aptGetCleanup $ Text.unlines dockerFile
+                in do
+                  ruleCatches aptGetCleanup $ Text.unlines dockerFile
+                  onBuildRuleCatches aptGetCleanup $ Text.unlines dockerFile
             it "no warn apt-get cleanup in intermediate stage that cleans lists" $
                 let dockerFile =
                         [ "FROM ubuntu as foo"
@@ -101,7 +126,9 @@ main =
                         , "FROM foo"
                         , "RUN hey!"
                         ]
-                in ruleCatchesNot aptGetCleanup $ Text.unlines dockerFile
+                in do
+                  ruleCatchesNot aptGetCleanup $ Text.unlines dockerFile
+                  onBuildRuleCatchesNot aptGetCleanup $ Text.unlines dockerFile
             it "no warn apt-get cleanup in intermediate stage when stage not used later" $
                 let dockerFile =
                         [ "FROM ubuntu as foo"
@@ -109,13 +136,17 @@ main =
                         , "FROM scratch"
                         , "RUN hey!"
                         ]
-                in ruleCatchesNot aptGetCleanup $ Text.unlines dockerFile
+                in do
+                  ruleCatchesNot aptGetCleanup $ Text.unlines dockerFile
+                  onBuildRuleCatchesNot aptGetCleanup $ Text.unlines dockerFile
             it "apt-get cleanup" $
                 let dockerFile =
                         [ "FROM scratch"
                         , "RUN apt-get update && apt-get install python && rm -rf /var/lib/apt/lists/*"
                         ]
-                in ruleCatchesNot aptGetCleanup $ Text.unlines dockerFile
+                in do
+                  ruleCatchesNot aptGetCleanup $ Text.unlines dockerFile
+                  onBuildRuleCatchesNot aptGetCleanup $ Text.unlines dockerFile
 
             it "apt-get pinned chained" $
                 let dockerFile =
@@ -123,7 +154,10 @@ main =
                         , " && apt-get -yqq --no-install-recommends install nodejs=0.10 \\"
                         , " && rm -rf /var/lib/apt/lists/*"
                         ]
-                in ruleCatchesNot aptGetVersionPinned $ Text.unlines dockerFile
+                in do
+                  ruleCatchesNot aptGetVersionPinned $ Text.unlines dockerFile
+                  onBuildRuleCatchesNot aptGetVersionPinned $ Text.unlines dockerFile
+
             it "apt-get pinned regression" $
                 let dockerFile =
                         [ "RUN apt-get update && apt-get install --no-install-recommends -y \\"
@@ -132,21 +166,31 @@ main =
                         , "git=1:2.5.0* \\"
                         , "ruby=1:2.1.*"
                         ]
-                in ruleCatchesNot aptGetVersionPinned $ Text.unlines dockerFile
+                in do
+                  ruleCatchesNot aptGetVersionPinned $ Text.unlines dockerFile
+                  onBuildRuleCatchesNot aptGetVersionPinned $ Text.unlines dockerFile
+
             it "has deprecated maintainer" $
                 ruleCatches hasNoMaintainer "FROM busybox\nMAINTAINER hudu@mail.com"
         --
         describe "apk add rules" $ do
-            it "apk upgrade" $ ruleCatches noApkUpgrade "RUN apk update && apk upgrade"
-            it "apk add version pinning single" $ ruleCatches apkAddVersionPinned "RUN apk add flex"
-            it "apk add no version pinning single" $
+            it "apk upgrade" $ do
+                ruleCatches noApkUpgrade "RUN apk update && apk upgrade"
+                onBuildRuleCatches noApkUpgrade "RUN apk update && apk upgrade"
+            it "apk add version pinning single" $ do
+                ruleCatches apkAddVersionPinned "RUN apk add flex"
+                onBuildRuleCatches apkAddVersionPinned "RUN apk add flex"
+            it "apk add no version pinning single" $ do
                 ruleCatchesNot apkAddVersionPinned "RUN apk add flex=2.6.4-r1"
+                onBuildRuleCatchesNot apkAddVersionPinned "RUN apk add flex=2.6.4-r1"
             it "apk add version pinned chained" $
                 let dockerFile =
                         [ "RUN apk add --no-cache flex=2.6.4-r1 \\"
                         , " && pip install -r requirements.txt"
                         ]
-                in ruleCatchesNot apkAddVersionPinned $ Text.unlines dockerFile
+                in do
+                  ruleCatchesNot apkAddVersionPinned $ Text.unlines dockerFile
+                  onBuildRuleCatchesNot apkAddVersionPinned $ Text.unlines dockerFile
             it "apk add version pinned regression" $
                 let dockerFile =
                         [ "RUN apk add --no-cache \\"
@@ -155,7 +199,9 @@ main =
                         , "python2=2.7.13-r1 \\"
                         , "libbz2=1.0.6-r5"
                         ]
-                in ruleCatchesNot apkAddVersionPinned $ Text.unlines dockerFile
+                in do
+                  ruleCatchesNot apkAddVersionPinned $ Text.unlines dockerFile
+                  onBuildRuleCatchesNot apkAddVersionPinned $ Text.unlines dockerFile
             it "apk add version pinned regression - one missed" $
                 let dockerFile =
                         [ "RUN apk add --no-cache \\"
@@ -164,10 +210,15 @@ main =
                         , "python2=2.7.13-r1 \\"
                         , "libbz2=1.0.6-r5"
                         ]
-                in ruleCatches apkAddVersionPinned $ Text.unlines dockerFile
-            it "apk add with --no-cache" $ ruleCatches apkAddNoCache "RUN apk add flex=2.6.4-r1"
-            it "apk add without --no-cache" $
+                in do
+                  ruleCatches apkAddVersionPinned $ Text.unlines dockerFile
+                  onBuildRuleCatches apkAddVersionPinned $ Text.unlines dockerFile
+            it "apk add with --no-cache" $ do
+                ruleCatches apkAddNoCache "RUN apk add flex=2.6.4-r1"
+                onBuildRuleCatches apkAddNoCache "RUN apk add flex=2.6.4-r1"
+            it "apk add without --no-cache" $ do
                 ruleCatchesNot apkAddNoCache "RUN apk add --no-cache flex=2.6.4-r1"
+                onBuildRuleCatchesNot apkAddNoCache "RUN apk add --no-cache flex=2.6.4-r1"
             it "apk add virtual package" $
                 let dockerFile =
                         [ "RUN apk add \\"
@@ -177,141 +228,223 @@ main =
                         , "&& python setup.py install \\"
                         , "&& apk del build-dependencies"
                         ]
-                in ruleCatchesNot apkAddVersionPinned $ Text.unlines dockerFile
+                in do
+                  ruleCatchesNot apkAddVersionPinned $ Text.unlines dockerFile
+                  onBuildRuleCatchesNot apkAddVersionPinned $ Text.unlines dockerFile
         --
         describe "EXPOSE rules" $ do
             it "invalid port" $ ruleCatches invalidPort "EXPOSE 80000"
             it "valid port" $ ruleCatchesNot invalidPort "EXPOSE 60000"
         --
         describe "pip pinning" $ do
-            it "pip2 version not pinned" $
+            it "pip2 version not pinned" $ do
                 ruleCatches pipVersionPinned "RUN pip2 install MySQL_python"
-            it "pip3 version not pinned" $
+                onBuildRuleCatches pipVersionPinned "RUN pip2 install MySQL_python"
+            it "pip3 version not pinned" $ do
                 ruleCatches pipVersionPinned "RUN pip3 install MySQL_python"
-            it "pip3 version pinned" $
+                onBuildRuleCatches pipVersionPinned "RUN pip2 install MySQL_python"
+            it "pip3 version pinned" $ do
                 ruleCatchesNot pipVersionPinned "RUN pip3 install MySQL_python==1.2.2"
-            it "pip install requirements" $
+                onBuildRuleCatchesNot pipVersionPinned "RUN pip3 install MySQL_python==1.2.2"
+            it "pip install requirements" $ do
                 ruleCatchesNot pipVersionPinned "RUN pip install -r requirements.txt"
-            it "pip install use setup.py" $
+                onBuildRuleCatchesNot pipVersionPinned "RUN pip install -r requirements.txt"
+            it "pip install use setup.py" $ do
                 ruleCatchesNot pipVersionPinned "RUN pip install ."
-            it "pip version not pinned" $
+                onBuildRuleCatchesNot pipVersionPinned "RUN pip install ."
+            it "pip version not pinned" $ do
                 ruleCatches pipVersionPinned "RUN pip install MySQL_python"
-            it "pip version pinned" $
+                onBuildRuleCatches pipVersionPinned "RUN pip install MySQL_python"
+            it "pip version pinned" $ do
                 ruleCatchesNot pipVersionPinned "RUN pip install MySQL_python==1.2.2"
-            it "pip version pinned with ~= operator" $
+                onBuildRuleCatchesNot pipVersionPinned "RUN pip install MySQL_python==1.2.2"
+            it "pip version pinned with ~= operator" $ do
                 ruleCatchesNot pipVersionPinned "RUN pip install MySQL_python~=1.2.2"
-            it "pip version pinned with === operator" $
+                onBuildRuleCatchesNot pipVersionPinned "RUN pip install MySQL_python~=1.2.2"
+            it "pip version pinned with === operator" $ do
                 ruleCatchesNot pipVersionPinned "RUN pip install MySQL_python===1.2.2"
-            it "pip version pinned with flag" $
+                onBuildRuleCatchesNot pipVersionPinned "RUN pip install MySQL_python===1.2.2"
+            it "pip version pinned with flag" $ do
                 ruleCatchesNot pipVersionPinned "RUN pip install --ignore-installed MySQL_python==1.2.2"
-            it "pip version pinned with python -m" $
+                onBuildRuleCatchesNot pipVersionPinned "RUN pip install --ignore-installed MySQL_python==1.2.2"
+            it "pip version pinned with python -m" $ do
                 ruleCatchesNot pipVersionPinned "RUN python -m pip install example==1.2.2"
-            it "pip install git" $
+                onBuildRuleCatchesNot pipVersionPinned "RUN python -m pip install example==1.2.2"
+            it "pip install git" $ do
                 ruleCatchesNot
                     pipVersionPinned
                     "RUN pip install git+https://github.com/rtfd/r-ext.git@0.6-alpha#egg=r-ext"
-            it "pip install unversioned git" $
+                onBuildRuleCatchesNot
+                    pipVersionPinned
+                    "RUN pip install git+https://github.com/rtfd/r-ext.git@0.6-alpha#egg=r-ext"
+            it "pip install unversioned git" $ do
                 ruleCatches
                     pipVersionPinned
                     "RUN pip install git+https://github.com/rtfd/read-ext.git#egg=read-ext"
-            it "pip install upper bound" $
+                onBuildRuleCatches
+                    pipVersionPinned
+                    "RUN pip install git+https://github.com/rtfd/read-ext.git#egg=read-ext"
+            it "pip install upper bound" $ do
                 ruleCatchesNot pipVersionPinned "RUN pip install 'alabaster>=0.7'"
-            it "pip install lower bound" $
+                onBuildRuleCatchesNot pipVersionPinned "RUN pip install 'alabaster>=0.7'"
+            it "pip install lower bound" $ do
                 ruleCatchesNot pipVersionPinned "RUN pip install 'alabaster<0.7'"
-            it "pip install excluded version" $
+                onBuildRuleCatchesNot pipVersionPinned "RUN pip install 'alabaster<0.7'"
+            it "pip install excluded version" $ do
                 ruleCatchesNot pipVersionPinned "RUN pip install 'alabaster!=0.7'"
-            it "pip install user directory" $
+                onBuildRuleCatchesNot pipVersionPinned "RUN pip install 'alabaster!=0.7'"
+            it "pip install user directory" $ do
                 ruleCatchesNot pipVersionPinned "RUN pip install MySQL_python==1.2.2 --user"
-            it "pip install no pip version check" $
+                onBuildRuleCatchesNot pipVersionPinned "RUN pip install MySQL_python==1.2.2 --user"
+            it "pip install no pip version check" $ do
                 ruleCatchesNot
                     pipVersionPinned
                     "RUN pip install MySQL_python==1.2.2 --disable-pip-version-check"
-            it "pip install no cache dir" $
+                onBuildRuleCatchesNot
+                    pipVersionPinned
+                    "RUN pip install MySQL_python==1.2.2 --disable-pip-version-check"
+            it "pip install no cache dir" $ do
                 ruleCatchesNot pipVersionPinned "RUN pip install MySQL_python==1.2.2 --no-cache-dir"
+                onBuildRuleCatchesNot pipVersionPinned "RUN pip install MySQL_python==1.2.2 --no-cache-dir"
         --
         describe "npm pinning" $ do
-            it "version pinned in package.json" $ ruleCatchesNot npmVersionPinned "RUN npm install"
-            it "version pinned in package.json with arguments" $
+            it "version pinned in package.json" $ do
+                ruleCatchesNot npmVersionPinned "RUN npm install"
+                onBuildRuleCatchesNot npmVersionPinned "RUN npm install"
+            it "version pinned in package.json with arguments" $ do
                 ruleCatchesNot npmVersionPinned "RUN npm install --progress=false"
-            it "version pinned" $ ruleCatchesNot npmVersionPinned "RUN npm install express@4.1.1"
-            it "version pinned with scope" $
+                onBuildRuleCatchesNot npmVersionPinned "RUN npm install --progress=false"
+            it "version pinned" $ do
+                ruleCatchesNot npmVersionPinned "RUN npm install express@4.1.1"
+                onBuildRuleCatchesNot npmVersionPinned "RUN npm install express@4.1.1"
+            it "version pinned with scope" $ do
                 ruleCatchesNot npmVersionPinned "RUN npm install @myorg/privatepackage@\">=0.1.0\""
-            it "version pinned multiple packages" $
+                onBuildRuleCatchesNot npmVersionPinned "RUN npm install @myorg/privatepackage@\">=0.1.0\""
+            it "version pinned multiple packages" $ do
                 ruleCatchesNot npmVersionPinned "RUN npm install express@\"4.1.1\" sax@0.1.1"
-            it "version pinned with --global" $
+                onBuildRuleCatchesNot npmVersionPinned "RUN npm install express@\"4.1.1\" sax@0.1.1"
+            it "version pinned with --global" $ do
                 ruleCatchesNot npmVersionPinned "RUN npm install --global express@\"4.1.1\""
-            it "version pinned with -g" $
+                onBuildRuleCatchesNot npmVersionPinned "RUN npm install --global express@\"4.1.1\""
+            it "version pinned with -g" $ do
                 ruleCatchesNot npmVersionPinned "RUN npm install -g express@\"4.1.1\""
-            it "commit pinned for git+ssh" $
+                onBuildRuleCatchesNot npmVersionPinned "RUN npm install -g express@\"4.1.1\""
+            it "commit pinned for git+ssh" $ do
                 ruleCatchesNot
                     npmVersionPinned
                     "RUN npm install git+ssh://git@github.com:npm/npm.git#v1.0.27"
-            it "commit pinned for git+http" $
+                onBuildRuleCatchesNot
+                    npmVersionPinned
+                    "RUN npm install git+ssh://git@github.com:npm/npm.git#v1.0.27"
+            it "commit pinned for git+http" $ do
                 ruleCatchesNot
                     npmVersionPinned
                     "RUN npm install git+http://isaacs@github.com/npm/npm#semver:^5.0"
-            it "commit pinned for git+https" $
+                onBuildRuleCatchesNot
+                    npmVersionPinned
+                    "RUN npm install git+http://isaacs@github.com/npm/npm#semver:^5.0"
+            it "commit pinned for git+https" $ do
                 ruleCatchesNot
                     npmVersionPinned
                     "RUN npm install git+https://isaacs@github.com/npm/npm.git#v1.0.27"
-            it "commit pinned for git" $
+                onBuildRuleCatchesNot
+                    npmVersionPinned
+                    "RUN npm install git+https://isaacs@github.com/npm/npm.git#v1.0.27"
+            it "commit pinned for git" $ do
                 ruleCatchesNot
                     npmVersionPinned
                     "RUN npm install git://github.com/npm/npm.git#v1.0.27"
+                onBuildRuleCatchesNot
+                    npmVersionPinned
+                    "RUN npm install git://github.com/npm/npm.git#v1.0.27"
+
       --version range is not supported
       --it "version pinned with scope" $
       --  ruleCatchesNot npmVersionPinned "RUN npm install @myorg/privatepackage@\">=0.1.0 <0.2.0\""
-            it "version not pinned" $ ruleCatches npmVersionPinned "RUN npm install express"
-            it "version not pinned with scope" $
+            it "version not pinned" $ do
+                ruleCatches npmVersionPinned "RUN npm install express"
+                onBuildRuleCatches npmVersionPinned "RUN npm install express"
+            it "version not pinned with scope" $ do
                 ruleCatches npmVersionPinned "RUN npm install @myorg/privatepackage"
-            it "version not pinned multiple packages" $
+                onBuildRuleCatches npmVersionPinned "RUN npm install @myorg/privatepackage"
+            it "version not pinned multiple packages" $ do
                 ruleCatches npmVersionPinned "RUN npm install express sax@0.1.1"
-            it "version not pinned with --global" $
+                onBuildRuleCatches npmVersionPinned "RUN npm install express sax@0.1.1"
+            it "version not pinned with --global" $ do
                 ruleCatches npmVersionPinned "RUN npm install --global express"
-            it "commit not pinned for git+ssh" $
+                onBuildRuleCatches npmVersionPinned "RUN npm install --global express"
+            it "commit not pinned for git+ssh" $ do
                 ruleCatches npmVersionPinned "RUN npm install git+ssh://git@github.com:npm/npm.git"
-            it "commit not pinned for git+http" $
+                onBuildRuleCatches npmVersionPinned "RUN npm install git+ssh://git@github.com:npm/npm.git"
+            it "commit not pinned for git+http" $ do
                 ruleCatches npmVersionPinned "RUN npm install git+http://isaacs@github.com/npm/npm"
-            it "commit not pinned for git+https" $
+                onBuildRuleCatches npmVersionPinned "RUN npm install git+http://isaacs@github.com/npm/npm"
+            it "commit not pinned for git+https" $ do
                 ruleCatches
                     npmVersionPinned
                     "RUN npm install git+https://isaacs@github.com/npm/npm.git"
-            it "commit not pinned for git" $
+                onBuildRuleCatches
+                    npmVersionPinned
+                    "RUN npm install git+https://isaacs@github.com/npm/npm.git"
+            it "commit not pinned for git" $ do
                 ruleCatches npmVersionPinned "RUN npm install git://github.com/npm/npm.git"
+                onBuildRuleCatches npmVersionPinned "RUN npm install git://github.com/npm/npm.git"
         --
         describe "use SHELL" $ do
-            it "RUN ln" $ ruleCatches useShell "RUN ln -sfv /bin/bash /bin/sh"
-            it "RUN ln with unrelated symlinks" $
+            it "RUN ln" $ do
+                ruleCatches useShell "RUN ln -sfv /bin/bash /bin/sh"
+                onBuildRuleCatches useShell "RUN ln -sfv /bin/bash /bin/sh"
+            it "RUN ln with unrelated symlinks" $ do
                 ruleCatchesNot useShell "RUN ln -sf /bin/true /sbin/initctl"
-            it "RUN ln with multiple acceptable commands" $
+                onBuildRuleCatchesNot useShell "RUN ln -sf /bin/true /sbin/initctl"
+            it "RUN ln with multiple acceptable commands" $ do
                 ruleCatchesNot useShell "RUN ln -s foo bar && unrelated && something_with /bin/sh"
+                onBuildRuleCatchesNot useShell "RUN ln -s foo bar && unrelated && something_with /bin/sh"
         --
         describe "COPY rules" $ do
             it "use add" $ ruleCatches useAdd "COPY packaged-app.tar /usr/src/app"
             it "use not add" $ ruleCatchesNot useAdd "COPY package.json /usr/src/app"
         --
         describe "other rules" $ do
-            it "apt-get auto yes" $ ruleCatches aptGetYes "RUN apt-get install python"
-            it "apt-get yes shortflag" $ ruleCatchesNot aptGetYes "RUN apt-get install -yq python"
-            it "apt-get yes quiet level 2 implies -y" $
+            it "apt-get auto yes" $ do
+              ruleCatches aptGetYes "RUN apt-get install python"
+              onBuildRuleCatches aptGetYes "RUN apt-get install python"
+            it "apt-get yes shortflag" $ do
+              ruleCatchesNot aptGetYes "RUN apt-get install -yq python"
+              onBuildRuleCatchesNot aptGetYes "RUN apt-get install -yq python"
+            it "apt-get yes quiet level 2 implies -y" $ do
                 ruleCatchesNot aptGetYes "RUN apt-get install -qq python"
-            it "apt-get yes different pos" $
+                onBuildRuleCatchesNot aptGetYes "RUN apt-get install -qq python"
+            it "apt-get yes different pos" $ do
                 ruleCatchesNot aptGetYes "RUN apt-get install -y python"
-            it "apt-get with auto yes" $ ruleCatchesNot aptGetYes "RUN apt-get -y install python"
-            it "apt-get with auto expanded yes" $
+                onBuildRuleCatchesNot aptGetYes "RUN apt-get install -y python"
+            it "apt-get with auto yes" $ do
+                ruleCatchesNot aptGetYes "RUN apt-get -y install python"
+                onBuildRuleCatchesNot aptGetYes "RUN apt-get -y install python"
+            it "apt-get with auto expanded yes" $ do
                 ruleCatchesNot aptGetYes "RUN apt-get --yes install python"
-            it "apt-get install recommends" $
+                onBuildRuleCatchesNot aptGetYes "RUN apt-get --yes install python"
+            it "apt-get install recommends" $ do
                 ruleCatchesNot
                     aptGetNoRecommends
                     "RUN apt-get install --no-install-recommends python"
-            it "apt-get no install recommends" $
+                onBuildRuleCatchesNot
+                    aptGetNoRecommends
+                    "RUN apt-get install --no-install-recommends python"
+            it "apt-get no install recommends" $ do
                 ruleCatches aptGetNoRecommends "RUN apt-get install python"
-            it "apt-get no install recommends" $
+                onBuildRuleCatches aptGetNoRecommends "RUN apt-get install python"
+            it "apt-get no install recommends" $ do
                 ruleCatches aptGetNoRecommends "RUN apt-get -y install python"
-            it "apt-get version" $
+                onBuildRuleCatches aptGetNoRecommends "RUN apt-get -y install python"
+            it "apt-get version" $ do
                 ruleCatchesNot aptGetVersionPinned "RUN apt-get install -y python=1.2.2"
-            it "apt-get pinned" $
+                onBuildRuleCatchesNot aptGetVersionPinned "RUN apt-get install -y python=1.2.2"
+            it "apt-get pinned" $ do
                 ruleCatchesNot
+                    aptGetVersionPinned
+                    "RUN apt-get -y --no-install-recommends install nodejs=0.10"
+                onBuildRuleCatchesNot
                     aptGetVersionPinned
                     "RUN apt-get -y --no-install-recommends install nodejs=0.10"
             it "apt-get tolerate target-release" $
@@ -324,7 +457,9 @@ main =
                           \openjdk-8-jdk=8u131-b11-1~bpo8+1 &&\\"
                         , " rm -rf /var/lib/apt/lists/*"
                         ]
-                in ruleCatchesNot aptGetVersionPinned $ Text.unlines dockerFile
+                in do
+                  ruleCatchesNot aptGetVersionPinned $ Text.unlines dockerFile
+                  onBuildRuleCatchesNot aptGetVersionPinned $ Text.unlines dockerFile
 
             it "has maintainer" $ ruleCatches hasNoMaintainer "FROM debian\nMAINTAINER Lukas"
             it "has maintainer first" $ ruleCatches hasNoMaintainer "MAINTAINER Lukas\nFROM DEBIAN"
@@ -468,6 +603,17 @@ assertChecks rule s makeAssertions =
         Left err -> assertFailure $ show err
         Right dockerFile -> makeAssertions $ analyze [rule] dockerFile
 
+
+assertOnBuildChecks :: HasCallStack => Rule -> Text.Text -> ([RuleCheck] -> IO a) -> IO a
+assertOnBuildChecks rule s makeAssertions =
+    case parseText (s <> "\n") of
+        Left err -> assertFailure $ show err
+        Right dockerFile -> checkOnBuild dockerFile
+  where
+    checkOnBuild dockerFile = makeAssertions $ analyze [rule] (fmap wrapInOnBuild dockerFile)
+    wrapInOnBuild (InstructionPos (Run args) so li) = InstructionPos (OnBuild (Run args)) so li
+    wrapInOnBuild i = i
+
 -- Assert a failed check exists for rule
 ruleCatches :: HasCallStack => Rule -> Text.Text -> Assertion
 ruleCatches rule s = assertChecks rule s f
@@ -476,7 +622,19 @@ ruleCatches rule s = assertChecks rule s f
       assertEqual "No check for rule found" 1 $ length checks
       assertBool "Incorrect line number for result" $ null [c | c <- checks, linenumber c <= 0]
 
+onBuildRuleCatches :: HasCallStack => Rule -> Text.Text -> Assertion
+onBuildRuleCatches rule s = assertOnBuildChecks rule s f
+  where
+    f checks = do
+      assertEqual "No check for rule found" 1 $ length checks
+      assertBool "Incorrect line number for result" $ null [c | c <- checks, linenumber c <= 0]
+
 ruleCatchesNot :: HasCallStack => Rule -> Text.Text -> Assertion
 ruleCatchesNot rule s = assertChecks rule s f
+  where
+    f checks = assertEqual "Found check of rule" 0 $ length checks
+
+onBuildRuleCatchesNot :: HasCallStack => Rule -> Text.Text -> Assertion
+onBuildRuleCatchesNot rule s = assertOnBuildChecks rule s f
   where
     f checks = assertEqual "Found check of rule" 0 $ length checks


### PR DESCRIPTION
Implementing our own shell parser based on splititng on whitespace was
brittle, specially in the parsing of `RUN` instructions with multiple
commands.

This change introduces several new functions to inspect the ShellCheck AST
and perform both transformations and assertions to all the scripts we find
in a dockerfile

I also took the chance to fix #216 in the process
Funnily enough, this also fixes #217 