### PR TITLE
Fix gem version check when suplying the `--version` flag

### DIFF
--- a/src/Hadolint/Rules.hs
+++ b/src/Hadolint/Rules.hs
@@ -846,6 +846,8 @@ gems shell =
     | cmd <- Shell.presentCommands shell
     , Shell.cmdHasArgs "gem" ["install", "i"] cmd
     , not (Shell.cmdHasArgs "gem" ["-v"] cmd)
+    , not (Shell.cmdHasArgs "gem" ["--version"] cmd)
+    , not (Shell.cmdHasPrefixArg "gem" "--version=" cmd)
     , arg <- Shell.getArgsNoFlags cmd
     , arg /= "install"
     , arg /= "i"

--- a/src/Hadolint/Shell.hs
+++ b/src/Hadolint/Shell.hs
@@ -150,6 +150,11 @@ cmdHasArgs expectedName expectedArgs (Command n args _)
     | expectedName /= n = False
     | otherwise = not $ null [arg | CmdPart arg _ <- args, arg `elem` expectedArgs]
 
+cmdHasPrefixArg :: Text.Text -> Text.Text -> Command -> Bool
+cmdHasPrefixArg expectedName expectedArg (Command n args _)
+    | expectedName /= n = False
+    | otherwise = not $ null [arg | CmdPart arg _ <- args, expectedArg `Text.isPrefixOf` arg]
+
 extractAllArgs :: Token -> [CmdPart]
 extractAllArgs (T_SimpleCommand _ _ (_:allArgs)) = map mkPart allArgs
   where

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -178,6 +178,12 @@ main =
               it "does not warn on -v" $ do
                 ruleCatchesNot gemVersionPinned "RUN gem install bundler -v '2.0.1'"
                 onBuildRuleCatchesNot gemVersionPinned "RUN gem install bundler -v '2.0.1'"
+              it "does not warn on --version without =" $ do
+                ruleCatchesNot gemVersionPinned "RUN gem install bundler --version '2.0.1'"
+                onBuildRuleCatchesNot gemVersionPinned "RUN gem install bundler --version '2.0.1'"
+              it "does not warn on --version with =" $ do
+                ruleCatchesNot gemVersionPinned "RUN gem install bundler --version='2.0.1'"
+                onBuildRuleCatchesNot gemVersionPinned "RUN gem install bundler --version='2.0.1'"
               it "does not warn on extra flags" $ do
                 ruleCatchesNot gemVersionPinned "RUN gem install bundler:2.0.1 -- --use-system-libraries=true"
                 onBuildRuleCatchesNot gemVersionPinned "RUN gem install bundler:2.0.1 -- --use-system-libraries=true"


### PR DESCRIPTION
### What I did

Fixes false positive when suplying a gem version via the `--version` flag:
```
RUN gem install bundler --version '2.0.1'
RUN gem install bundler --version='2.0.1'
```

### How I did it

While I was able to make it work for the `--version '2.0.1'` case, I don't know what to do to make it work for `--version='2.0.1'` (with the `=` in between).

### How to verify it

I've added tests for both cases.

closes #336 