### PR TITLE
Make sure shellcheck runs in ONBUILD

### DIFF
--- a/src/Hadolint/Rules.hs
+++ b/src/Hadolint/Rules.hs
@@ -44,18 +44,18 @@ type IgnoreRuleParser = Megaparsec.Parsec Void Text.Text
 
 type ParsedFile = [InstructionPos Bash.ParsedBash]
 
--- | A funtion to check individual dockerfile instructions.
+-- | A function to check individual dockerfile instructions.
 -- It gets the current state and a line number.
 -- It should return the new state and whether or not the check passes for the given instruction.
 type SimpleCheckerWithState state
      = state -> Linenumber -> Instruction Bash.ParsedBash -> (state, Bool)
 
--- | A funtion to check individual dockerfile instructions.
+-- | A function to check individual dockerfile instructions.
 -- It gets the current line number.
 -- It should return True if the check passes for the given instruction.
 type SimpleCheckerWithLine = (Linenumber -> Instruction Bash.ParsedBash -> Bool)
 
--- | A funtion to check individual dockerfile instructions.
+-- | A function to check individual dockerfile instructions.
 -- It should return the new state and a list of Metadata records.
 -- Each Metadata record signifies a failing check for the given instruction.
 type CheckerWithState state

--- a/src/Hadolint/Rules.hs
+++ b/src/Hadolint/Rules.hs
@@ -44,18 +44,20 @@ type IgnoreRuleParser = Megaparsec.Parsec Void Text.Text
 
 type ParsedFile = [InstructionPos Bash.ParsedBash]
 
--- | An instructions checker function that gets the current state and a line number.
--- It should return the new state and whether or not the check passed for the given instruction.
+-- | A funtion to check individual dockerfile instructions.
+-- It gets the current state and a line number.
+-- It should return the new state and whether or not the check passes for the given instruction.
 type SimpleCheckerWithState state
      = state -> Linenumber -> Instruction Bash.ParsedBash -> (state, Bool)
 
--- | An instructions checker function that gets the line number.
--- It should whether or not the check passed for the given instruction.
+-- | A funtion to check individual dockerfile instructions.
+-- It gets the current line number.
+-- It should return True if the check passes for the given instruction.
 type SimpleCheckerWithLine = (Linenumber -> Instruction Bash.ParsedBash -> Bool)
 
--- | An instructions checker function that gets the current state and a line number.
--- It should return the new state and list Metadata record with the data explaining all the
--- reasons the instruction failed
+-- | A funtion to check individual dockerfile instructions.
+-- It should return the new state and a list of Metadata records.
+-- Each Metadata record signifies a failing check for the given instruction.
 type CheckerWithState state
      = state -> Linenumber -> Instruction Bash.ParsedBash -> (state, [Metadata])
 

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -474,6 +474,16 @@ main =
                 ruleCatchesNot useShell "RUN ln -s foo bar && unrelated && something_with /bin/sh"
                 onBuildRuleCatchesNot useShell "RUN ln -s foo bar && unrelated && something_with /bin/sh"
         --
+        --
+        describe "Shellcheck" $ do
+            it "runs shellchek on RUN instructions" $ do
+                ruleCatches shellcheckBash "RUN echo $MISSING_QUOTES"
+                onBuildRuleCatches shellcheckBash "RUN echo $MISSING_QUOTES"
+            it "not warns on valid scripts" $ do
+                ruleCatchesNot shellcheckBash "RUN echo foo"
+                onBuildRuleCatchesNot shellcheckBash "RUN echo foo"
+        --
+        --
         describe "COPY rules" $ do
             it "use add" $ ruleCatches useAdd "COPY packaged-app.tar /usr/src/app"
             it "use not add" $ ruleCatchesNot useAdd "COPY package.json /usr/src/app"


### PR DESCRIPTION
The `shellcheckBash` rule was the last rule to not use one of the instruction traversal functions, which caused it to not inherit the automatic traversal of `ONBUILD` instructions.

I had to change a bit how the traversal functions worked, since `shellcheck` can produce many messages per instruction, which we were not prepared to do.

Fixes #230 