### PR TITLE
Run the linter in parallel when multiple files supplied

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -28,6 +28,8 @@ dependencies:
   - language-docker >=9.1.2 && < 10
 library:
   source-dirs: src
+  generated-other-modules:
+    - Paths_hadolint
   dependencies:
     - &bytestring bytestring >=0.10
     - &split split >=0.2
@@ -41,6 +43,7 @@ library:
     - HsYAML
     - filepath
     - directory >= 1.3.0
+    - async
 executables:
   hadolint:
     main: Main.hs
@@ -51,6 +54,11 @@ executables:
       - gitrev >=1.3.1
       - text
       - containers
+    ghc-options:
+      - -O2
+      - -threaded
+      - -rtsopts
+      - -with-rtsopts=-N
     when:
       # OS X does not support static build https://developer.apple.com/library/content/qa/qa1118
       - condition: "flag(static) && !(os(osx))"

--- a/package.yaml
+++ b/package.yaml
@@ -44,6 +44,7 @@ library:
     - filepath
     - directory >= 1.3.0
     - async
+    - parallel
 executables:
   hadolint:
     main: Main.hs
@@ -54,11 +55,7 @@ executables:
       - gitrev >=1.3.1
       - text
       - containers
-    ghc-options:
-      - -O2
-      - -threaded
-      - -rtsopts
-      - -with-rtsopts=-N
+    ghc-options: -O2 -threaded -rtsopts "-with-rtsopts=-N5 -A4m"
     when:
       # OS X does not support static build https://developer.apple.com/library/content/qa/qa1118
       - condition: "flag(static) && !(os(osx))"

--- a/src/Hadolint/Formatter/Format.hs
+++ b/src/Hadolint/Formatter/Format.hs
@@ -24,8 +24,8 @@ import Text.Megaparsec.Error
 import Text.Megaparsec.Pos (SourcePos, sourcePosPretty)
 
 data Result s e = Result
-  { errors :: Seq (ParseErrorBundle s e),
-    checks :: Seq RuleCheck
+  { errors :: !(Seq (ParseErrorBundle s e)),
+    checks :: !(Seq RuleCheck)
   }
 
 instance Semigroup (Result s e) where

--- a/src/Hadolint/Lint.hs
+++ b/src/Hadolint/Lint.hs
@@ -59,15 +59,13 @@ lint :: LintOptions -> NonEmpty.NonEmpty String -> IO (Format.Result Text Docker
 lint LintOptions {ignoreRules = ignoreList, rulesConfig} dFiles = do
   parsedFiles <- Async.mapConcurrently parseFile (NonEmpty.toList dFiles)
   let results = lintAll parsedFiles `using` parListChunk (div numCapabilities 2) rseq
-  return $ buildResults results
+  return $ mconcat results
   where
     parseFile :: String -> IO (Either Error Dockerfile)
     parseFile "-" = Docker.parseStdin
     parseFile s = Docker.parseFile s
 
     lintAll = fmap (lintDockerfile ignoreList)
-
-    buildResults = foldr (<>) mempty
 
     lintDockerfile ignoreRules ast = processedFile ast
       where

--- a/src/Hadolint/Rules.hs
+++ b/src/Hadolint/Rules.hs
@@ -23,7 +23,7 @@ data Metadata = Metadata
     severity :: Severity,
     message :: Text.Text
   }
-  deriving (Eq)
+  deriving (Eq, Show)
 
 -- a check is the application of a rule on a specific part of code
 -- the enforced result and the affected position
@@ -36,7 +36,7 @@ data RuleCheck = RuleCheck
     linenumber :: Linenumber,
     success :: Bool
   }
-  deriving (Eq)
+  deriving (Eq, Show)
 
 -- | Contains the required parameters for optional rules
 newtype RulesConfig = RulesConfig


### PR DESCRIPTION
### What I did

A use case surfaced by #475 is that some people lint lots of files, and try to make things faster by running them in parallel using bash.

Running things in parallel in Haskell is trivial, so I went ahead and added this feature. After some superficial testing, found out that the best performance is reached at maximum 4 CPUs at a time. That's why I capped the `-N` to 4.

Whoever wants to experiment with more CPUs may invoke `hadolint` like this:

```
hadolint +RTS -N[num] -RTS Dockerfile1 Dockerfile2 Dockerfile3...
```