### PR TITLE
INTEGRATION.md: gitlab-ci

### DIFF
--- a/docs/INTEGRATION.md
+++ b/docs/INTEGRATION.md
@@ -57,7 +57,6 @@ Add the following job to your project's `.gitlab-ci.yml`:
 
 ```yaml
 lint_dockerfile:
-  stage: lint
   image: hadolint/hadolint:latest-debian
   script:
     - hadolint Dockerfile


### PR DESCRIPTION
The YAML in the current docs fails with: 

> Found errors in your .gitlab-ci.yml:
>
> lint_dockerfile job: stage parameter should be:
>  - .pre
>  - build
>  - test
>  - deploy
>  - .post
>
> You can also test your .gitlab-ci.yml in CI Lint

This fixes that (though it might put the linting into the wrong phase)

### What I did

Docpatch

### How to verify it

1. Paste the previous version into a `.gitlab-ci.yaml`, get 🔴 _your YAML is invalid_
1. Paste this version into a `.gitlab-ci.yaml`, get 💚 _the results of a lint_
