### PR TITLE
Ignore unsatisfiable shellcheck error 1090

### DIFF
--- a/src/Hadolint/Shell.hs
+++ b/src/Hadolint/Shell.hs
@@ -81,6 +81,7 @@ shellcheck (ShellOpts sh env) (ParsedShell txt _ _) =
     script = "#!" ++ extractShell sh ++ "\n" ++ printVars ++ Text.unpack txt
     exclusions =
         [ 2187 -- exclude the warning about the ash shell not being supported
+        , 1090 -- requires a directive (shell comment) that can't be expressed in a Dockerfile 
         ]
     -- | Shellcheck complains when the shebang has more than one argument, so we only take the first
     extractShell s =


### PR DESCRIPTION
According to https://github.com/koalaman/shellcheck/wiki/SC1090 the fix is to put a shell comment "directive" to assist -- "# shellcheck source=/dev/null".  This can't work in a Dockerfile because `#` is also the Docker comment character.  So with no obvious workaround, the error must simply be ignored completely.

* fixes #343 
