### PR TITLE
Add hadolint-shim

### DIFF
--- a/docs/INTEGRATION.md
+++ b/docs/INTEGRATION.md
@@ -261,9 +261,13 @@ if docker run --rm -i hadolint/hadolint < "%d/%f"
 | grep -EC100 ':WARNING:' ; then exit 1 ; else exit 0 ; fi
 ```
 
-## Shims
+## Other
 
-- [hadolint-shim](https://github.com/kornicameister/hadolint-shim)
+Following section contains different angles on `hadolint` usage that go outside of [code review](#code-review) or 
+[editors' integration](#editors). 
+
+- [hadolint-shim](https://github.com/kornicameister/hadolint-shim) - use `hadolint` as normal executable on systems where
+  static binaries are not accessible
 
 [linter-hadolint]: https://atom.io/packages/linter-hadolint
 [linter-hadolint-img]: https://user-images.githubusercontent.com/18702153/33764234-7abc1f24-dc0b-11e7-96b6-4f08207b6950.png

--- a/docs/INTEGRATION.md
+++ b/docs/INTEGRATION.md
@@ -267,7 +267,7 @@ Following section contains different angles on `hadolint` usage
 that go outside of [code review](#code-review) or [editors' integration](#editors). 
 
 - [hadolint-shim](https://github.com/kornicameister/hadolint-shim) - use `hadolint` 
-  as normal executable on systems where static binaries are not accessible
+  as normal executable on systems where static binaries are not available
 
 [linter-hadolint]: https://atom.io/packages/linter-hadolint
 [linter-hadolint-img]: https://user-images.githubusercontent.com/18702153/33764234-7abc1f24-dc0b-11e7-96b6-4f08207b6950.png

--- a/docs/INTEGRATION.md
+++ b/docs/INTEGRATION.md
@@ -266,8 +266,8 @@ if docker run --rm -i hadolint/hadolint < "%d/%f"
 Following section contains different angles on `hadolint` usage that go outside of [code review](#code-review) or 
 [editors' integration](#editors). 
 
-- [hadolint-shim](https://github.com/kornicameister/hadolint-shim) - use `hadolint` as normal executable on systems where
-  static binaries are not accessible
+- [hadolint-shim](https://github.com/kornicameister/hadolint-shim) - use `hadolint` as normal executable on systems
+  where static binaries are not accessible
 
 [linter-hadolint]: https://atom.io/packages/linter-hadolint
 [linter-hadolint-img]: https://user-images.githubusercontent.com/18702153/33764234-7abc1f24-dc0b-11e7-96b6-4f08207b6950.png

--- a/docs/INTEGRATION.md
+++ b/docs/INTEGRATION.md
@@ -263,11 +263,11 @@ if docker run --rm -i hadolint/hadolint < "%d/%f"
 
 ## Other
 
-Following section contains different angles on `hadolint` usage that go outside of [code review](#code-review) or 
-[editors' integration](#editors). 
+Following section contains different angles on `hadolint` usage 
+that go outside of [code review](#code-review) or [editors' integration](#editors). 
 
-- [hadolint-shim](https://github.com/kornicameister/hadolint-shim) - use `hadolint` as normal executable on systems
-  where static binaries are not accessible
+- [hadolint-shim](https://github.com/kornicameister/hadolint-shim) - use `hadolint` 
+  as normal executable on systems where static binaries are not accessible
 
 [linter-hadolint]: https://atom.io/packages/linter-hadolint
 [linter-hadolint-img]: https://user-images.githubusercontent.com/18702153/33764234-7abc1f24-dc0b-11e7-96b6-4f08207b6950.png

--- a/docs/INTEGRATION.md
+++ b/docs/INTEGRATION.md
@@ -261,6 +261,10 @@ if docker run --rm -i hadolint/hadolint < "%d/%f"
 | grep -EC100 ':WARNING:' ; then exit 1 ; else exit 0 ; fi
 ```
 
+## Shims
+
+- [hadolint-shim](https://github.com/kornicameister/hadolint-shim)
+
 [linter-hadolint]: https://atom.io/packages/linter-hadolint
 [linter-hadolint-img]: https://user-images.githubusercontent.com/18702153/33764234-7abc1f24-dc0b-11e7-96b6-4f08207b6950.png
 [lucasdf]: https://github.com/lucasdf


### PR DESCRIPTION
This is somehow new but I've been relying on such solution for longer time and it proven to be quite robust used both in shell and `neovim` integration.

### What I did

Created an alternative approach to use `hadolint` via shim that gets installed somewhere into `$PATH`

### How I did it

Wrote simple [bin/hadolint](https://github.com/kornicameister/dotfiles/commits/master/bin/hadolint) shim longer while ago and have decided to extract it [here](https://github.com/kornicameister/hadolint-shim) for others to pick up if needed. There are editor integrations for sure but sometimes there is need to just do `hadolint` in `$SHELL` and it is much simpler to just do `hadolint Dockerfile` instead of `docker run ...` on systems that do not provide static binaries.


### How to verify it

Following installation instruction [here](https://github.com/kornicameister/hadolint-shim/blob/master/README.md#installation). 

PS. I will provide basic CI later on will comment on this PR as well. This should provide a good verification example.