### PR TITLE
Support --trusted-host for pip install

### DIFF
--- a/src/Hadolint/Rules.hs
+++ b/src/Hadolint/Rules.hs
@@ -617,6 +617,7 @@ pipVersionPinned = instructionRule code severity message check
             , "root"
             , "src"
             , "t", "target"
+            , "trusted-host"
             , "upgrade-strategy"
             ] cmd
     versionFixed package = hasVersionSymbol package || isVersionedGit package

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -433,6 +433,9 @@ main =
             it "pip version pinned with flag --target" $ do
                 ruleCatchesNot pipVersionPinned "RUN pip3 install --target /opt/yamllint yamllint==1.20.0"
                 onBuildRuleCatchesNot pipVersionPinned "RUN pip3 install --target /opt/yamllint yamllint==1.20.0"
+            it "pip version pinned with flag --trusted-host" $ do
+                ruleCatchesNot pipVersionPinned "RUN pip3 install --trusted-host host example==1.2.2"
+                onBuildRuleCatchesNot pipVersionPinned "RUN pip3 install --trusted-host host example==1.2.2"
             it "pip version pinned with python -m" $ do
                 ruleCatchesNot pipVersionPinned "RUN python -m pip install example==1.2.2"
                 onBuildRuleCatchesNot pipVersionPinned "RUN python -m pip install example==1.2.2"


### PR DESCRIPTION
Fixes: #459

Fixes false-positive for `pipVersionNotPinned` when using `--trusted-host`; new test added.