### PR TITLE
feature: `pip install` from local archive no longer emits DL3013 #485

### DIFF
--- a/src/Hadolint/Rules.hs
+++ b/src/Hadolint/Rules.hs
@@ -643,10 +643,12 @@ pipVersionPinned = instructionRule code severity message check
               "upgrade-strategy"
             ]
             cmd
-    versionFixed package = hasVersionSymbol package || isVersionedGit package
+    versionFixed package = hasVersionSymbol package || isVersionedGit package || isLocalPackage package
     isVersionedGit package = "git+http" `Text.isInfixOf` package && "@" `Text.isInfixOf` package
     versionSymbols = ["==", ">=", "<=", ">", "<", "!=", "~=", "==="]
     hasVersionSymbol package = or [s `Text.isInfixOf` package | s <- versionSymbols]
+    localPackageFileExtensions = [".whl", ".tar.gz"]
+    isLocalPackage package = or [s `Text.isSuffixOf` package | s <- localPackageFileExtensions]
 
 stripInstallPrefix :: [Text.Text] -> [Text.Text]
 stripInstallPrefix cmd = dropWhile (== "install") (dropWhile (/= "install") cmd)

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -518,6 +518,11 @@ main =
       it "pip3 version pinned" $ do
         ruleCatchesNot pipVersionPinned "RUN pip3 install MySQL_python==1.2.2"
         onBuildRuleCatchesNot pipVersionPinned "RUN pip3 install MySQL_python==1.2.2"
+      it "pip3 install from local package" $ do
+        ruleCatchesNot pipVersionPinned "RUN pip3 install mypkg.whl"
+        ruleCatchesNot pipVersionPinned "RUN pip3 install mypkg.tar.gz"
+        onBuildRuleCatchesNot pipVersionPinned "RUN pip3 install mypkg.whl"
+        onBuildRuleCatchesNot pipVersionPinned "RUN pip3 install mypkg.tar.gz"
       it "pip install requirements" $ do
         ruleCatchesNot pipVersionPinned "RUN pip install -r requirements.txt"
         onBuildRuleCatchesNot pipVersionPinned "RUN pip install -r requirements.txt"


### PR DESCRIPTION
Fixes #485

### What I did
- Exclude local archives from emitting DL3013.
- Test that local archives no longer emit DL3013

Emitting DL3013 for local packages is pointless, since the developer of the dockerfile controls what that local package is anyways and therefore also controls the version of the software within.

### How to verify it
This Dockerfile no longer triggers DL3013:
```Dockerfile
RUN pip install mypkg.whl
RUN pip install mypkg.tar.gz
```

This Dockerfile still triggers DL3013:
```Dockerfile
RUN pip install numpy
```

PR also comes with unit tests.