### PR TITLE
Allow npm local install

### DIFF
--- a/src/Hadolint/Rules.hs
+++ b/src/Hadolint/Rules.hs
@@ -633,12 +633,14 @@ npmVersionPinned = instructionRule code severity message check
     isNpmInstall = Shell.cmdHasArgs "npm" ["install"]
     installIsFirst cmd = ["install"] `isPrefixOf` Shell.getArgsNoFlags cmd
     packages cmd = stripInstallPrefix (Shell.getArgsNoFlags cmd)
-    versionFixed package =
-        if hasGitPrefix package
-            then isVersionedGit package
-            else hasVersionSymbol package
+    versionFixed package
+        | hasGitPrefix package = isVersionedGit package
+        | isFolder package = True
+        | otherwise = hasVersionSymbol package
     gitPrefixes = ["git://", "git+ssh://", "git+http://", "git+https://"]
     hasGitPrefix package = or [p `Text.isPrefixOf` package | p <- gitPrefixes]
+    pathPrefixes = ["/", "./", "../", "~/"]
+    isFolder package = or [p `Text.isPrefixOf` package | p <- pathPrefixes]
     isVersionedGit package = "#" `Text.isInfixOf` package
     hasVersionSymbol package = "@" `Text.isInfixOf` dropScope package
       where

--- a/src/Hadolint/Rules.hs
+++ b/src/Hadolint/Rules.hs
@@ -635,10 +635,13 @@ npmVersionPinned = instructionRule code severity message check
     packages cmd = stripInstallPrefix (Shell.getArgsNoFlags cmd)
     versionFixed package
         | hasGitPrefix package = isVersionedGit package
+        | hasTarballSuffix package = True
         | isFolder package = True
         | otherwise = hasVersionSymbol package
     gitPrefixes = ["git://", "git+ssh://", "git+http://", "git+https://"]
     hasGitPrefix package = or [p `Text.isPrefixOf` package | p <- gitPrefixes]
+    tarballSuffixes = [".tar", ".tar.gz", ".tgz"]
+    hasTarballSuffix package = or [p `Text.isSuffixOf` package | p <- tarballSuffixes]
     pathPrefixes = ["/", "./", "../", "~/"]
     isFolder package = or [p `Text.isPrefixOf` package | p <- pathPrefixes]
     isVersionedGit package = "#" `Text.isInfixOf` package

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -496,6 +496,18 @@ main =
             it "version pinned with -g" $ do
                 ruleCatchesNot npmVersionPinned "RUN npm install -g express@\"4.1.1\""
                 onBuildRuleCatchesNot npmVersionPinned "RUN npm install -g express@\"4.1.1\""
+            it "version does not have to be pinned for folder - absolute path" $ do
+                ruleCatchesNot npmVersionPinned "RUN npm install /folder"
+                onBuildRuleCatchesNot npmVersionPinned "RUN npm install /folder"
+            it "version does not have to be pinned for folder - relative path from current folder" $ do
+                ruleCatchesNot npmVersionPinned "RUN npm install ./folder"
+                onBuildRuleCatchesNot npmVersionPinned "RUN npm install ./folder"
+            it "version does not have to be pinned for folder - relative path to parent folder" $ do
+                ruleCatchesNot npmVersionPinned "RUN npm install ../folder"
+                onBuildRuleCatchesNot npmVersionPinned "RUN npm install ../folder"
+            it "version does not have to be pinned for folder - relative path from home" $ do
+                ruleCatchesNot npmVersionPinned "RUN npm install ~/folder"
+                onBuildRuleCatchesNot npmVersionPinned "RUN npm install ~/folder"
             it "commit pinned for git+ssh" $ do
                 ruleCatchesNot
                     npmVersionPinned

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -496,6 +496,15 @@ main =
             it "version pinned with -g" $ do
                 ruleCatchesNot npmVersionPinned "RUN npm install -g express@\"4.1.1\""
                 onBuildRuleCatchesNot npmVersionPinned "RUN npm install -g express@\"4.1.1\""
+            it "version does not have to be pinned for tarball suffix .tar" $ do
+                ruleCatchesNot npmVersionPinned "RUN npm install package-v1.2.3.tar"
+                onBuildRuleCatchesNot npmVersionPinned "RUN npm install package-v1.2.3.tar"
+            it "version does not have to be pinned for tarball suffix .tar.gz" $ do
+                ruleCatchesNot npmVersionPinned "RUN npm install package-v1.2.3.tar.gz"
+                onBuildRuleCatchesNot npmVersionPinned "RUN npm install package-v1.2.3.tar.gz"
+            it "version does not have to be pinned for tarball suffix .tgz" $ do
+                ruleCatchesNot npmVersionPinned "RUN npm install package-v1.2.3.tgz"
+                onBuildRuleCatchesNot npmVersionPinned "RUN npm install package-v1.2.3.tgz"
             it "version does not have to be pinned for folder - absolute path" $ do
                 ruleCatchesNot npmVersionPinned "RUN npm install /folder"
                 onBuildRuleCatchesNot npmVersionPinned "RUN npm install /folder"


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

### What I did

Fixed #356.

### How I did it

Looked at [docs](https://docs.npmjs.com/cli/install) and implemented tarball installation based on list of suffixes and folder installation based on prefixes with `/`.

I do not think that we can detect if users are installing from a folder or they are installing an unversioned package

```bash
npm install folder_or_package_who_knows
```   

This will be a false positive if it is a folder.

### How to verify it

I have written tests to cover cases I can think of.