### PR TITLE
Add gem version pinning

### DIFF
--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -161,6 +161,11 @@ main =
               it "pinned" $ do
                 ruleCatchesNot gemVersionPinned "RUN gem i bundler:1"
                 onBuildRuleCatchesNot gemVersionPinned "RUN gem i bundler:1"
+              it "multi" $ do
+                ruleCatches gemVersionPinned "RUN gem i bunlder:1 nokogiri"
+                onBuildRuleCatches gemVersionPinned "RUN gem i bunlder:1 nokogiri"
+                ruleCatchesNot gemVersionPinned "RUN gem i bunlder:1 nokogirii:1"
+                onBuildRuleCatchesNot gemVersionPinned "RUN gem i bunlder:1 nokogiri:1"
             describe "install" $ do
               it "unpinned" $ do
                 ruleCatches gemVersionPinned "RUN gem install bundler"

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -152,6 +152,23 @@ main =
                 ruleCatchesNot invalidCmd "RUN apt-get install ssh"
                 onBuildRuleCatchesNot invalidCmd "RUN apt-get install ssh"
         --
+        describe "gem" $ do
+          describe "version pinning" $ do
+            describe "i" $ do
+              it "unpinned" $ do
+                ruleCatches gemVersionPinned "RUN gem i bundler"
+                onBuildRuleCatches gemVersionPinned "RUN gem i bundler"
+              it "pinned" $ do
+                ruleCatchesNot gemVersionPinned "RUN gem i bundler:1"
+                onBuildRuleCatchesNot gemVersionPinned "RUN gem i bundler:1"
+            describe "install" $ do
+              it "unpinned" $ do
+                ruleCatches gemVersionPinned "RUN gem install bundler"
+                onBuildRuleCatches gemVersionPinned "RUN gem install bundler"
+              it "pinned" $ do
+                ruleCatchesNot gemVersionPinned "RUN gem install bundler:1"
+                onBuildRuleCatchesNot gemVersionPinned "RUN gem install bundler:1"
+        --
         describe "apt-get rules" $ do
             it "apt" $
                 let dockerFile =

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -152,7 +152,7 @@ main =
                 ruleCatchesNot invalidCmd "RUN apt-get install ssh"
                 onBuildRuleCatchesNot invalidCmd "RUN apt-get install ssh"
         --
-        describe "gem" $ do
+        describe "gem" $
           describe "version pinning" $ do
             describe "i" $ do
               it "unpinned" $ do


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

### What I did

add gem version pinning (to match pip, npm)

### How I did it

detect `gem install|i PACKAGE:VERSION`

### How to verify it

Tests included