### PR TITLE
format: add rule severity to tty output #495

### DIFF
--- a/src/Hadolint/Formatter/TTY.hs
+++ b/src/Hadolint/Formatter/TTY.hs
@@ -27,7 +27,7 @@ formatChecks :: Functor f => f RuleCheck -> f Text.Text
 formatChecks = fmap formatCheck
   where
     formatCheck (RuleCheck meta source line _) =
-      formatPos source line <> code meta <> " " <> message meta
+      formatPos source line <> code meta <> " " <> Text.pack (severityText (severity meta)) <> ": " <> message meta
 
 formatPos :: Filename -> Linenumber -> Text.Text
 formatPos source line = source <> ":" <> Text.pack (show line) <> " "


### PR DESCRIPTION
- Add rule severity to tty output
- Fixes #495

### What I did

Make tty output show severity of rules. Pretty small one-line change.

### How to verify it
Take this Dockerfile:
```Dockerfile
FROM debian
RUN export node_version="0.10" \
&& apt-get update && apt-get -y install nodejs="$node_verion"
COPY package.json usr/src/app
RUN cd /usr/src/app \
&& npm install node-static
EXPOSE 80000
CMD ["npm", "start"]
```

It will produce this output:
```Shell
$ hadolint Dockerfile
Dockerfile:1 warning: DL3006 Always tag the version of an image explicitly
Dockerfile:2 warning: SC2154 node_verion is referenced but not assigned (did you mean 'node_version'?).
Dockerfile:2 info: DL3009 Delete the apt-get lists after installing something
Dockerfile:2 info: DL3015 Avoid additional packages by specifying `--no-install-recommends`
Dockerfile:5 warning: DL3003 Use WORKDIR to switch to a directory
Dockerfile:5 warning: DL3016 Pin versions in npm. Instead of `npm install <package>` use `npm install <package>@<version>`
Dockerfile:7 error: DL3011 Valid UNIX ports range from 0 to 65535
```