### PR TITLE
Add sh as valide shell for pipefail

### DIFF
--- a/src/Hadolint/Rules.hs
+++ b/src/Hadolint/Rules.hs
@@ -801,7 +801,7 @@ usePipefail = instructionRuleState code severity message check False
         null
             [ True
             | cmd@(Shell.Command name arguments _) <- Shell.presentCommands script
-            , validShell <- ["/bin/bash", "/bin/zsh", "/bin/ash", "bash", "zsh", "ash"]
+            , validShell <- ["/bin/bash", "/bin/zsh", "/bin/ash","/bin/sh", "bash", "zsh", "ash","sh"]
             , name == validShell
             , Shell.hasFlag "o" cmd
             , arg <- Shell.arg <$> arguments


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

### What I did

Add the sh shell 9 and it absolute path /bin/sh to the list of valide shell for the rule DL4006

### How I did it

add "sh" and "/bin/sh"

### How to verify it

with this to dockerfile
```
FROM alpine:3.8

SHELL ["/bin/sh","-o", "pipefail","-c"]
RUN exit 1 | echo "bonjour" > file.txt
```
current output
```
hadolint.exe Dockerfile_nofail
Dockerfile_fail.txt:4 SC2216 Piping to 'echo', a command that doesn't read stdin. Did you want 'cat' instead?
Dockerfile_fail.txt:4 DL4006 Set the SHELL option -o pipefail before RUN with a pipe in it
```
and at build
```
docker build -t test -f Dockerfile_nofail .
Sending build context to Docker daemon  9.809MB
Step 1/3 : FROM alpine:3.8
 ---> dac705114996
Step 2/3 : SHELL ["/bin/sh","-o", "pipefail","-c"]
 ---> Using cache
 ---> 2cc990378d1d
Step 3/3 : RUN exit 1 | echo "bonjour" > file.txt
 ---> Running in 8c1239bbd4dd
The command '/bin/sh -o pipefail -c exit 1 | echo "bonjour" > file.txt' returned a non-zero code: 1
```

expected output :
```
hadolint.exe Dockerfile_nofail
Dockerfile_fail.txt:4 SC2216 Piping to 'echo', a command that doesn't read stdin. Did you want 'cat' instead?
```