### PR TITLE
bugfix: false positive whith quoted `WORKDIR` #261

### DIFF
--- a/src/Hadolint/Rules.hs
+++ b/src/Hadolint/Rules.hs
@@ -292,10 +292,14 @@ absoluteWorkdir = instructionRule code severity message check
     severity = ErrorC
     message = "Use absolute WORKDIR"
     check (Workdir loc)
-      | "$" `Text.isPrefixOf` loc = True
-      | "/" `Text.isPrefixOf` loc = True
+      | "$" `Text.isPrefixOf` Text.dropAround dropQuotes loc = True
+      | "/" `Text.isPrefixOf` Text.dropAround dropQuotes loc = True
       | otherwise = False
     check _ = True
+    dropQuotes chr
+      | chr == '\"' = True
+      | chr == '\'' = True
+      | otherwise = False
 
 hasNoMaintainer :: Rule
 hasNoMaintainer = instructionRule code severity message check

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -1006,9 +1006,18 @@ main =
                 "ENTRYPOINT another"
               ]
          in ruleCatches multipleEntrypoints $ Text.unlines dockerFile
+
       it "single entry" $ ruleCatchesNot multipleEntrypoints "ENTRYPOINT /bin/true"
       it "no entry" $ ruleCatchesNot multipleEntrypoints "FROM busybox"
+      it "workdir relative" $ ruleCatches absoluteWorkdir "WORKDIR relative/dir"
+      it "workdir absolute" $ ruleCatchesNot absoluteWorkdir "WORKDIR /usr/local"
       it "workdir variable" $ ruleCatchesNot absoluteWorkdir "WORKDIR ${work}"
+      it "workdir relative single quotes" $ ruleCatches absoluteWorkdir "WORKDIR \'relative/dir\'"
+      it "workdir absolute single quotes" $ ruleCatchesNot absoluteWorkdir "WORKDIR \'/usr/local\'"
+      -- no test for variable/single quotes since the variable would not expand.
+      it "workdir relative double quotes" $ ruleCatches absoluteWorkdir "WORKDIR \"relative/dir\""
+      it "workdir absolute double quotes" $ ruleCatchesNot absoluteWorkdir "WORKDIR \"/usr/local\""
+      it "workdir variable double quotes" $ ruleCatchesNot absoluteWorkdir "WORKDIR \"${dir}\""
       it "scratch" $ ruleCatchesNot noUntagged "FROM scratch"
     --
     describe "add files and archives" $ do


### PR DESCRIPTION
Fixes #261 

### What I did

- Strip quotes from argument of `WORKDIR`
- Test correct behaviour with single and double quotes

### How to verify it
The following Dockerfile no longer triggers DL3000:
```Dockerfile
FROM debian:buster
ENV myworkdir "/var/lib"
WORKDIR /tmp
WORKDIR "/usr/src"
WORKDIR '/usr/local'
WORKDIR "${myworkdir}"
```

The following Dockerfile does still trigger DL3000 on all occasions:
```Dockerfile
FROM debian:buster
WORKDIR var/lib
WORKDIR "var/lib"
WORKDIR 'var/lib'
```

This is also reflected in unit tests.