### PR TITLE
Python pip basic auth | fixes [#452]

### DIFF
--- a/src/Hadolint/Shell.hs
+++ b/src/Hadolint/Shell.hs
@@ -198,5 +198,6 @@ hasArg arg Command {arguments} = not $ null [a | CmdPart a _ <- arguments, a == 
 dropFlagArg :: [Text.Text] -> Command -> Command
 dropFlagArg flagsToDrop Command {name, arguments, flags} = Command name filterdArgs flags
   where
-    idsToDrop = Set.fromList [fId + 2 | CmdPart f fId <- flags, f `elem` flagsToDrop]
+    idsToDrop = Set.fromList [getValueId fId arguments | CmdPart f fId <- flags, f `elem` flagsToDrop]
     filterdArgs = [arg | arg@(CmdPart _ aId) <- arguments, not (aId `Set.member` idsToDrop)]
+getValueId fId flags = foldl min (maxBound :: Int) $ filter (>fId) $ map partId flags 

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -519,6 +519,13 @@ main =
             it "pip install constraints file - short version argument" $ do
                 ruleCatchesNot pipVersionPinned "RUN pip install pykafka -c http://foo.bar.baz"
                 onBuildRuleCatchesNot pipVersionPinned "RUN pip install pykafka -c http://foo.bar.baz"
+            it "pip install --index-url with --extra-index-url with basic auth" $ do
+                ruleCatchesNot
+                    pipVersionPinned
+                    "RUN pip install --index-url https://user:pass@eg.com/foo --extra-index-url https://user:pass@ex-eg.io/foo foobar==1.0.0"
+                onBuildRuleCatchesNot
+                    pipVersionPinned
+                    "RUN pip install --index-url https://user:pass@eg.com/foo --extra-index-url https://user:pass@ex-eg.io/foo foobar==1.0.0"
         --
         describe "npm pinning" $ do
             it "version pinned in package.json" $ do


### PR DESCRIPTION
### What I did
This PR resolves issue #452. Problem was in wrong arguments ordering which was created by ShellCheck. For example, pip command mentioned in issue was cut down to:
```
[
CmdPart {arg = "install", partId = 6},
CmdPart {arg = "--index-url", partId = 8},
CmdPart {arg = "https://user:pass@eg.com/foo", partId = 12},
CmdPart {arg = "--extra-index-url", partId = 14},
CmdPart {arg = "https://user:pass@ex-eg.io/foo", partId = 18},
CmdPart {arg = "foobar==1.0.0", partId = 20}
]
```
Extra-index-url id is 14 and it tries to remove item with id 16, but that id doesn't exsist. 

### How I did it
Search for the smallest argument id which is greater than the flag id. 

### How to verify it
Tests mentioned in issue was added in Spec file. 