### PR TITLE
Rules: Add rules for `yum` commands, #470

### DIFF
--- a/src/Hadolint/Shell.hs
+++ b/src/Hadolint/Shell.hs
@@ -143,6 +143,9 @@ allCommands check script = all check (presentCommands script)
 noCommands :: (Command -> Bool) -> ParsedShell -> Bool
 noCommands check = allCommands (not . check)
 
+anyCommands :: (Command -> Bool) -> ParsedShell -> Bool
+anyCommands check script = any check (presentCommands script)
+
 findCommandNames :: ParsedShell -> [Text]
 findCommandNames script = map name (presentCommands script)
 

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -190,6 +190,20 @@ main =
                 ruleCatchesNot gemVersionPinned "RUN gem install bundler:2.0.1 -- --use-system-libraries=true"
                 onBuildRuleCatchesNot gemVersionPinned "RUN gem install bundler:2.0.1 -- --use-system-libraries=true"
         --
+        describe "yum rules" $ do
+            it "yum update" $ do
+                ruleCatches noYumUpdate "RUN yum update"
+                onBuildRuleCatches noYumUpdate "RUN yum update"
+            it "yum version pinning" $ do
+                ruleCatches yumVersionPinned "RUN yum install -y tomcat && yum clean all"
+                onBuildRuleCatches yumVersionPinned "RUN yum install -y tomcat && yum clean all"
+            it "yum no clean all" $ do
+                ruleCatches yumCleanup "RUN yum install -y mariadb-10.4"
+                onBuildRuleCatches yumCleanup "RUN yum install -y mariadb-10.4"
+            it "yum non-interactive" $ do
+                ruleCatches yumYes "RUN yum install httpd-2.4.24 && yum clean all"
+                onBuildRuleCatches yumYes "RUN yum install httpd-2.4.24 && yum clean all"
+        --
         describe "apt-get rules" $ do
             it "apt" $
                 let dockerFile =


### PR DESCRIPTION
Add four rules for `yum` commands warning on bad practices:

  * `yum update`
  * `yum install` without non-interactive flag `-y`
  * `yum install -y <pkg>` without version pinning
  * `yum install ...` without also cleaning up with `yum clean all`

These four rules are accompanied by test for each rule.
Also included is a new helper function `Shell.anyCommands`.

<!--
If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

### What I did

Add four rules for linting `yum` commands in `RUN` layers. These four rules check for common mistakes and bad-practices with `yum` in Dockerfiles.
This PR is related to #470, but does not suffice to close it since `zypper` and `dnf` checks are still missing.

### How I did it

I expanded the `Rules.hs` file. I also added a new helper function in the `Shell.hs` file: `Shell.anyCommands` that works like `Shell.allCommands`, except it matches on any instead of all commands in a shell line.

### How to verify it

Run the test suite, or run `hadolint` on this Dockerfile:

```Dockerfile
FROM centos:8
RUN yum update
RUN yum install httpd
RUN yum install -y tomcat
RUN yum install -y mariadb-10.4
RUN yum install -y php-7.2 && yum clean all
```
The `FROM` and the last `RUN yum install..` line will not produce warnings and the other lines will each trigger a different combination of warnings for `yum`.