### PR TITLE
added description how to pass config into container

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,12 @@ the `--config` option
 hadolint --config /path/to/config.yaml Dockerfile
 ```
 
+To pass a custom configuration file (using relative or absolute path) to a container, use the following command:
+
+```bash
+docker run --rm -i -v ./your/path/to/hadolint.yaml:/root/.config/hadolint.yaml hadolint/hadolint < Dockerfile
+```
+
 ## Inline ignores
 
 It is also possible to ignore rules by using a special comment directly above the Dockerfile


### PR DESCRIPTION
README.md file now clarifies how to pass a specific configuration YAML file (using its relative or absolute file path) to a container
via bind mount (`-v` option for docker) to customize the linter behavior, which checks the Dockerfile that is piped into the container.

Related issues:
* https://github.com/hadolint/hadolint/issues/308
* https://github.com/hadolint/hadolint/issues/346
