### PR TITLE
Warn on untrusted FROM registries

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -20,7 +20,7 @@ ghc-options:
 dependencies:
   - base >=4.8 && <5
   - megaparsec >=6.4
-  - language-docker >=6.0.1 && < 7
+  - language-docker >=6.0.3 && < 7
 library:
   source-dirs: src
   exposed-modules:

--- a/package.yaml
+++ b/package.yaml
@@ -16,6 +16,7 @@ ghc-options:
   - -Wincomplete-record-updates
   - -Wincomplete-uni-patterns
   - -Wredundant-constraints
+  - -optP-Wno-nonportable-include-path
 dependencies:
   - base >=4.8 && <5
   - megaparsec >=6.4
@@ -52,6 +53,7 @@ executables:
       - directory >= 1.3.0
       - yaml
       - text
+      - containers
     when:
     # OS X does not support static build https://developer.apple.com/library/content/qa/qa1118
     - condition: '!(os(osx))'

--- a/src/Hadolint/Rules.hs
+++ b/src/Hadolint/Rules.hs
@@ -737,3 +737,15 @@ usePipefail = instructionRuleState code severity message check False
             , arg <- Bash.getAllArgs cmd
             , arg == "pipefail"
             ]
+
+allowedRegistry :: Set.Set Registry -> Rule
+allowedRegistry allowed = instructionRule code severity message check
+  where
+    code = "DL3026"
+    severity = ErrorC
+    message = "Only use one of the allowed registries in the FROM image"
+    check (From (UntaggedImage img _)) = Set.null allowed || isAllowed img
+    check (From (TaggedImage img _ _)) = Set.null allowed || isAllowed img
+    check _ = True
+    isAllowed Image {registryName = Just registry} = Set.member registry allowed
+    isAllowed Image {registryName = Nothing, imageName} = imageName == "scratch" || Set.member "docker.io"  allowed || Set.member "hub.docker.com" allowed

--- a/src/Hadolint/Rules.hs
+++ b/src/Hadolint/Rules.hs
@@ -10,7 +10,7 @@ import Data.Maybe (catMaybes)
 import qualified Hadolint.Bash as Bash
 import Language.Docker.Syntax
 
-import Data.Semigroup ((<>))
+import Data.Semigroup (Semigroup, (<>))
 import qualified Data.Set as Set
 import qualified Data.Text as Text
 import Data.Void (Void)
@@ -37,8 +37,20 @@ data RuleCheck = RuleCheck
     , success :: Bool
     } deriving (Eq)
 
+-- | Contains the required parameters for optional rules
+newtype RulesConfig = RulesConfig
+    { allowedRegistries :: Set.Set Registry -- ^ The docker registries that are allowed in FROM
+    } deriving (Show, Eq)
+
 instance Ord RuleCheck where
     a `compare` b = linenumber a `compare` linenumber b
+
+instance Semigroup RulesConfig where
+    RulesConfig a <> RulesConfig b = RulesConfig (a <> b)
+
+instance Monoid RulesConfig where
+    mempty = RulesConfig mempty
+    mappend = (<>)
 
 type IgnoreRuleParser = Megaparsec.Parsec Void Text.Text
 
@@ -177,6 +189,9 @@ rules =
     , useJsonArgs
     , usePipefail
     ]
+
+optionalRules :: RulesConfig -> [Rule]
+optionalRules RulesConfig {allowedRegistries} = [registryIsAllowed allowedRegistries]
 
 commentMetadata :: ShellCheck.Interface.Comment -> Metadata
 commentMetadata (ShellCheck.Interface.Comment severity code message) =
@@ -738,8 +753,8 @@ usePipefail = instructionRuleState code severity message check False
             , arg == "pipefail"
             ]
 
-allowedRegistry :: Set.Set Registry -> Rule
-allowedRegistry allowed = instructionRule code severity message check
+registryIsAllowed :: Set.Set Registry -> Rule
+registryIsAllowed allowed = instructionRule code severity message check
   where
     code = "DL3026"
     severity = ErrorC
@@ -748,4 +763,6 @@ allowedRegistry allowed = instructionRule code severity message check
     check (From (TaggedImage img _ _)) = Set.null allowed || isAllowed img
     check _ = True
     isAllowed Image {registryName = Just registry} = Set.member registry allowed
-    isAllowed Image {registryName = Nothing, imageName} = imageName == "scratch" || Set.member "docker.io"  allowed || Set.member "hub.docker.com" allowed
+    isAllowed Image {registryName = Nothing, imageName} =
+        imageName == "scratch" ||
+        Set.member "docker.io" allowed || Set.member "hub.docker.com" allowed

--- a/src/Hadolint/Rules.hs
+++ b/src/Hadolint/Rules.hs
@@ -758,7 +758,7 @@ registryIsAllowed allowed = instructionRule code severity message check
   where
     code = "DL3026"
     severity = ErrorC
-    message = "Only use one of the allowed registries in the FROM image"
+    message = "Use only an allowed registry in the FROM image"
     check (From (UntaggedImage img _)) = Set.null allowed || isAllowed img
     check (From (TaggedImage img _ _)) = Set.null allowed || isAllowed img
     check _ = True

--- a/stack.yaml
+++ b/stack.yaml
@@ -3,6 +3,6 @@ extra-package-dbs: []
 packages:
 - .
 extra-deps:
-- language-docker-6.0.1
+- language-docker-6.0.3
 - ShellCheck-0.5.0
 resolver: lts-11.12

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE OverloadedLists #-}
 import Test.HUnit hiding (Label)
 import Test.Hspec
 
@@ -824,6 +825,28 @@ main =
                         , "RUN wget -O - https://some.site | wc -l file > /number"
                         ]
                 in ruleCatches usePipefail $ Text.unlines dockerFile
+        --
+        describe "Allowed docker registries" $ do
+            it "warn on non-allowed registry" $
+                let dockerFile =
+                        [ "FROM random.com/debian"
+                        ]
+                in ruleCatches (allowedRegistry ["docker.io"]) $ Text.unlines dockerFile
+            it "don't warn on empty allowed registries" $
+                let dockerFile =
+                        [ "FROM random.com/debian"
+                        ]
+                in ruleCatchesNot (allowedRegistry []) $ Text.unlines dockerFile
+            it "don't warn on allowed registries" $
+                let dockerFile =
+                        [ "FROM random.com/debian"
+                        ]
+                in ruleCatchesNot (allowedRegistry ["x.com", "random.com"]) $ Text.unlines dockerFile
+            it "don't warn on scratch image" $
+                let dockerFile =
+                        [ "FROM scratch"
+                        ]
+                in ruleCatchesNot (allowedRegistry ["x.com", "random.com"]) $ Text.unlines dockerFile
 
 assertChecks :: HasCallStack => Rule -> Text.Text -> ([RuleCheck] -> IO a) -> IO a
 assertChecks rule s makeAssertions =

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -847,9 +847,10 @@ main =
                         [ "FROM scratch"
                         ]
                 in ruleCatchesNot (registryIsAllowed ["x.com", "random.com"]) $ Text.unlines dockerFile
-            it "allows boths forms of docker.io" $
+            it "allows boths all forms of docker.io" $
                 let dockerFile =
                         [ "FROM ubuntu:18.04 AS builder1"
+                        , "FROM zemanlx/ubuntu:18.04 AS builder2"
                         , "FROM docker.io/zemanlx/ubuntu:18.04 AS builder3"
                         ]
                 in ruleCatchesNot (registryIsAllowed ["docker.io"]) $ Text.unlines dockerFile

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -831,22 +831,22 @@ main =
                 let dockerFile =
                         [ "FROM random.com/debian"
                         ]
-                in ruleCatches (allowedRegistry ["docker.io"]) $ Text.unlines dockerFile
+                in ruleCatches (registryIsAllowed ["docker.io"]) $ Text.unlines dockerFile
             it "don't warn on empty allowed registries" $
                 let dockerFile =
                         [ "FROM random.com/debian"
                         ]
-                in ruleCatchesNot (allowedRegistry []) $ Text.unlines dockerFile
+                in ruleCatchesNot (registryIsAllowed []) $ Text.unlines dockerFile
             it "don't warn on allowed registries" $
                 let dockerFile =
                         [ "FROM random.com/debian"
                         ]
-                in ruleCatchesNot (allowedRegistry ["x.com", "random.com"]) $ Text.unlines dockerFile
+                in ruleCatchesNot (registryIsAllowed ["x.com", "random.com"]) $ Text.unlines dockerFile
             it "don't warn on scratch image" $
                 let dockerFile =
                         [ "FROM scratch"
                         ]
-                in ruleCatchesNot (allowedRegistry ["x.com", "random.com"]) $ Text.unlines dockerFile
+                in ruleCatchesNot (registryIsAllowed ["x.com", "random.com"]) $ Text.unlines dockerFile
 
 assertChecks :: HasCallStack => Rule -> Text.Text -> ([RuleCheck] -> IO a) -> IO a
 assertChecks rule s makeAssertions =

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -842,11 +842,17 @@ main =
                         [ "FROM random.com/debian"
                         ]
                 in ruleCatchesNot (registryIsAllowed ["x.com", "random.com"]) $ Text.unlines dockerFile
-            it "don't warn on scratch image" $
+            it "doesn't warn on scratch image" $
                 let dockerFile =
                         [ "FROM scratch"
                         ]
                 in ruleCatchesNot (registryIsAllowed ["x.com", "random.com"]) $ Text.unlines dockerFile
+            it "allows boths forms of docker.io" $
+                let dockerFile =
+                        [ "FROM ubuntu:18.04 AS builder1"
+                        , "FROM docker.io/zemanlx/ubuntu:18.04 AS builder3"
+                        ]
+                in ruleCatchesNot (registryIsAllowed ["docker.io"]) $ Text.unlines dockerFile
 
 assertChecks :: HasCallStack => Rule -> Text.Text -> ([RuleCheck] -> IO a) -> IO a
 assertChecks rule s makeAssertions =


### PR DESCRIPTION
### What I did

This implements and closes #225 

### How I did it

The CLI now accepts many `--trusted-registry` flags and a new config file key `trustedRegistries` to control what registries can be used in `FROM` instructions.

Example:

`hadolint --trusted-registry crazy.io --trusted-registry random.io Dockerfile`