### PR TITLE
Update ShellCheck to 0.6.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -75,20 +75,24 @@ matrix:
       install:
         # Build image
         - travis_wait 30 docker build
-          --tag hadolint:$(git describe --tags --dirty)
-          --file docker/Dockerfile .
-        - docker build --tag hadolint:debian --file docker/Dockerfile --target debian-distro .
+          --tag hadolint:$(git describe --always --tags --dirty)
+          --file docker/Dockerfile
+          --target distro .
+        - docker build
+          --tag hadolint:$(git describe --always --tags --dirty)-debian
+          --file docker/Dockerfile
+          --target debian-distro .
       script:
         # List images
         - docker image ls
         # Lint its own Dockerfile
-        - docker run --rm -i hadolint:$(git describe --tags --dirty) <
+        - docker run --rm -i hadolint:$(git describe  --always --tags --dirty) <
           docker/Dockerfile
         # Check that version in hadolint in the same as its `git describe`
         - grep $(git describe --dirty) <<<
-          $(docker run --rm -i hadolint:$(git describe --tags --dirty) hadolint --version)
+          $(docker run --rm -i hadolint:$(git describe  --always --tags --dirty) hadolint --version)
         - grep $(git describe --dirty) <<<
-          $(docker run --rm -i hadolint:debian hadolint --version)
+          $(docker run --rm -i hadolint:$(git describe  --always --tags --dirty)-debian hadolint --version)
       after_success: true
 
     - env: Version_Check_and_Linting

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ matrix:
     - env: &lts-latest ARGS="--resolver lts"
       dist: xenial
 
-    - env: &lts-fixed ARGS="--resolver lts-12.6"
+    - env: &lts-fixed ARGS="--resolver lts-13.5"
       dist: xenial
       addons:
         artifacts: {paths: [./releases]}

--- a/package.yaml
+++ b/package.yaml
@@ -26,7 +26,7 @@ library:
   dependencies:
     - &bytestring bytestring >=0.10
     - &split split >=0.2
-    - &ShellCheck ShellCheck >=0.5.0
+    - &ShellCheck ShellCheck >=0.6.0
     - aeson
     - text
     - bytestring

--- a/src/Hadolint/Rules.hs
+++ b/src/Hadolint/Rules.hs
@@ -258,10 +258,14 @@ shellcheck = mapInstructions check Shell.defaultShellOpts
     check st _ (Run (ArgumentsText script)) = (st, doCheck st script)
     check st _ _ = (st, [])
     doCheck opts script = nub [commentMetadata c | c <- Shell.shellcheck opts script]
-    -- | Converts ShellCheck errors into our own errors type
-    commentMetadata :: ShellCheck.Interface.Comment -> Metadata
-    commentMetadata (ShellCheck.Interface.Comment severity code message) =
-        Metadata (Text.pack ("SC" ++ show code)) severity (Text.pack message)
+
+-- | Converts ShellCheck errors into our own errors type
+commentMetadata :: ShellCheck.Interface.PositionedComment -> Metadata
+commentMetadata c = Metadata (Text.pack ("SC" ++ show (code c))) (severity c) (Text.pack (message c))
+  where
+    severity pc = ShellCheck.Interface.cSeverity $ ShellCheck.Interface.pcComment pc
+    code pc = ShellCheck.Interface.cCode $ ShellCheck.Interface.pcComment pc
+    message pc = ShellCheck.Interface.cMessage $ ShellCheck.Interface.pcComment pc
 
 absoluteWorkdir :: Rule
 absoluteWorkdir = instructionRule code severity message check

--- a/src/Hadolint/Rules.hs
+++ b/src/Hadolint/Rules.hs
@@ -517,7 +517,7 @@ apkAddPackages args =
     , arg /= "add"
     ]
   where
-    dropTarget = Shell.dropFlagArg ["t", "virtual"]
+    dropTarget = Shell.dropFlagArg ["t", "virtual", "repository"]
 
 apkAddNoCache :: Rule
 apkAddNoCache = instructionRule code severity message check

--- a/src/Hadolint/Rules.hs
+++ b/src/Hadolint/Rules.hs
@@ -580,7 +580,7 @@ pipVersionPinned = instructionRule code severity message check
         ["install"] `isInfixOf` Shell.getAllArgs cmd &&
         not (["-r"] `isInfixOf` Shell.getAllArgs cmd || ["."] `isInfixOf` Shell.getAllArgs cmd)
     hasBuildConstraint = Shell.hasFlag "constraint"
-    packages cmd = stripInstallPrefix (Shell.getArgsNoFlags cmd)
+    packages cmd = stripInstallPrefix $ Shell.getArgsNoFlags $ Shell.dropFlagArg ["i", "index-url", "extra-index-url"] cmd
     versionFixed package = hasVersionSymbol package || isVersionedGit package
     isVersionedGit package = "git+http" `isInfixOf` package && "@" `isInfixOf` package
     versionSymbols = ["==", ">=", "<=", ">", "<", "!=", "~=", "==="]

--- a/stack.yaml
+++ b/stack.yaml
@@ -2,7 +2,7 @@ flags: {}
 extra-package-dbs: []
 packages:
 - .
-resolver: lts-12.6
+resolver: lts-13.5
 extra-deps:
 - megaparsec-7.0.2
-- language-docker-8.0.0
+- ShellCheck-0.6.0

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -309,6 +309,24 @@ main =
                 in do
                   ruleCatchesNot apkAddVersionPinned $ Text.unlines dockerFile
                   onBuildRuleCatchesNot apkAddVersionPinned $ Text.unlines dockerFile
+            it "apk add with repository without equal sign" $
+                let dockerFile =
+                        [ "RUN apk add --no-cache \\"
+                        , "--repository https://nl.alpinelinux.org/alpine/edge/testing \\"
+                        , "flow=0.78.0-r0"
+                        ]
+                in do
+                ruleCatchesNot apkAddVersionPinned $ Text.unlines dockerFile
+                onBuildRuleCatchesNot apkAddVersionPinned $ Text.unlines dockerFile
+            it "apk add with repository with equal sign" $
+                let dockerFile =
+                        [ "RUN apk add --no-cache \\"
+                        , "--repository=https://nl.alpinelinux.org/alpine/edge/testing \\"
+                        , "flow=0.78.0-r0"
+                        ]
+                in do
+                ruleCatchesNot apkAddVersionPinned $ Text.unlines dockerFile
+                onBuildRuleCatchesNot apkAddVersionPinned $ Text.unlines dockerFile
         --
         describe "EXPOSE rules" $ do
             it "invalid port" $ ruleCatches invalidPort "EXPOSE 80000"

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -399,6 +399,27 @@ main =
                 onBuildRuleCatchesNot
                     pipVersionPinned
                     "RUN pip install MySQL_python==1.2.2 --disable-pip-version-check"
+            it "pip install --index-url" $ do
+                ruleCatchesNot
+                    pipVersionPinned
+                    "RUN pip install --index-url https://eg.com/foo foobar==1.0.0"
+                onBuildRuleCatchesNot
+                    pipVersionPinned
+                    "RUN pip install --index-url https://eg.com/foo foobar==1.0.0"
+            it "pip install index-url with -i flag" $ do
+                ruleCatchesNot
+                    pipVersionPinned
+                    "RUN pip install --index-url https://eg.com/foo foobar==1.0.0"
+                onBuildRuleCatchesNot
+                    pipVersionPinned
+                    "RUN pip install --index-url https://eg.com/foo foobar==1.0.0"
+            it "pip install --index-url with --extra-index-url" $ do
+                ruleCatchesNot
+                    pipVersionPinned
+                    "RUN pip install --index-url https://eg.com/foo --extra-index-url https://ex-eg.io/foo foobar==1.0.0"
+                onBuildRuleCatchesNot
+                    pipVersionPinned
+                    "RUN pip install --index-url https://eg.com/foo --extra-index-url https://ex-eg.io/foo foobar==1.0.0"
             it "pip install no cache dir" $ do
                 ruleCatchesNot pipVersionPinned "RUN pip install MySQL_python==1.2.2 --no-cache-dir"
                 onBuildRuleCatchesNot pipVersionPinned "RUN pip install MySQL_python==1.2.2 --no-cache-dir"


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

### What I did

- Updated SheckCheck from 0.5.0 to 0.6.0
- ￼Add allowed `repository` flag for `apk add` - fixes #290
- ￼Add allowed `index-url` falgs for `pip install` - fixes #287

### How I did it

- Updated stack to latest `lts` and fixed all issues that raised as `ShellCheck.Interface` was heavily refactored.

### How to verify it

Travis-CI should now pass for all environments, even `nightly`. For fixes, I have added tests.