### PR TITLE
Add noApt rule

### DIFF
--- a/src/Hadolint/Rules.hs
+++ b/src/Hadolint/Rules.hs
@@ -202,6 +202,7 @@ rules =
     , useShell
     , useJsonArgs
     , usePipefail
+    , noApt
     ]
 
 optionalRules :: RulesConfig -> [Rule]
@@ -755,6 +756,16 @@ useJsonArgs = instructionRule code severity message check
     message = "Use arguments JSON notation for CMD and ENTRYPOINT arguments"
     check (Cmd (ArgumentsText _)) = False
     check (Entrypoint (ArgumentsText _)) = False
+    check _ = True
+
+noApt :: Rule
+noApt = instructionRule code severity message check
+  where
+    code = "DL3026"
+    severity = WarningC
+    message =
+        "Do not use apt as it is meant to be a end-user tool, use apt-get or apt-cache instead"
+    check (Run args) = argumentsRule (not . usingProgram "apt") args
     check _ = True
 
 usePipefail :: Rule

--- a/src/Hadolint/Rules.hs
+++ b/src/Hadolint/Rules.hs
@@ -761,7 +761,7 @@ useJsonArgs = instructionRule code severity message check
 noApt :: Rule
 noApt = instructionRule code severity message check
   where
-    code = "DL3026"
+    code = "DL3027"
     severity = WarningC
     message =
         "Do not use apt as it is meant to be a end-user tool, use apt-get or apt-cache instead"

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -153,7 +153,15 @@ main =
                 onBuildRuleCatchesNot invalidCmd "RUN apt-get install ssh"
         --
         describe "apt-get rules" $ do
-            it "apt upgrade" $ do
+            it "apt" $
+                let dockerFile =
+                        [ "FROM ubuntu"
+                        , "RUN apt install python"
+                        ]
+                in do
+                  ruleCatches noApt $ Text.unlines dockerFile
+                  onBuildRuleCatches noApt $ Text.unlines dockerFile
+            it "apt-get upgrade" $ do
                 ruleCatches noAptGetUpgrade "RUN apt-get update && apt-get upgrade"
                 onBuildRuleCatches noAptGetUpgrade "RUN apt-get update && apt-get upgrade"
             it "apt-get version pinning" $ do


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

closes #318 

### What I did

added a `noApt` rule to detect and discourage use of `apt`, recommending `apt-get` or other binaries

### How I did it

Followed the pattern of `noSudo`

### How to verify it

Simple test is included
