### PR TITLE
bugfix: Fix crash on trailing whitespace #448

### DIFF
--- a/src/Hadolint/Rules.hs
+++ b/src/Hadolint/Rules.hs
@@ -752,7 +752,7 @@ copyEndingSlash = instructionRule code severity message check
         | length sources > 1 = endsWithSlash t
         | otherwise = True
     check _ = True
-    endsWithSlash (TargetPath t) = Text.last t == '/' -- it is safe to use last, as the target is never empty
+    endsWithSlash (TargetPath t) = not (Text.null t) && Text.last t == '/'
 
 copyFromExists :: Rule
 copyFromExists dockerfile = instructionRuleLine code severity message check dockerfile


### PR DESCRIPTION
Add simple test against a target path parsed as empty.
A trailing whitespace could cause the target path to be falsely parsed
empty and that would cause a crash with `Data.Text.last`.

fixes #448 
<!--
If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

### What I did / How I did it
Add guard against crashing when the last argument of a `COPY` instruction ends with a whitespace.
The parser would assume the target path of the `COPY` instruction comes after the last whitespace, which would cause the target path to be empty in this case. That would crash the following operations on that target path.
Instead, now the rule evaluates to true.

### How to verify it
See bugreport #448.

### Discussion
This fix is pretty crude and only prevents crashing. I am not sure if the behaviour now is satisfactory, since a trailing whitespace would trigger `DL3021`, causing a confusing message. This could be resolved by linting against trailing whitespaces in general, since that would clarify the output.

Example Dockerfile:
```Dockerfile
FROM scratch
COPY a b/ 
```
Actual Output:
`Dockerfile:2 DL3021 COPY with more than 2 arguments requires the last argument to end with /`