### PR TITLE
include test for missing apt-get cleanup

### DIFF
--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -213,6 +213,16 @@ main =
                 in do
                   ruleCatches aptGetCleanup $ Text.unlines dockerFile
                   onBuildRuleCatches aptGetCleanup $ Text.unlines dockerFile
+            it "apt-get no cleanup different" $
+                let dockerFile =
+                        [ "FROM golang:latest as build"
+                          , "WORKDIR /go/src/github.com/pomerium/pomerium"
+                          , "RUN apt-get update \\"
+                          , "&& apt-get -y install zip"
+                        ]
+                in do
+                  ruleCatches aptGetCleanup $ Text.unlines dockerFile
+                  onBuildRuleCatches aptGetCleanup $ Text.unlines dockerFile
             it "apt-get cleanup in stage image" $
                 let dockerFile =
                         [ "FROM ubuntu as foo"


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

### What I did

Currently seeing no `DL3009` with the `Dockerfile` snippet below, trying to replicate issue in test

```
FROM golang:latest as build
WORKDIR /go/src/github.com/pomerium/pomerium

RUN apt-get update \
    && apt-get -y install zip
```

### How I did it

### How to verify it
