### PR TITLE
formatter: support for megaparsec >=9.0.0 #488

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -24,7 +24,7 @@ ghc-options:
   - -optP-Wno-nonportable-include-path
 dependencies:
   - base >=4.8 && <5
-  - megaparsec >=7.0
+  - megaparsec >= 9.0.0
   - language-docker >=9.1.2 && < 10
 library:
   source-dirs: src

--- a/src/Hadolint/Formatter/Checkstyle.hs
+++ b/src/Hadolint/Formatter/Checkstyle.hs
@@ -17,9 +17,10 @@ import qualified Data.Text as Text
 import Hadolint.Formatter.Format
 import Hadolint.Rules (Metadata (..), RuleCheck (..))
 import ShellCheck.Interface
-import Text.Megaparsec (Stream)
+import Text.Megaparsec (TraversableStream)
 import Text.Megaparsec.Error
 import Text.Megaparsec.Pos (sourceColumn, sourceLine, sourceName, unPos)
+import Text.Megaparsec.Stream (VisualStream)
 
 data CheckStyle = CheckStyle
   { file :: String,
@@ -30,7 +31,7 @@ data CheckStyle = CheckStyle
     source :: String
   }
 
-errorToCheckStyle :: (Stream s, ShowErrorComponent e) => ParseErrorBundle s e -> CheckStyle
+errorToCheckStyle :: (VisualStream s, TraversableStream s, ShowErrorComponent e) => ParseErrorBundle s e -> CheckStyle
 errorToCheckStyle err =
   CheckStyle
     { file = sourceName pos,
@@ -83,7 +84,7 @@ escape = concatMap doEscape
         else "&#" ++ show (ord c) ++ ";"
     isOk x = any (\check -> check x) [isAsciiUpper, isAsciiLower, isDigit, (`elem` [' ', '.', '/'])]
 
-formatResult :: (Stream s, ShowErrorComponent e) => Result s e -> Builder.Builder
+formatResult :: (VisualStream s, TraversableStream s, ShowErrorComponent e) => Result s e -> Builder.Builder
 formatResult (Result errors checks) =
   "<?xml version='1.0' encoding='UTF-8'?><checkstyle version='4.3'>" <> xmlBody <> "</checkstyle>"
   where
@@ -94,5 +95,5 @@ formatResult (Result errors checks) =
     checkstyleChecks = fmap ruleToCheckStyle checks
     sameFileName CheckStyle {file = f1} CheckStyle {file = f2} = f1 == f2
 
-printResult :: (Stream s, ShowErrorComponent e) => Result s e -> IO ()
+printResult :: (VisualStream s, TraversableStream s, ShowErrorComponent e) => Result s e -> IO ()
 printResult result = B.putStr (Builder.toLazyByteString (formatResult result))

--- a/src/Hadolint/Formatter/Codacy.hs
+++ b/src/Hadolint/Formatter/Codacy.hs
@@ -14,9 +14,10 @@ import Data.Sequence (Seq)
 import qualified Data.Text as Text
 import Hadolint.Formatter.Format (Result (..), errorPosition)
 import Hadolint.Rules (Metadata (..), RuleCheck (..))
-import Text.Megaparsec (Stream)
+import Text.Megaparsec (TraversableStream)
 import Text.Megaparsec.Error
 import Text.Megaparsec.Pos (sourceLine, sourceName, unPos)
+import Text.Megaparsec.Stream (VisualStream)
 
 data Issue = Issue
   { filename :: String,
@@ -29,7 +30,7 @@ instance ToJSON Issue where
   toJSON Issue {..} =
     object ["filename" .= filename, "patternId" .= patternId, "message" .= msg, "line" .= line]
 
-errorToIssue :: (Stream s, ShowErrorComponent e) => ParseErrorBundle s e -> Issue
+errorToIssue :: (VisualStream s, TraversableStream s, ShowErrorComponent e) => ParseErrorBundle s e -> Issue
 errorToIssue err =
   Issue
     { filename = sourceName pos,
@@ -50,14 +51,14 @@ checkToIssue RuleCheck {..} =
       line = linenumber
     }
 
-formatResult :: (Stream s, ShowErrorComponent e) => Result s e -> Seq Issue
+formatResult :: (VisualStream s, TraversableStream s, ShowErrorComponent e) => Result s e -> Seq Issue
 formatResult (Result errors checks) = allIssues
   where
     allIssues = errorMessages <> checkMessages
     errorMessages = fmap errorToIssue errors
     checkMessages = fmap checkToIssue checks
 
-printResult :: (Stream s, ShowErrorComponent e) => Result s e -> IO ()
+printResult :: (VisualStream s, TraversableStream s, ShowErrorComponent e) => Result s e -> IO ()
 printResult result = mapM_ output (formatResult result)
   where
     output value = B.putStrLn (encode value)

--- a/src/Hadolint/Formatter/Codeclimate.hs
+++ b/src/Hadolint/Formatter/Codeclimate.hs
@@ -17,9 +17,10 @@ import GHC.Generics
 import Hadolint.Formatter.Format (Result (..), errorPosition)
 import Hadolint.Rules (Metadata (..), RuleCheck (..))
 import ShellCheck.Interface
-import Text.Megaparsec (Stream)
+import Text.Megaparsec (TraversableStream)
 import Text.Megaparsec.Error
 import Text.Megaparsec.Pos (sourceColumn, sourceLine, sourceName, unPos)
+import Text.Megaparsec.Stream (VisualStream)
 
 data Issue = Issue
   { checkName :: String,
@@ -60,7 +61,7 @@ instance ToJSON Issue where
         "severity" .= impact
       ]
 
-errorToIssue :: (Stream s, ShowErrorComponent e) => ParseErrorBundle s e -> Issue
+errorToIssue :: (VisualStream s, TraversableStream s, ShowErrorComponent e) => ParseErrorBundle s e -> Issue
 errorToIssue err =
   Issue
     { checkName = "DL1000",
@@ -90,14 +91,14 @@ severityText severity =
     InfoC -> "info"
     StyleC -> "minor"
 
-formatResult :: (Stream s, ShowErrorComponent e) => Result s e -> Seq Issue
+formatResult :: (VisualStream s, TraversableStream s, ShowErrorComponent e) => Result s e -> Seq Issue
 formatResult (Result errors checks) = allIssues
   where
     allIssues = errorMessages <> checkMessages
     errorMessages = fmap errorToIssue errors
     checkMessages = fmap checkToIssue checks
 
-printResult :: (Stream s, ShowErrorComponent e) => Result s e -> IO ()
+printResult :: (VisualStream s, TraversableStream s, ShowErrorComponent e) => Result s e -> IO ()
 printResult result = mapM_ output (formatResult result)
   where
     output value = do

--- a/src/Hadolint/Formatter/Format.hs
+++ b/src/Hadolint/Formatter/Format.hs
@@ -19,9 +19,10 @@ import Data.Sequence (Seq)
 import qualified Data.Sequence as Seq
 import Hadolint.Rules
 import ShellCheck.Interface
-import Text.Megaparsec (Stream (..), pstateSourcePos)
+import Text.Megaparsec (TraversableStream (..), pstateSourcePos)
 import Text.Megaparsec.Error
 import Text.Megaparsec.Pos (SourcePos, sourcePosPretty)
+import Text.Megaparsec.Stream (VisualStream)
 
 data Result s e = Result
   { errors :: !(Seq (ParseErrorBundle s e)),
@@ -62,14 +63,14 @@ stripNewlines =
           else c
     )
 
-errorMessageLine :: (Stream s, ShowErrorComponent e) => ParseErrorBundle s e -> String
+errorMessageLine :: (VisualStream s, TraversableStream s, ShowErrorComponent e) => ParseErrorBundle s e -> String
 errorMessageLine err@(ParseErrorBundle e _) =
   errorPositionPretty err ++ " " ++ parseErrorTextPretty (NE.head e)
 
-errorPositionPretty :: Stream s => ParseErrorBundle s e -> String
+errorPositionPretty :: TraversableStream s => ParseErrorBundle s e -> String
 errorPositionPretty err = sourcePosPretty (errorPosition err)
 
-errorPosition :: Stream s => ParseErrorBundle s e -> Text.Megaparsec.Pos.SourcePos
+errorPosition :: TraversableStream s => ParseErrorBundle s e -> Text.Megaparsec.Pos.SourcePos
 errorPosition (ParseErrorBundle e s) =
   let (_, posState) = reachOffset (errorOffset (NE.head e)) s
    in pstateSourcePos posState

--- a/src/Hadolint/Formatter/TTY.hs
+++ b/src/Hadolint/Formatter/TTY.hs
@@ -13,13 +13,14 @@ import qualified Data.Text as Text
 import Hadolint.Formatter.Format
 import Hadolint.Rules
 import Language.Docker.Syntax
-import Text.Megaparsec (Stream (..))
+import Text.Megaparsec (TraversableStream)
 import Text.Megaparsec.Error
+import Text.Megaparsec.Stream (VisualStream)
 
-formatErrors :: (Stream s, ShowErrorComponent e, Functor f) => f (ParseErrorBundle s e) -> f String
+formatErrors :: (VisualStream s, TraversableStream s, ShowErrorComponent e, Functor f) => f (ParseErrorBundle s e) -> f String
 formatErrors = fmap formatError
 
-formatError :: (Stream s, ShowErrorComponent e) => ParseErrorBundle s e -> String
+formatError :: (VisualStream s, TraversableStream s, ShowErrorComponent e) => ParseErrorBundle s e -> String
 formatError err = stripNewlines (errorMessageLine err)
 
 formatChecks :: Functor f => f RuleCheck -> f Text.Text
@@ -31,7 +32,7 @@ formatChecks = fmap formatCheck
 formatPos :: Filename -> Linenumber -> Text.Text
 formatPos source line = source <> ":" <> Text.pack (show line) <> " "
 
-printResult :: (Stream s, ShowErrorComponent e) => Result s e -> IO ()
+printResult :: (VisualStream s, TraversableStream s, ShowErrorComponent e) => Result s e -> IO ()
 printResult Result {errors, checks} = printErrors >> printChecks
   where
     printErrors = mapM_ putStrLn (formatErrors errors)

--- a/stack.yaml
+++ b/stack.yaml
@@ -4,6 +4,7 @@ packages:
   - .
 resolver: lts-16.18
 extra-deps:
+  - megaparsec-9.0.0@sha256:920d1e469056c746b532333a078c2a9a195fab5e860e0c9734ee92a28c2bfb65,3117
   - ShellCheck-0.7.1@sha256:94a6ee5a38e2668204bc95fdc7539a9a4ca7230984157694409444530c23b5a4,3170
   - language-docker-9.1.2
 ghc-options:


### PR DESCRIPTION
- Megaparsec has changed the `Stream` Typeclass.
- Reflect the upstream changes during usage of Megaparsec.

<!--
If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

### What I did

Fix build errors with Megaparsec >= 9.0.0
Fixes: #488 
Note: This breaks compatibility with Megaparsec < 9.0.0

### How I did it

Reflect the upstream changes in the `Stream` typeclass in the formatter code.
Here is the upstream commit that changed the interface: https://github.com/mrkkrp/megaparsec/commit/f8ef95c025f00dc3ea6bb2c78c71e89dc749f413

### How to verify it

The following should work:
```
$ stack --resolver nightly-2020-11-11 build hadolint
$ stack --resolver nightly-2020-11-11 test
```