### PR TITLE
Add codacy formatter

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -31,6 +31,7 @@ import qualified Hadolint.Formatter.Codeclimate as Codeclimate
 import qualified Hadolint.Formatter.Format as Format
 import qualified Hadolint.Formatter.Json as Json
 import qualified Hadolint.Formatter.TTY as TTY
+import qualified Hadolint.Formatter.Codacy as Codacy
 import qualified Hadolint.Rules as Rules
 
 type IgnoreRule = Text
@@ -42,6 +43,7 @@ data OutputFormat
     | TTY
     | CodeclimateJson
     | Checkstyle
+    | Codacy
     deriving (Show, Eq)
 
 data LintOptions = LintOptions
@@ -69,6 +71,7 @@ toOutputFormat "json" = Just Json
 toOutputFormat "tty" = Just TTY
 toOutputFormat "codeclimate" = Just CodeclimateJson
 toOutputFormat "checkstyle" = Just Checkstyle
+toOutputFormat "codacy" = Just Codacy
 toOutputFormat _ = Nothing
 
 showFormat :: OutputFormat -> String
@@ -76,6 +79,7 @@ showFormat Json = "json"
 showFormat TTY = "tty"
 showFormat CodeclimateJson = "codeclimate"
 showFormat Checkstyle = "checkstyle"
+showFormat Codacy = "codacy"
 
 parseOptions :: Parser LintOptions
 parseOptions =
@@ -102,10 +106,10 @@ parseOptions =
             (maybeReader toOutputFormat)
             (long "format" <> -- options for the output format
              short 'f' <>
-             help "The output format for the results [tty | json | checkstyle | codeclimate]" <>
+             help "The output format for the results [tty | json | checkstyle | codeclimate | codacy]" <>
              value TTY <> -- The default value
              showDefaultWith showFormat <>
-             completeWith ["tty", "json", "checkstyle", "codeclimate"])
+             completeWith ["tty", "json", "checkstyle", "codeclimate", "codacy"])
     --
     -- | Parse a list of ignored rules
     ignoreList =
@@ -226,6 +230,7 @@ lint LintOptions {ignoreRules = ignoreList, dockerfiles = dFiles, format, rulesC
             Json -> Json.printResult res
             Checkstyle -> Checkstyle.printResult res
             CodeclimateJson -> Codeclimate.printResult res >> exitSuccess
+            Codacy -> Codacy.printResult res >> exitSuccess
     lintDockerfile ignoreRules dockerFile = do
         ast <- Docker.parseFile (parseFilename dockerFile)
         return (processedFile ast)

--- a/src/Hadolint/Formatter/Codacy.hs
+++ b/src/Hadolint/Formatter/Codacy.hs
@@ -1,0 +1,73 @@
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE DeriveGeneric #-}
+
+module Hadolint.Formatter.Codacy
+    ( printResult
+    , formatResult
+    ) where
+
+import Data.Aeson hiding (Result)
+import qualified Data.ByteString.Lazy as B
+import qualified Data.List.NonEmpty as NE
+import Data.Monoid ((<>))
+import Data.Sequence (Seq)
+import qualified Data.Text as Text
+import GHC.Generics
+import Hadolint.Formatter.Format (Result(..))
+import Hadolint.Rules (Metadata(..), RuleCheck(..))
+import ShellCheck.Interface
+import Text.Megaparsec.Error
+       (ParseError, ShowErrorComponent, ShowToken, errorPos,
+        parseErrorTextPretty)
+import Text.Megaparsec.Pos
+       (sourceColumn, sourceLine, sourceName, unPos)
+
+data Issue = Issue
+    { filename :: String
+    , msg :: String
+    , patternId :: String
+    , line :: Int
+    }
+
+instance ToJSON Issue where
+    toJSON Issue {..} =
+        object
+            [ "filename" .= filename
+            , "patternId" .= patternId
+            , "message" .= msg
+            , "line" .= line
+            ]
+
+errorToIssue :: (ShowToken t, Ord t, ShowErrorComponent e) => ParseError t e -> Issue
+errorToIssue err =
+    Issue
+    { filename = sourceName pos
+    , patternId = "DL1000"
+    , msg = parseErrorTextPretty err
+    , line = linenumber
+    }
+  where
+    pos = NE.head (errorPos err)
+    linenumber = unPos (sourceLine pos)
+    
+checkToIssue :: RuleCheck -> Issue
+checkToIssue RuleCheck {..} =
+    Issue
+    { filename = Text.unpack filename
+    , patternId = Text.unpack (code metadata)
+    , msg = Text.unpack (message metadata)
+    , line = linenumber
+    }
+
+formatResult :: (ShowToken t, Ord t, ShowErrorComponent e) => Result t e -> Seq Issue
+formatResult (Result errors checks) = allIssues
+  where
+    allIssues = errorMessages <> checkMessages
+    errorMessages = fmap errorToIssue errors
+    checkMessages = fmap checkToIssue checks
+
+printResult :: (ShowToken t, Ord t, ShowErrorComponent e) => Result t e -> IO ()
+printResult result = mapM_ output (formatResult result)
+  where
+    output value = B.putStrLn (encode value)

--- a/src/Hadolint/Formatter/Codacy.hs
+++ b/src/Hadolint/Formatter/Codacy.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE DeriveGeneric #-}
 
 module Hadolint.Formatter.Codacy
     ( printResult
@@ -8,20 +7,18 @@ module Hadolint.Formatter.Codacy
     ) where
 
 import Data.Aeson hiding (Result)
-import qualified Data.ByteString.Lazy as B
+import qualified Data.ByteString.Lazy.Char8 as B
 import qualified Data.List.NonEmpty as NE
 import Data.Monoid ((<>))
 import Data.Sequence (Seq)
 import qualified Data.Text as Text
-import GHC.Generics
 import Hadolint.Formatter.Format (Result(..))
 import Hadolint.Rules (Metadata(..), RuleCheck(..))
-import ShellCheck.Interface
 import Text.Megaparsec.Error
        (ParseError, ShowErrorComponent, ShowToken, errorPos,
         parseErrorTextPretty)
 import Text.Megaparsec.Pos
-       (sourceColumn, sourceLine, sourceName, unPos)
+       (sourceLine, sourceName, unPos)
 
 data Issue = Issue
     { filename :: String


### PR DESCRIPTION
Hey guys,

First of all, we really like the tool you’ve created, and we would love to support it on our product.
Because of this, we needed a formatter that would return an output matching the one we expect on our side, so we created one (Codacy.hs) similarly to the ones you already have on your tool and added it as an option to your Main.hs.

Let us know if something needs improvement.

Epic Code Reviews