### PR TITLE
Upgrading parser to verion 7

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -20,7 +20,7 @@ ghc-options:
 dependencies:
   - base >=4.8 && <5
   - megaparsec >=6.4
-  - language-docker >=6.0.4 && < 7
+  - language-docker >=7.0.0 && < 8
 library:
   source-dirs: src
   dependencies:

--- a/stack.yaml
+++ b/stack.yaml
@@ -3,3 +3,5 @@ extra-package-dbs: []
 packages:
 - .
 resolver: lts-12.6
+extra-deps:
+- language-docker-7.0.0


### PR DESCRIPTION
No longer using /dev/stdin as the pseudo file for parsing stdin.
Instead, read stdin directly.

fixes #273 
fixes #263 
