### PR TITLE
Fixed the Allowed registries rule

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: hadolint
-version: '1.10.1'
+version: '1.10.2'
 synopsis: Dockerfile Linter JavaScript API
 description: A smarter Dockerfile linter that helps you build best practice Docker images.
 category: Development

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -950,6 +950,13 @@ main =
                         ]
                 in ruleCatchesNot (registryIsAllowed ["docker.io"]) $ Text.unlines dockerFile
 
+            it "allows using previous stages" $
+                let dockerFile =
+                        [ "FROM random.com/foo AS builder1"
+                        , "FROM builder1 AS builder2"
+                        ]
+                in ruleCatchesNot (registryIsAllowed ["random.com"]) $ Text.unlines dockerFile
+
 assertChecks :: HasCallStack => Rule -> Text.Text -> ([RuleCheck] -> IO a) -> IO a
 assertChecks rule s makeAssertions =
     case parseText (s <> "\n") of


### PR DESCRIPTION
It was failing when using a stage as an image name