### PR TITLE
Avoid running certain rules with powershell

### DIFF
--- a/src/Hadolint/Rules.hs
+++ b/src/Hadolint/Rules.hs
@@ -759,9 +759,12 @@ usePipefail = instructionRuleState code severity message check False
     severity = WarningC
     message = "Set the SHELL option -o pipefail before RUN with a pipe in it"
     check _ _ From {} = (False, True) -- Reset the state each time we find a new FROM
-    check _ _ (Shell args) = (argumentsRule hasPipefailOption args, True)
+    check _ _ (Shell args)
+      | argumentsRule isPowerShell args = (True, True)
+      | otherwise = (argumentsRule hasPipefailOption args, True)
     check False _ (Run args) = (False, argumentsRule notHasPipes args)
     check st _ _ = (st, True)
+    isPowerShell (Shell.ParsedShell orig _)= "pwsh" `Text.isPrefixOf` orig
     notHasPipes script = not (Shell.hasPipes script)
     hasPipefailOption script =
         not $

--- a/src/Hadolint/Shell.hs
+++ b/src/Hadolint/Shell.hs
@@ -48,7 +48,10 @@ setShell :: Text.Text -> ShellOpts -> ShellOpts
 setShell s (ShellOpts _ v) = ShellOpts s v
 
 shellcheck :: ShellOpts -> ParsedShell -> [Comment]
-shellcheck (ShellOpts sh env) (ParsedShell txt _) = map comment runShellCheck
+shellcheck (ShellOpts sh env) (ParsedShell txt _) =
+    if "pwsh" `Text.isPrefixOf` sh
+        then [] -- Do no run for powershell
+        else map comment runShellCheck
   where
     runShellCheck = crComments $ runIdentity $ checkScript si spec
     comment (PositionedComment _ _ c) = c

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -568,6 +568,15 @@ main =
                 in do
                   ruleCatchesNot shellcheck dockerFile
                   onBuildRuleCatchesNot shellcheck dockerFile
+
+            it "Does not complain on powershell" $
+                let dockerFile = Text.unlines
+                        [ "SHELL [\"pwsh\", \"-c\"]"
+                        , "RUN Get-Variable PSVersionTable | Select-Object -ExpandProperty Value"
+                        ]
+                in do
+                  ruleCatchesNot shellcheck dockerFile
+                  onBuildRuleCatchesNot shellcheck dockerFile
         --
         --
         describe "COPY rules" $ do
@@ -894,6 +903,13 @@ main =
                         [ "FROM scratch as build"
                         , "SHELL [\"/bin/zsh\", \"-o\", \"pipefail\", \"-c\"]"
                         , "RUN wget -O - https://some.site | wc -l file > /number"
+                        ]
+                in ruleCatchesNot usePipefail $ Text.unlines dockerFile
+            it "don't warn on powershell" $
+                let dockerFile =
+                        [ "FROM scratch as build"
+                        , "SHELL [\"pwsh\", \"-c\"]"
+                        , "RUN Get-Variable PSVersionTable | Select-Object -ExpandProperty Value"
                         ]
                 in ruleCatchesNot usePipefail $ Text.unlines dockerFile
             it "warns when using plain sh" $


### PR DESCRIPTION
When the shell is set to powershell, we avoid running shellcheck
and the pipefail check.

fixes #246