### PR TITLE
add proxy attribute | pip

### DIFF
--- a/src/Hadolint/Rules.hs
+++ b/src/Hadolint/Rules.hs
@@ -620,6 +620,7 @@ pipVersionPinned = instructionRule code severity message check
             , "platform"
             , "prefix"
             , "progress-bar"
+            , "proxy"
             , "python-version"
             , "root"
             , "src"


### PR DESCRIPTION
### What I did
I add proxy flag in pip command array. 

```
--proxy <proxy>             Specify a proxy in the form [user:passwd@]proxy.server:port
```

### How I did it

### How to verify it
