### PR TITLE
Allow installation from deb file as versioned

### DIFF
--- a/src/Hadolint/Rules.hs
+++ b/src/Hadolint/Rules.hs
@@ -445,7 +445,7 @@ aptGetVersionPinned = instructionRule code severity message check
         \install <package>=<version>`"
     check (Run args) = argumentsRule (all versionFixed . aptGetPackages) args
     check _ = True
-    versionFixed package = "=" `Text.isInfixOf` package
+    versionFixed package = "=" `Text.isInfixOf` package || ("/" `Text.isInfixOf` package || ".deb" `Text.isSuffixOf` package)
 
 aptGetPackages :: Shell.ParsedShell -> [Text.Text]
 aptGetPackages args =

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -725,6 +725,9 @@ main =
             it "apt-get version" $ do
                 ruleCatchesNot aptGetVersionPinned "RUN apt-get install -y python=1.2.2"
                 onBuildRuleCatchesNot aptGetVersionPinned "RUN apt-get install -y python=1.2.2"
+            it "apt-get version" $ do
+                ruleCatchesNot aptGetVersionPinned "RUN apt-get install ./wkhtmltox_0.12.5-1.bionic_amd64.deb"
+                onBuildRuleCatchesNot aptGetVersionPinned "RUN apt-get install ./wkhtmltox_0.12.5-1.bionic_amd64.deb"
             it "apt-get pinned" $ do
                 ruleCatchesNot
                     aptGetVersionPinned


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

### What I did

Fixed #345.

### How I did it

Allowed packages containing `/` (is defined by path is OS) and have the suffix `.deb` to be considered versioned.

### How to verify it

Added tests.
