### PR TITLE
Upgraded parser to version 8

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -19,8 +19,8 @@ ghc-options:
   - -optP-Wno-nonportable-include-path
 dependencies:
   - base >=4.8 && <5
-  - megaparsec >=6.4
-  - language-docker >=7.0.0 && < 8
+  - megaparsec >=7.0
+  - language-docker >=8.0.0 && < 9
 library:
   source-dirs: src
   dependencies:

--- a/src/Hadolint/Formatter/Checkstyle.hs
+++ b/src/Hadolint/Formatter/Checkstyle.hs
@@ -11,17 +11,14 @@ import qualified Data.ByteString.Lazy.Char8 as B
 import Data.Char
 import Data.Foldable (toList)
 import Data.List (groupBy)
-import qualified Data.List.NonEmpty as NE
 import Data.Monoid ((<>), mconcat)
 import qualified Data.Text as Text
 import Hadolint.Formatter.Format
 import Hadolint.Rules (Metadata(..), RuleCheck(..))
 import ShellCheck.Interface
+import Text.Megaparsec (Stream)
 import Text.Megaparsec.Error
-       (ParseError, ShowErrorComponent, ShowToken, errorPos,
-        parseErrorTextPretty)
-import Text.Megaparsec.Pos
-       (sourceColumn, sourceLine, sourceName, unPos)
+import Text.Megaparsec.Pos (sourceColumn, sourceLine, sourceName, unPos)
 
 data CheckStyle = CheckStyle
     { file :: String
@@ -32,29 +29,29 @@ data CheckStyle = CheckStyle
     , source :: String
     }
 
-errorToCheckStyle :: (ShowToken t, Ord t, ShowErrorComponent e) => ParseError t e -> CheckStyle
+errorToCheckStyle :: (Stream s, ShowErrorComponent e) => ParseErrorBundle s e -> CheckStyle
 errorToCheckStyle err =
     CheckStyle
-    { file = sourceName pos
-    , line = unPos (sourceLine pos)
-    , column = unPos (sourceColumn pos)
-    , impact = severityText ErrorC
-    , msg = stripNewlines (parseErrorTextPretty err)
-    , source = "DL1000"
-    }
+        { file = sourceName pos
+        , line = unPos (sourceLine pos)
+        , column = unPos (sourceColumn pos)
+        , impact = severityText ErrorC
+        , msg = errorBundlePretty err
+        , source = "DL1000"
+        }
   where
-    pos = NE.head (errorPos err)
+    pos = errorPosition err
 
 ruleToCheckStyle :: RuleCheck -> CheckStyle
 ruleToCheckStyle RuleCheck {..} =
     CheckStyle
-    { file = Text.unpack filename
-    , line = linenumber
-    , column = 1
-    , impact = severityText (severity metadata)
-    , msg = Text.unpack (message metadata)
-    , source = Text.unpack (code metadata)
-    }
+        { file = Text.unpack filename
+        , line = linenumber
+        , column = 1
+        , impact = severityText (severity metadata)
+        , msg = Text.unpack (message metadata)
+        , source = Text.unpack (code metadata)
+        }
 
 toXml :: [CheckStyle] -> Builder.Builder
 toXml checks = wrap fileName (foldMap convert checks)
@@ -85,7 +82,7 @@ escape = concatMap doEscape
             else "&#" ++ show (ord c) ++ ";"
     isOk x = any (\check -> check x) [isAsciiUpper, isAsciiLower, isDigit, (`elem` [' ', '.', '/'])]
 
-formatResult :: (ShowToken t, Ord t, ShowErrorComponent e) => Result t e -> Builder.Builder
+formatResult :: (Stream s, ShowErrorComponent e) => Result s e -> Builder.Builder
 formatResult (Result errors checks) =
     "<?xml version='1.0' encoding='UTF-8'?><checkstyle version='4.3'>" <> xmlBody <> "</checkstyle>"
   where
@@ -96,5 +93,5 @@ formatResult (Result errors checks) =
     checkstyleChecks = fmap ruleToCheckStyle checks
     sameFileName CheckStyle {file = f1} CheckStyle {file = f2} = f1 == f2
 
-printResult :: (ShowToken t, Ord t, ShowErrorComponent e) => Result t e -> IO ()
+printResult :: (Stream s, ShowErrorComponent e) => Result s e -> IO ()
 printResult result = B.putStr (Builder.toLazyByteString (formatResult result))

--- a/src/Hadolint/Formatter/Codacy.hs
+++ b/src/Hadolint/Formatter/Codacy.hs
@@ -8,17 +8,14 @@ module Hadolint.Formatter.Codacy
 
 import Data.Aeson hiding (Result)
 import qualified Data.ByteString.Lazy.Char8 as B
-import qualified Data.List.NonEmpty as NE
 import Data.Monoid ((<>))
 import Data.Sequence (Seq)
 import qualified Data.Text as Text
-import Hadolint.Formatter.Format (Result(..))
+import Hadolint.Formatter.Format (Result(..), errorPosition)
 import Hadolint.Rules (Metadata(..), RuleCheck(..))
+import Text.Megaparsec (Stream)
 import Text.Megaparsec.Error
-       (ParseError, ShowErrorComponent, ShowToken, errorPos,
-        parseErrorTextPretty)
-import Text.Megaparsec.Pos
-       (sourceLine, sourceName, unPos)
+import Text.Megaparsec.Pos (sourceLine, sourceName, unPos)
 
 data Issue = Issue
     { filename :: String
@@ -29,42 +26,37 @@ data Issue = Issue
 
 instance ToJSON Issue where
     toJSON Issue {..} =
-        object
-            [ "filename" .= filename
-            , "patternId" .= patternId
-            , "message" .= msg
-            , "line" .= line
-            ]
+        object ["filename" .= filename, "patternId" .= patternId, "message" .= msg, "line" .= line]
 
-errorToIssue :: (ShowToken t, Ord t, ShowErrorComponent e) => ParseError t e -> Issue
+errorToIssue :: (Stream s, ShowErrorComponent e) => ParseErrorBundle s e -> Issue
 errorToIssue err =
     Issue
-    { filename = sourceName pos
-    , patternId = "DL1000"
-    , msg = parseErrorTextPretty err
-    , line = linenumber
-    }
+        { filename = sourceName pos
+        , patternId = "DL1000"
+        , msg = errorBundlePretty err
+        , line = linenumber
+        }
   where
-    pos = NE.head (errorPos err)
+    pos = errorPosition err
     linenumber = unPos (sourceLine pos)
-    
+
 checkToIssue :: RuleCheck -> Issue
 checkToIssue RuleCheck {..} =
     Issue
-    { filename = Text.unpack filename
-    , patternId = Text.unpack (code metadata)
-    , msg = Text.unpack (message metadata)
-    , line = linenumber
-    }
+        { filename = Text.unpack filename
+        , patternId = Text.unpack (code metadata)
+        , msg = Text.unpack (message metadata)
+        , line = linenumber
+        }
 
-formatResult :: (ShowToken t, Ord t, ShowErrorComponent e) => Result t e -> Seq Issue
+formatResult :: (Stream s, ShowErrorComponent e) => Result s e -> Seq Issue
 formatResult (Result errors checks) = allIssues
   where
     allIssues = errorMessages <> checkMessages
     errorMessages = fmap errorToIssue errors
     checkMessages = fmap checkToIssue checks
 
-printResult :: (ShowToken t, Ord t, ShowErrorComponent e) => Result t e -> IO ()
+printResult :: (Stream s, ShowErrorComponent e) => Result s e -> IO ()
 printResult result = mapM_ output (formatResult result)
   where
     output value = B.putStrLn (encode value)

--- a/src/Hadolint/Formatter/Format.hs
+++ b/src/Hadolint/Formatter/Format.hs
@@ -1,35 +1,48 @@
 module Hadolint.Formatter.Format
     ( severityText
     , stripNewlines
+    , errorMessageLine
+    , errorPosition
+    , errorPositionPretty
+    , Text.Megaparsec.Error.errorBundlePretty
     , Result(..)
+    , isEmpty
     , toResult
     ) where
 
 import Data.List (sort)
+import qualified Data.List.NonEmpty as NE
 import Data.Monoid (Monoid)
 import Data.Semigroup
-import Data.Sequence (Seq, fromList, singleton)
+import qualified Data.Sequence as Seq
+import Data.Sequence (Seq)
 import Hadolint.Rules
 import ShellCheck.Interface
-import Text.Megaparsec.Error (ParseError)
+import Text.Megaparsec (Stream(..))
+import Text.Megaparsec.Error
+import Text.Megaparsec.Pos (SourcePos, sourcePosPretty)
 
-data Result t e = Result
-    { errors :: Seq (ParseError t e)
+data Result s e = Result
+    { errors :: Seq (ParseErrorBundle s e)
     , checks :: Seq RuleCheck
-    } deriving (Eq)
+    }
 
-instance Semigroup (Result t e) where
+instance Semigroup (Result s e) where
     (Result e1 c1) <> (Result e2 c2) = Result (e1 <> e2) (c1 <> c2)
 
-instance Monoid (Result t e) where
+instance Monoid (Result s e) where
     mappend = (<>)
     mempty = Result mempty mempty
 
-toResult :: Either (ParseError t e) [RuleCheck] -> Result t e
+isEmpty :: Result s e -> Bool
+isEmpty (Result Seq.Empty Seq.Empty) = True
+isEmpty _ = False
+
+toResult :: Either (ParseErrorBundle s e) [RuleCheck] -> Result s e
 toResult res =
     case res of
-        Left err -> Result (singleton err) mempty
-        Right c -> Result mempty (fromList (sort c))
+        Left err -> Result (Seq.singleton err) mempty
+        Right c -> Result mempty (Seq.fromList (sort c))
 
 severityText :: Severity -> String
 severityText s =
@@ -41,8 +54,19 @@ severityText s =
 
 stripNewlines :: String -> String
 stripNewlines =
-    map
-        (\c ->
+    map (\c ->
              if c == '\n'
                  then ' '
                  else c)
+
+errorMessageLine :: (Stream s, ShowErrorComponent e) => ParseErrorBundle s e -> String
+errorMessageLine err@(ParseErrorBundle e _) =
+    errorPositionPretty err ++ " " ++ parseErrorTextPretty (NE.head e)
+
+errorPositionPretty :: Stream s => ParseErrorBundle s e -> String
+errorPositionPretty err = sourcePosPretty (errorPosition err)
+
+errorPosition :: Stream s => ParseErrorBundle s e -> Text.Megaparsec.Pos.SourcePos
+errorPosition (ParseErrorBundle e s) =
+    let (pos, _, _) = reachOffset (errorOffset (NE.head e)) s
+     in pos

--- a/src/Hadolint/Formatter/TTY.hs
+++ b/src/Hadolint/Formatter/TTY.hs
@@ -4,28 +4,22 @@
 module Hadolint.Formatter.TTY
     ( printResult
     , formatError
+    , formatChecks
     ) where
 
-import qualified Data.List.NonEmpty as NE
 import Data.Semigroup ((<>))
 import qualified Data.Text as Text
 import Hadolint.Formatter.Format
 import Hadolint.Rules
 import Language.Docker.Syntax
+import Text.Megaparsec (Stream(..))
 import Text.Megaparsec.Error
-       (ParseError, ShowErrorComponent, ShowToken, errorPos,
-        parseErrorTextPretty)
-import Text.Megaparsec.Pos (sourcePosPretty)
 
-formatErrors ::
-       (ShowToken t, Ord t, ShowErrorComponent e, Functor f) => f (ParseError t e) -> f String
+formatErrors :: (Stream s, ShowErrorComponent e, Functor f) => f (ParseErrorBundle s e) -> f String
 formatErrors = fmap formatError
 
-formatError :: (ShowToken t, Ord t, ShowErrorComponent e) => ParseError t e -> String
-formatError err = posPart ++ " " ++ stripNewlines (parseErrorTextPretty err)
-  where
-    pos = NE.head (errorPos err)
-    posPart = sourcePosPretty pos
+formatError :: (Stream s, ShowErrorComponent e) => ParseErrorBundle s e -> String
+formatError err = stripNewlines (errorMessageLine err)
 
 formatChecks :: Functor f => f RuleCheck -> f Text.Text
 formatChecks = fmap formatCheck
@@ -36,7 +30,7 @@ formatChecks = fmap formatCheck
 formatPos :: Filename -> Linenumber -> Text.Text
 formatPos source line = source <> ":" <> Text.pack (show line) <> " "
 
-printResult :: (ShowToken t, Ord t, ShowErrorComponent e) => Result t e -> IO ()
+printResult :: (Stream s, ShowErrorComponent e) => Result s e -> IO ()
 printResult Result {errors, checks} = printErrors >> printChecks
   where
     printErrors = mapM_ putStrLn (formatErrors errors)

--- a/stack.yaml
+++ b/stack.yaml
@@ -4,4 +4,5 @@ packages:
 - .
 resolver: lts-12.6
 extra-deps:
-- language-docker-7.0.0
+- megaparsec-7.0.2
+- language-docker-8.0.0


### PR DESCRIPTION
Upgrades language-docker to version 8, which fixes some parser problems and changes the error formatting. I plan to use this error formatting to add a coloured TTY reporting with source position previews for parsing errors.

The format for parsing errors will change for all other formatters, the `message` field in all of them will look like this:

```
Dockerfile:2:1:
  |
2 | RUD apt-get install
  | ^
unexpected 'R'
expecting '#', ADD, ARG, CMD, COPY, ENTRYPOINT, ENV, EXPOSE, FROM, HEALTHCHECK, LABEL, MAINTAINER, ONBUILD, RUN, SHELL, STOPSIGNAL, USER, VOLUME, WORKDIR, end of input, or whitespace
```

@jllopes I hope this is fine with Codacy

also fixes #277