### PR TITLE
Support pip requirement pinning with long parameter

### DIFF
--- a/src/Hadolint/Rules.hs
+++ b/src/Hadolint/Rules.hs
@@ -595,7 +595,7 @@ pipVersionPinned = instructionRule code severity message check
     -- in running this rule
     relevantInstall cmd =
         ["install"] `isInfixOf` Shell.getArgs cmd &&
-        not (["-r"] `isInfixOf` Shell.getArgs cmd || ["."] `isInfixOf` Shell.getArgs cmd)
+        not (["--requirement"] `isInfixOf` Shell.getArgs cmd || ["-r"] `isInfixOf` Shell.getArgs cmd || ["."] `isInfixOf` Shell.getArgs cmd)
     hasBuildConstraint = Shell.hasFlag "constraint"
     packages cmd =
         stripInstallPrefix $

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -383,6 +383,9 @@ main =
             it "pip install requirements" $ do
                 ruleCatchesNot pipVersionPinned "RUN pip install -r requirements.txt"
                 onBuildRuleCatchesNot pipVersionPinned "RUN pip install -r requirements.txt"
+            it "pip install requirements with long flag" $ do
+                ruleCatchesNot pipVersionPinned "RUN pip install --requirement requirements.txt"
+                onBuildRuleCatchesNot pipVersionPinned "RUN pip install --requirement requirements.txt"
             it "pip install use setup.py" $ do
                 ruleCatchesNot pipVersionPinned "RUN pip install ."
                 onBuildRuleCatchesNot pipVersionPinned "RUN pip install ."


### PR DESCRIPTION
### What I did
When using the long parameter for installing pip packages (`RUN pip install --requirement /tmp/requirements.txt`), this get's incorrectly reported by hadolint as un-pinned package versions, as hadolint currently only recognizes the short parameter (`RUN pip install -r /tmp/requirements.txt`).
This PR extends the parsing rules so that also the long parameter is recognized properly.

### How to verify it

When having a `RUN pip install --requirement /tmp/requirements.txt
` statement in the Dockerfile, previously hadolint reported:
```
Dockerfile:4 DL3013 Pin versions in pip. Instead of `pip install <package>` use `pip install <package>==<version>`
```
With the changed version, it correctly recognizes it as an installation of pinned package versions.