### PR TITLE
Add Codacy to integrations page

### DIFF
--- a/docs/INTEGRATION.md
+++ b/docs/INTEGRATION.md
@@ -1,5 +1,12 @@
 # Hadolint Integrations
 
+## Automated Code Review
+
+### Codacy
+
+[Codacy](https://www.codacy.com/) automates hadolint code reviews on every
+commit and pull request, reporting code style and error prone issues.
+
 ## Travis CI
 
 Integration with Travis CI requires minimal changes and adding less than


### PR DESCRIPTION
Thank you for the great tool!
I am adding Codacy to the integration page as an automated code review tool.
This way, more people can use hadolint analysis out of the box, for free.