### PR TITLE
Update version in docs & unify base image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -28,7 +28,7 @@ RUN curl -sSL https://github.com/upx/upx/releases/download/v3.94/upx-3.94-amd64_
   | tar -x --xz --strip-components 1 upx-3.94-amd64_linux/upx \
   && ./upx --best --ultra-brute /root/.local/bin/hadolint
 
-FROM debian:stable-slim AS debian-distro
+FROM debian:stretch-slim AS debian-distro
 COPY --from=builder /root/.local/bin/hadolint /bin/
 CMD ["/bin/hadolint", "-"]
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -9,8 +9,8 @@ Images include only `hadolint` static binary.
 ## Supported tags
 
 - `hadolint/hadolint:latest` tracks master branch
-- `hadolint/hadolint:VERSION` refers release version, eg. `v1.2.3`
-- `hadolint/hadolint:EXTENDED_VERSION` refers to the same version as `hadolint --version` with short git sha, eg. `v1.2.3-0-g7df5f1c`
+- `hadolint/hadolint:VERSION` refers release version, eg. `v1.9.0`
+- `hadolint/hadolint:EXTENDED_VERSION` refers to the same version as `hadolint --version` with short git sha, eg. `v1.9.0-0-g4c4881a`
 
 Check out [Docker Hub](https://hub.docker.com/r/hadolint/hadolint/tags/) for available tags.
 
@@ -26,14 +26,14 @@ Verify the install
 
 ```bash
 docker run --rm hadolint/hadolint hadolint --version
-Haskell Dockerfile Linter v1.2.3-2-gaf24cc3
+Haskell Dockerfile Linter v1.9.0-0-g4c4881a
 ```
 
 or use a particular version number:
 
 ```bash
-docker run --rm hadolint/hadolint:v1.2.3 hadolint --version
-Haskell Dockerfile Linter v1.2.3-0-g7df5f1c
+docker run --rm hadolint/hadolint:v1.9.0 hadolint --version
+Haskell Dockerfile Linter v1.9.0-0-g4c4881a
 ```
 
 Lint your `Dockerfile`:

--- a/docker/README.md
+++ b/docker/README.md
@@ -4,13 +4,19 @@
 
 This is Docker image for the [hadolint](https://github.com/hadolint/hadolint).
 
-Images include only `hadolint` static binary.
+Default images include only `hadolint` static binary. All supported tags have also Debian based image alternative with `-debian` suffinx in tags.
 
 ## Supported tags
 
+`scratch` based tiny images:
 - `hadolint/hadolint:latest` tracks master branch
 - `hadolint/hadolint:VERSION` refers release version, eg. `v1.9.0`
 - `hadolint/hadolint:EXTENDED_VERSION` refers to the same version as `hadolint --version` with short git sha, eg. `v1.9.0-0-g4c4881a`
+
+`debian` based images:
+- `hadolint/hadolint:latest-debian` tracks master branch
+- `hadolint/hadolint:VERSION-debian` refers release version, eg. `v1.9.0-debian`
+- `hadolint/hadolint:EXTENDED_VERSION-debian` refers to the same version as `hadolint --version` with short git sha, eg. `v1.9.0-0-g4c4881a-debian`
 
 Check out [Docker Hub](https://hub.docker.com/r/hadolint/hadolint/tags/) for available tags.
 

--- a/docs/INTEGRATION.md
+++ b/docs/INTEGRATION.md
@@ -15,7 +15,7 @@ env:
   HADOLINT: "${HOME}/hadolint"
 install:
   # Download hadolint binary and set it as executable
-  - curl -sL -o ${HADOLINT} "https://github.com/hadolint/hadolint/releases/download/v1.5.0/hadolint-$(uname -s)-$(uname -m)"
+  - curl -sL -o ${HADOLINT} "https://github.com/hadolint/hadolint/releases/download/v1.9.0/hadolint-$(uname -s)-$(uname -m)"
     && chmod 700 ${HADOLINT}
 script:
   # List files which name starts with 'Dockerfile'
@@ -70,11 +70,11 @@ Hadolint is used in two plugins:
 
 -   [ALE][] (Asynchronous Lint Engine) - plugin for providing linting in NeoVim
     and Vim 8 while you edit your text files.
-    
+
 ### VS Code
 
-> Visual Studio Code is a lightweight but powerful source code editor which 
-> runs on your desktop and is available for Windows, macOS and Linux. 
+> Visual Studio Code is a lightweight but powerful source code editor which
+> runs on your desktop and is available for Windows, macOS and Linux.
 
 There is an integration [vscode-hadolint][] with [VS Code][], built by [ExiaSR][].
 


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

### What I did

- Updated version in docs
- Changed base image for Debian distro image to use same as we have for build. That should shorten a build time as we do not need to download another image.
