### PR TITLE
Add cabal flag for static compilation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -141,7 +141,7 @@ before_install:
 
 install:
   - travis_retry stack --no-terminal --install-ghc $ARGS test --only-dependencies
-  - stack --no-terminal $ARGS install --ghc-options='-fPIC'
+  - stack --no-terminal $ARGS install --ghc-options='-fPIC' --flag hadolint:static
 
 script:
   - stack --no-terminal $ARGS test

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,7 +15,7 @@ before_build:
 build_script:
   # Suppress output from stack, as there is a lot and it's not necessary.
   - stack --no-terminal --install-ghc test --only-dependencies --keep-going > nul
-  - stack --no-terminal --local-bin-path . install
+  - stack --no-terminal --local-bin-path . install --flag hadolint:static
 
 test_script:
   - stack test

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -21,7 +21,7 @@ RUN stack --no-terminal --install-ghc test --only-dependencies
 
 COPY . /opt/hadolint
 RUN scripts/fetch_version.sh \
-  && stack install --ghc-options="-fPIC"
+  && stack install --ghc-options="-fPIC" --flag hadolint:static
 
 # COMPRESS WITH UPX
 RUN curl -sSL https://github.com/upx/upx/releases/download/v3.94/upx-3.94-amd64_linux.tar.xz \

--- a/package.yaml
+++ b/package.yaml
@@ -10,6 +10,11 @@ license: GPL-3
 homepage: https://github.com/hadolint/hadolint
 git: git@github.com:hadolint/hadolint.git
 extra-source-files: README.md
+flags:
+  static:
+    description: Use static linking for the hadolint executable
+    default: false
+    manual: true
 ghc-options:
   - -Wall
   - -Wcompat
@@ -48,7 +53,7 @@ executables:
       - containers
     when:
       # OS X does not support static build https://developer.apple.com/library/content/qa/qa1118
-      - condition: "!(os(osx))"
+      - condition: "flag(static) && !(os(osx))"
         ld-options:
           - -static
           - -pthread


### PR DESCRIPTION
Adds a flag to the hadolint package that toggles static compilation.
By default I set it to `false` and enable this flag in the `Dockerfile`, 
`appveyor.yml` and `travis.yml`.

The reason is that some systems don't easily support static linking,
so using the flag when you want it is nicer instead of having to patch
around this problem.

I tested locally that it "works" without setting anything and that it "breaks" (for me on NixOS) when enabling the `static` flag.

We could also set the flag to `true` by default, and I would manually patch the package for NixOS, but it feels like disabling the static compilation by default is a saner default.  WDYT?