### PR TITLE
Update README with windows installation step

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,12 @@ If you are on OSX you can use [brew](https://brew.sh/) to install `hadolint`.
 brew install hadolint
 ```
 
+On Windows you can use [scoop](https://github.com/lukesampson/scoop) to install `hadolint`.
+
+```batch
+scoop install hadolint
+```
+
 As shown before, `hadolint` is available as a Docker container:
 
 ```bash


### PR DESCRIPTION
Thx to lukesampson/scoop#2972 it is possible to install `hadolint` using [scoop](https://github.com/lukesampson/scoop) installer.
<!--
If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

### What I did

### How I did it

### How to verify it