### PR TITLE
update actions syntax

### DIFF
--- a/docs/INTEGRATION.md
+++ b/docs/INTEGRATION.md
@@ -30,22 +30,25 @@ script:
 
 ## GitHub Actions
 
-For GitHub you can build on the existing docker image with debian to
-run through all the Dockerfiles in your repository and print out a list of issues.
-You can find an example implementation
-[here](https://github.com/cds-snc/github-actions/tree/master/docker-lint).
-Your workflow might look something like this (feel free to use the provided Docker
-image `cdssnc/docker-lint` or create your own):
+For GitHub Actions you can use the [Hadolint Action in the GitHub Marketplace](https://github.com/marketplace/actions/hadolint-action).
 
-```hcl
-workflow "Lint Dockerfiles" {
-  on = "push"
-  resolves = ["Lint all the files"]
-}
+```yaml
+name: Lint Dockerfile
 
-action "Lint all the files" {
-  uses = "docker://cdssnc/docker-lint"
-}
+on: push
+
+jobs:
+  linter:
+    runs-on: ubuntu-latest
+    steps:
+
+      - uses: actions/checkout@v2
+
+      - name: Lint Dockerfile
+        uses: brpaz/hadolint-action@master
+        with:
+          dockerfile: "Dockerfile"
+
 ```
 
 ## Gitlab CI


### PR DESCRIPTION
### What I did

GitHub Actions use a YAML workflow definition now, so this updates the integration example doc to reflect the new syntax.

### How I did it

Lots of trial and error to get Hadolint running in Actions😸 

### How to verify it

Create a PR adding the contents of the example action to `.github/workflows/main.yml`