### PR TITLE
Added support for the --constraint flag in pip

### DIFF
--- a/src/Hadolint/Rules.hs
+++ b/src/Hadolint/Rules.hs
@@ -569,7 +569,7 @@ pipVersionPinned = instructionRule code severity message check
         \<package>==<version>`"
     check (Run args) = argumentsRule (Shell.noCommands forgotToPinVersion) args
     check _ = True
-    forgotToPinVersion cmd = isPipInstall cmd && not (all versionFixed (packages cmd))
+    forgotToPinVersion cmd = isPipInstall cmd && not (hasBuildConstraint cmd) && not (all versionFixed (packages cmd))
     -- Check if the command is a pip* install command, and that specific pacakges are being listed
     isPipInstall cmd =
         case Shell.getCommandName cmd of
@@ -580,6 +580,7 @@ pipVersionPinned = instructionRule code severity message check
     relevantInstall cmd =
         ["install"] `isInfixOf` Shell.getAllArgs cmd &&
         not (["-r"] `isInfixOf` Shell.getAllArgs cmd || ["."] `isInfixOf` Shell.getAllArgs cmd)
+    hasBuildConstraint = Shell.hasFlag "constraint"
     packages cmd = stripInstallPrefix (Shell.getArgsNoFlags cmd)
     versionFixed package = hasVersionSymbol package || isVersionedGit package
     isVersionedGit package = "git+http" `isInfixOf` package && "@" `isInfixOf` package

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -379,6 +379,9 @@ main =
             it "pip install no cache dir" $ do
                 ruleCatchesNot pipVersionPinned "RUN pip install MySQL_python==1.2.2 --no-cache-dir"
                 onBuildRuleCatchesNot pipVersionPinned "RUN pip install MySQL_python==1.2.2 --no-cache-dir"
+            it "pip install constraints file" $ do
+                ruleCatchesNot pipVersionPinned "RUN pip install pykafka --constraint http://foo.bar.baz"
+                onBuildRuleCatchesNot pipVersionPinned "RUN pip install pykafka --constraint http://foo.bar.baz"
         --
         describe "npm pinning" $ do
             it "version pinned in package.json" $ do


### PR DESCRIPTION
No longer warn about missing constraints for pip packages when the flag
is present.

fixes #229