### PR TITLE
Fixed requirements usage in pip install

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@ Please [create an issue][] if you have an idea for a good rule.
 | [DL3039](https://github.com/hadolint/hadolint/wiki/DL3039)   | Do not use `dnf update`                                                                                                                             |
 | [DL3040](https://github.com/hadolint/hadolint/wiki/DL3040)   | `dnf clean all` missing after dnf command.                                                                                                          |
 | [DL3041](https://github.com/hadolint/hadolint/wiki/DL3041)   | Specify version with `dnf install -y <package>-<version>`                                                                                           |
+| [DL3042](https://github.com/hadolint/hadolint/wiki/DL3038) | Avoid cache directory with `pip install --no-cache-dir <package>`.                                                                                  |
 | [DL4000](https://github.com/hadolint/hadolint/wiki/DL4000)   | MAINTAINER is deprecated.                                                                                                                           |
 | [DL4001](https://github.com/hadolint/hadolint/wiki/DL4001)   | Either use Wget or Curl but not both.                                                                                                               |
 | [DL4003](https://github.com/hadolint/hadolint/wiki/DL4003)   | Multiple `CMD` instructions found.                                                                                                                  |

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -633,6 +633,28 @@ main =
         onBuildRuleCatchesNot
           pipVersionPinned
           "RUN pip install --index-url https://user:pass@eg.com/foo --extra-index-url https://user:pass@ex-eg.io/foo foobar==1.0.0"
+
+    --
+    describe "pip cache dir" $ do
+      it "pip2 --no-cache-dir not used" $ do
+        ruleCatches pipNoCacheDir           "RUN pip2 install MySQL_python"
+        onBuildRuleCatches pipNoCacheDir    "RUN pip2 install MySQL_python"
+      it "pip3 --no-cache-dir not used" $ do
+        ruleCatches pipNoCacheDir           "RUN pip3 install MySQL_python"
+        onBuildRuleCatches pipNoCacheDir    "RUN pip3 install MySQL_python"
+      it "pip --no-cache-dir not used" $ do
+        ruleCatches pipNoCacheDir           "RUN pip install MySQL_python"
+        onBuildRuleCatches pipNoCacheDir    "RUN pip install MySQL_python"
+      it "pip2 --no-cache-dir used" $ do
+        ruleCatchesNot pipNoCacheDir        "RUN pip2 install MySQL_python --no-cache-dir"
+        onBuildRuleCatchesNot pipNoCacheDir "RUN pip2 install MySQL_python --no-cache-dir"
+      it "pip3 --no-cache-dir used" $ do
+        ruleCatchesNot pipNoCacheDir        "RUN pip3 install --no-cache-dir MySQL_python"
+        onBuildRuleCatchesNot pipNoCacheDir "RUN pip3 install --no-cache-dir MySQL_python"
+      it "pip --no-cache-dir used" $ do
+        ruleCatchesNot pipNoCacheDir        "RUN pip install MySQL_python --no-cache-dir"
+        onBuildRuleCatchesNot pipNoCacheDir "RUN pip install MySQL_python --no-cache-dir"
+
     --
     describe "npm pinning" $ do
       it "version pinned in package.json" $ do


### PR DESCRIPTION
Resolves #467

### What I did

Updated the rule for pip install when dealing with requirements files.

### How I did it

Moved the `requirementsInstall` function out of the `isPipInstall` function into the higher level `forgotToPinVersion`

### How to verify it

Use the Dockerfile provided in the related issue.

There appears to be existing tests for this case that were passing when they should not have. Any suggestions for correcting this?