### PR TITLE
Add Emacs on the list of supported editors

### DIFF
--- a/docs/INTEGRATION.md
+++ b/docs/INTEGRATION.md
@@ -237,7 +237,7 @@ Hadolint is used in two plugins:
 ### Emacs
 > Emacs is an extensible, customizable, free/libre text editor.
 
-- [Flycheck](https://www.flycheck.org/en/latest/languages.html#dockerfile) - a modern on-the-fly syntax checking extension for GNU Emacs.
+- [flycheck][] - a modern on-the-fly syntax checking extension for GNU Emacs.
 
 
 ### VS Code
@@ -284,6 +284,7 @@ that go outside of [code review](#code-review) or [editors' integration](#editor
 [niksite]: https://github.com/niksite
 [syntastic]: https://github.com/vim-syntastic/syntastic
 [ale]: https://github.com/w0rp/ale
+[flycheck]: https://www.flycheck.org/en/latest/languages.html#dockerfile
 [vscode-hadolint]: https://marketplace.visualstudio.com/items?itemName=exiasr.hadolint
 [vscode-hadolint-gif]: https://i.gyazo.com/a701460ccdda13a1a449b2c3e8da40bc.gif
 [vs code]: https://code.visualstudio.com/

--- a/docs/INTEGRATION.md
+++ b/docs/INTEGRATION.md
@@ -239,7 +239,6 @@ Hadolint is used in two plugins:
 
 - [flycheck][] - a modern on-the-fly syntax checking extension for GNU Emacs.
 
-
 ### VS Code
 
 > Visual Studio Code is a lightweight but powerful source code editor which

--- a/docs/INTEGRATION.md
+++ b/docs/INTEGRATION.md
@@ -234,6 +234,12 @@ Hadolint is used in two plugins:
 -   [ALE][] (Asynchronous Lint Engine) - plugin for providing linting in NeoVim
     and Vim 8 while you edit your text files.
 
+### Emacs
+> Emacs is an extensible, customizable, free/libre text editor.
+
+- [Flycheck](https://www.flycheck.org/en/latest/languages.html#dockerfile) - a modern on-the-fly syntax checking extension for GNU Emacs.
+
+
 ### VS Code
 
 > Visual Studio Code is a lightweight but powerful source code editor which


### PR DESCRIPTION
Emacs support handolint with the flycheck extension.
https://www.flycheck.org/en/latest/languages.html#dockerfile
