### PR TITLE
Yum lint - Add negative tests

### DIFF
--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -190,19 +190,35 @@ main =
             onBuildRuleCatchesNot gemVersionPinned "RUN gem install bundler:2.0.1 -- --use-system-libraries=true"
     --
     describe "yum rules" $ do
-      it "yum update" $ do
-        ruleCatches noYumUpdate "RUN yum update"
-        onBuildRuleCatches noYumUpdate "RUN yum update"
-      it "yum version pinning" $ do
-        ruleCatches yumVersionPinned "RUN yum install -y tomcat && yum clean all"
-        onBuildRuleCatches yumVersionPinned "RUN yum install -y tomcat && yum clean all"
-      it "yum no clean all" $ do
-        ruleCatches yumCleanup "RUN yum install -y mariadb-10.4"
-        onBuildRuleCatches yumCleanup "RUN yum install -y mariadb-10.4"
-      it "yum non-interactive" $ do
-        ruleCatches yumYes "RUN yum install httpd-2.4.24 && yum clean all"
-        onBuildRuleCatches yumYes "RUN yum install httpd-2.4.24 && yum clean all"
-        --
+        it "yum update" $ do
+            ruleCatches noYumUpdate "RUN yum update"
+            ruleCatchesNot noYumUpdate "RUN yum install -y httpd-2.4.42 && yum clean all"
+            ruleCatchesNot noYumUpdate "RUN bash -c `# not even a yum command`"
+            onBuildRuleCatches noYumUpdate "RUN yum update"
+            onBuildRuleCatchesNot noYumUpdate "RUN yum install -y httpd-2.4.42 && yum clean all"
+            onBuildRuleCatchesNot noYumUpdate "RUN bash -c `# not even a yum command`"
+        it "yum version pinning" $ do
+            ruleCatches yumVersionPinned "RUN yum install -y tomcat && yum clean all"
+            ruleCatchesNot yumVersionPinned "RUN yum install -y tomcat-9.2 && yum clean all"
+            ruleCatchesNot yumVersionPinned "RUN bash -c `# not even a yum command`"
+            onBuildRuleCatches yumVersionPinned "RUN yum install -y tomcat && yum clean all"
+            onBuildRuleCatchesNot yumVersionPinned "RUN yum install -y tomcat-9.2 && yum clean all"
+            onBuildRuleCatchesNot yumVersionPinned "RUN bash -c `# not even a yum command`"
+        it "yum no clean all" $ do
+            ruleCatches yumCleanup "RUN yum install -y mariadb-10.4"
+            ruleCatchesNot yumCleanup "RUN yum install -y mariadb-10.4 && yum clean all"
+            ruleCatchesNot yumCleanup "RUN bash -c `# not even a yum command`"
+            onBuildRuleCatches yumCleanup "RUN yum install -y mariadb-10.4"
+            onBuildRuleCatchesNot yumCleanup "RUN yum install -y mariadb-10.4 && yum clean all"
+            onBuildRuleCatchesNot yumCleanup "RUN bash -c `# not even a yum command`"
+        it "yum non-interactive" $ do
+            ruleCatches yumYes "RUN yum install httpd-2.4.24 && yum clean all"
+            ruleCatchesNot yumYes "RUN yum install -y httpd-2.4.24 && yum clean all"
+            ruleCatchesNot yumYes "RUN bash -c `# not even a yum command`"
+            onBuildRuleCatches yumYes "RUN yum install httpd-2.4.24 && yum clean all"
+            onBuildRuleCatchesNot yumYes "RUN yum install -y httpd-2.4.24 && yum clean all"
+            onBuildRuleCatchesNot yumYes "RUN bash -c `# not even a yum command`"
+    --
     describe "zypper rules" $ do
         it "zupper update" $ do
             ruleCatches noZypperUpdate "RUN zypper update"
@@ -326,7 +342,6 @@ main =
          in do
               ruleCatchesNot aptGetCleanup $ Text.unlines dockerFile
               onBuildRuleCatchesNot aptGetCleanup $ Text.unlines dockerFile
-
       it "apt-get pinned chained" $
         let dockerFile =
               [ "RUN apt-get update \\",


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

### What I did

Add tests making sure `yum` lint rules are not overzealous.

### How I did it

- Test against correct use of `yum` in each case
- Test against no use of `yum` at all in each case

Both times the rule should not trigger.

### How to verify it

Run `stack test`. All tests should pass.
