### PR TITLE
alpine image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -81,6 +81,10 @@ matrix:
           --tag hadolint:$(git describe --always --tags --dirty)-debian
           --file docker/Dockerfile
           --target debian-distro .
+        - docker build
+          --tag hadolint:$(git describe --always --tags --dirty)-alpine
+          --file docker/Dockerfile
+          --target alpine-distro .
       script:
         # List images
         - docker image ls
@@ -92,6 +96,8 @@ matrix:
           $(docker run --rm -i hadolint:$(git describe  --always --tags --dirty) hadolint --version)
         - grep $(git describe --dirty) <<<
           $(docker run --rm -i hadolint:$(git describe  --always --tags --dirty)-debian hadolint --version)
+        - grep $(git describe --dirty) <<<
+          $(docker run --rm -i hadolint:$(git describe  --always --tags --dirty)-alpine hadolint --version)
       after_success: true
 
     - env: Version_Check_and_Linting

--- a/README.md
+++ b/README.md
@@ -59,11 +59,12 @@ As shown before, `hadolint` is available as a Docker container:
 docker pull hadolint/hadolint
 ```
 
-If you need a Docker container with shell access, use the Debian variant of the
-Docker image:
+If you need a Docker container with shell access, use the Debian or Alpine
+variants of the Docker image:
 
 ```bash
 docker pull hadolint/hadolint:latest-debian
+docker pull hadolint/hadolint:latest-alpine
 ```
 
 You can also build `hadolint` locally. You need [Haskell][] and the [stack][]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -35,3 +35,7 @@ CMD ["/bin/hadolint", "-"]
 FROM scratch AS distro
 COPY --from=builder /root/.local/bin/hadolint /bin/
 CMD ["/bin/hadolint", "-"]
+
+FROM alpine:3 AS alpine-distro
+COPY --from=builder /root/.local/bin/hadolint /bin/
+CMD ["/bin/hadolint", "-"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -4,7 +4,10 @@
 
 This is Docker image for the [hadolint](https://github.com/hadolint/hadolint).
 
-Default images include only `hadolint` static binary. All supported tags have also Debian based image alternative with `-debian` suffinx in tags.
+Default images include only `hadolint` static binary. All supported tags also have:
+
+- Debian based image alternative with `-debian` suffix in tags
+- Alpine based image alternative with `-alpine` suffix in tags
 
 ## Supported tags
 
@@ -17,6 +20,11 @@ Default images include only `hadolint` static binary. All supported tags have al
 - `hadolint/hadolint:latest-debian` tracks master branch
 - `hadolint/hadolint:VERSION-debian` refers release version, eg. `v1.9.0-debian`
 - `hadolint/hadolint:EXTENDED_VERSION-debian` refers to the same version as `hadolint --version` with short git sha, eg. `v1.9.0-0-g4c4881a-debian`
+
+`alpine` based images:
+- `hadolint/hadolint:latest-alpine` tracks master branch
+- `hadolint/hadolint:VERSION-alpine` refers release version, eg. `v1.9.0-alpine`
+- `hadolint/hadolint:EXTENDED_VERSION-alpine` refers to the same version as `hadolint --version` with short git sha, eg. `v1.9.0-0-g4c4881a-alpine`
 
 Check out [Docker Hub](https://hub.docker.com/r/hadolint/hadolint/tags/) for available tags.
 

--- a/docker/hooks/build
+++ b/docker/hooks/build
@@ -9,3 +9,8 @@ docker build \
   --tag "${IMAGE_NAME}-debian" \
   --file Dockerfile .. \
   --target debian-distro
+
+docker build \
+  --tag "${IMAGE_NAME}-alpine" \
+  --file Dockerfile .. \
+  --target alpine-distro

--- a/docker/hooks/push
+++ b/docker/hooks/push
@@ -9,5 +9,8 @@ docker tag "${IMAGE_NAME}" "${DOCKER_REPO}:$(git describe --long --always)"
 echo "=> Tag image: 'debian'"
 docker tag "${IMAGE_NAME}-debian" "${DOCKER_REPO}:$(git describe --long --always)-debian"
 
+echo "=> Tag image: 'alpine'"
+docker tag "${IMAGE_NAME}-alpine" "${DOCKER_REPO}:$(git describe --long --always)-alpine"
+
 echo "=> Push images"
 docker push "${DOCKER_REPO}"


### PR DESCRIPTION
### What I did

I've added an alpine target image, updating travis and documentation stuff where necessary. This come after some weeks of tests in my company where we need to use hadolint on jenkins' k8s plugin and we use alpine for the sake of image size (~8MiB vs debian's 53). We'd be glad if you consider adopting this enhancement.

### How I did it

Updated READMEs, travis config, dockerfile and his hooks. I didn't touched INTEGRATION docs because I'm unsure on how to proceed w/o rendering that file too much "noisy", what do you think about?

### How to verify it

Pipelines should pass


HTH, ciao!