### PR TITLE
Geany integration

### DIFF
--- a/docs/INTEGRATION.md
+++ b/docs/INTEGRATION.md
@@ -222,9 +222,15 @@ There is an integration [vscode-hadolint][] with [VS Code][], built by [ExiaSR][
 
 ### Geany
 
-> Geany is a powerful, stable and lightweight programmer's text editor that provides tons of useful features without bogging down your workflow. It runs on Linux, Windows and MacOS is translated into over 40 languages, and has built-in support for more than 50 programming languages.
+> Geany is a powerful, stable and lightweight programmer's text editor
+that provides tons of useful features without bogging down your workflow.
+It runs on Linux, Windows and MacOS is translated into over 40 languages,
+and has built-in support for more than 50 programming languages.
 
-The following can be used as a [build action](https://www.geany.org/manual/current/index.html#build-menu-commands-dialog) to [lint](https://www.geany.org/manual/current/index.html#lint) Dockerfiles.
+The following can be used as a
+[build action](https://www.geany.org/manual/current/index.html#build-menu-commands-dialog)
+to
+[lint](https://www.geany.org/manual/current/index.html#lint) Dockerfiles.
 
 ```
 if docker run --rm -i hadolint/hadolint < "%d/%f" | sed -re 's|^/dev/stdin:([0-9]*)|%d/%f:\1:WARNING:|' | grep -EC100 ':WARNING:' ; then exit 1 ; else exit 0 ; fi

--- a/docs/INTEGRATION.md
+++ b/docs/INTEGRATION.md
@@ -30,11 +30,11 @@ script:
 
 ## GitHub Actions
 
-For GitHub you can build on the existing docker image with debian to 
+For GitHub you can build on the existing docker image with debian to
 run through all the Dockerfiles in your repository and print out a list of issues.
-You can find an example implementation 
-[here](https://github.com/cds-snc/github-actions/tree/master/docker-lint). 
-Your workflow might look something like this (feel free to use the provided Docker 
+You can find an example implementation
+[here](https://github.com/cds-snc/github-actions/tree/master/docker-lint).
+Your workflow might look something like this (feel free to use the provided Docker
 image `cdssnc/docker-lint` or create your own):
 
 ```hcl
@@ -131,7 +131,7 @@ stage ("lint dockerfile") {
 
 ## Codeship Pro
 
-Add the hadolint docker container on codeship-services.yml with a docker volume 
+Add the hadolint docker container on codeship-services.yml with a docker volume
 with the repository attached to it:
 
 ```yaml
@@ -206,20 +206,6 @@ There is an integration [vscode-hadolint][] with [VS Code][], built by [ExiaSR][
 
 ![vscode-hadolint-gif][]
 
-[linter-hadolint]: https://atom.io/packages/linter-hadolint
-[linter-hadolint-img]: https://user-images.githubusercontent.com/18702153/33764234-7abc1f24-dc0b-11e7-96b6-4f08207b6950.png
-[lucasdf]: https://github.com/lucasdf
-[atom]: https://atom.io/
-[sublimelinter-contrib-hadolint]: https://github.com/niksite/SublimeLinter-contrib-hadolint
-[sublime text]: http://www.sublimetext.com/
-[niksite]: https://github.com/niksite
-[syntastic]: https://github.com/vim-syntastic/syntastic
-[ale]: https://github.com/w0rp/ale
-[vscode-hadolint]: https://marketplace.visualstudio.com/items?itemName=exiasr.hadolint
-[vscode-hadolint-gif]: https://i.gyazo.com/a701460ccdda13a1a449b2c3e8da40bc.gif
-[vs code]: https://code.visualstudio.com/
-[exiasr]: https://github.com/ExiaSR
-
 ### Geany
 
 > Geany is a powerful, stable and lightweight programmer's text editor
@@ -235,3 +221,17 @@ to
 ```
 if docker run --rm -i hadolint/hadolint < "%d/%f" | sed -re 's|^/dev/stdin:([0-9]*)|%d/%f:\1:WARNING:|' | grep -EC100 ':WARNING:' ; then exit 1 ; else exit 0 ; fi
 ```
+
+[linter-hadolint]: https://atom.io/packages/linter-hadolint
+[linter-hadolint-img]: https://user-images.githubusercontent.com/18702153/33764234-7abc1f24-dc0b-11e7-96b6-4f08207b6950.png
+[lucasdf]: https://github.com/lucasdf
+[atom]: https://atom.io/
+[sublimelinter-contrib-hadolint]: https://github.com/niksite/SublimeLinter-contrib-hadolint
+[sublime text]: http://www.sublimetext.com/
+[niksite]: https://github.com/niksite
+[syntastic]: https://github.com/vim-syntastic/syntastic
+[ale]: https://github.com/w0rp/ale
+[vscode-hadolint]: https://marketplace.visualstudio.com/items?itemName=exiasr.hadolint
+[vscode-hadolint-gif]: https://i.gyazo.com/a701460ccdda13a1a449b2c3e8da40bc.gif
+[vs code]: https://code.visualstudio.com/
+[exiasr]: https://github.com/ExiaSR

--- a/docs/INTEGRATION.md
+++ b/docs/INTEGRATION.md
@@ -227,5 +227,5 @@ There is an integration [vscode-hadolint][] with [VS Code][], built by [ExiaSR][
 The following can be used as a [build action](https://www.geany.org/manual/current/index.html#build-menu-commands-dialog) t [lint](https://www.geany.org/manual/current/index.html#lint) Dockerfiles.
 
 ```
-if docker run --rm -i hadolint/hadolint < "%f" | sed -re 's|^/dev/stdin:([0-9]*)|%d/%f:\1:WARNING:|' | grep -EC100 ':WARNING:' ; then exit 1 ; else exit 0 ; fi
+if docker run --rm -i hadolint/hadolint < "%d/%f" | sed -re 's|^/dev/stdin:([0-9]*)|%d/%f:\1:WARNING:|' | grep -EC100 ':WARNING:' ; then exit 1 ; else exit 0 ; fi
 ```

--- a/docs/INTEGRATION.md
+++ b/docs/INTEGRATION.md
@@ -224,7 +224,7 @@ There is an integration [vscode-hadolint][] with [VS Code][], built by [ExiaSR][
 
 > Geany is a powerful, stable and lightweight programmer's text editor that provides tons of useful features without bogging down your workflow. It runs on Linux, Windows and MacOS is translated into over 40 languages, and has built-in support for more than 50 programming languages.
 
-The following can be used as a [build action](https://www.geany.org/manual/current/index.html#build-menu-commands-dialog) t [lint](https://www.geany.org/manual/current/index.html#lint) Dockerfiles.
+The following can be used as a [build action](https://www.geany.org/manual/current/index.html#build-menu-commands-dialog) to [lint](https://www.geany.org/manual/current/index.html#lint) Dockerfiles.
 
 ```
 if docker run --rm -i hadolint/hadolint < "%d/%f" | sed -re 's|^/dev/stdin:([0-9]*)|%d/%f:\1:WARNING:|' | grep -EC100 ':WARNING:' ; then exit 1 ; else exit 0 ; fi

--- a/docs/INTEGRATION.md
+++ b/docs/INTEGRATION.md
@@ -218,8 +218,10 @@ The following can be used as a
 to
 [lint](https://www.geany.org/manual/current/index.html#lint) Dockerfiles.
 
-```
-if docker run --rm -i hadolint/hadolint < "%d/%f" | sed -re 's|^/dev/stdin:([0-9]*)|%d/%f:\1:WARNING:|' | grep -EC100 ':WARNING:' ; then exit 1 ; else exit 0 ; fi
+```sh
+if docker run --rm -i hadolint/hadolint < "%d/%f"
+| sed -re 's|^/dev/stdin:([0-9]*)|%d/%f:\1:WARNING:|'
+| grep -EC100 ':WARNING:' ; then exit 1 ; else exit 0 ; fi
 ```
 
 [linter-hadolint]: https://atom.io/packages/linter-hadolint

--- a/docs/INTEGRATION.md
+++ b/docs/INTEGRATION.md
@@ -209,9 +209,9 @@ There is an integration [vscode-hadolint][] with [VS Code][], built by [ExiaSR][
 ### Geany
 
 > Geany is a powerful, stable and lightweight programmer's text editor
-that provides tons of useful features without bogging down your workflow.
-It runs on Linux, Windows and MacOS is translated into over 40 languages,
-and has built-in support for more than 50 programming languages.
+> that provides tons of useful features without bogging down your workflow.
+> It runs on Linux, Windows and MacOS is translated into over 40 languages,
+> and has built-in support for more than 50 programming languages.
 
 The following can be used as a
 [build action](https://www.geany.org/manual/current/index.html#build-menu-commands-dialog)

--- a/docs/INTEGRATION.md
+++ b/docs/INTEGRATION.md
@@ -219,3 +219,13 @@ There is an integration [vscode-hadolint][] with [VS Code][], built by [ExiaSR][
 [vscode-hadolint-gif]: https://i.gyazo.com/a701460ccdda13a1a449b2c3e8da40bc.gif
 [vs code]: https://code.visualstudio.com/
 [exiasr]: https://github.com/ExiaSR
+
+### Geany
+
+> Geany is a powerful, stable and lightweight programmer's text editor that provides tons of useful features without bogging down your workflow. It runs on Linux, Windows and MacOS is translated into over 40 languages, and has built-in support for more than 50 programming languages.
+
+The following can be used as a [build action](https://www.geany.org/manual/current/index.html#build-menu-commands-dialog) t [lint](https://www.geany.org/manual/current/index.html#lint) Dockerfiles.
+
+```
+if docker run --rm -i hadolint/hadolint < "%f" | sed -re 's|^/dev/stdin:([0-9]*)|%d/%f:\1:WARNING:|' | grep -EC100 ':WARNING:' ; then exit 1 ; else exit 0 ; fi
+```


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

### What I did
I added a section to the integration documentation that describes how to include hadolint as a linter into Geany's build system.

### How I did it
I copied and pasted the relevant code from configuration.  Specifically, the code kicks off a Docker container with hadolint/hadolint then massages the output with sed into a format that Geany interprets as an error location.  If the output includes a string (in this case, ':WARNING:') then the build (lint) is marked as having failed.

Geany's build system runs the command via `/bin/sh -c ' (stuff) '` with quotes escaped and the following replacements:

%d directory to the file being edited / run
%f filename (basename -- no directory)

Screenshot:
![Screenshot_2019-11-06_15-44-42](https://user-images.githubusercontent.com/45051395/68337050-af620400-00ad-11ea-963c-32fcc21dca51.png)

### How to verify it
Open a Dockerfile, include the code in Geany's build actions, and run it.