### PR TITLE
Add workflow to deploy the container images to ghcr.io

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -17,7 +17,8 @@ REMOVE SENSITIVE DATA BEFORE POSTING (replace those parts with "REDACTED")
 -->
 
 **Output of `hadolint --version` or
-  `docker run --rm hadolint/hadolint hadolint --version`:**
+  `docker run --rm hadolint/hadolint hadolint --version` or
+  `docker run --rm ghcr.io/hadolint/hadolint hadolint --version`:**
 
 ```bash
 (paste your output here)

--- a/.github/workflows/ghcr.io.yml
+++ b/.github/workflows/ghcr.io.yml
@@ -1,0 +1,38 @@
+# Runs on pull requests against master
+
+name: Release
+
+on:
+  # Trigger the workflow on the new 'v*' tag created
+  push:
+    tags:
+      - "v*"
+
+defaults:
+  run:
+    working-directory: docker
+
+env:
+  IMAGE_NAME: hadolint
+  DOCKER_REPO: ghcr.io/${{ github.repository }}
+
+jobs:
+  deploy_container_image:
+    name: Release container image to ghcr.io
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out
+        uses: actions/checkout@v2
+
+      - name: Build
+        run: "bash hooks/build"
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GHCR_IO_REGISTRY_TOKEN }}
+
+      - name: Push
+        run: "bash hooks/push"

--- a/README.md
+++ b/README.md
@@ -31,7 +31,9 @@ platforms.
 Just pipe your `Dockerfile` to `docker run`:
 
 ```bash
-docker run --rm -i hadolint/hadolint < Dockerfile
+$ docker run --rm -i hadolint/hadolint < Dockerfile
+# or
+$ docker run --rm -i ghcr.io/hadolint/hadolint < Dockerfile
 ```
 
 ## Install
@@ -55,15 +57,20 @@ scoop install hadolint
 As shown before, `hadolint` is available as a Docker container:
 
 ```bash
-docker pull hadolint/hadolint
+$ docker pull hadolint/hadolint
+# or
+$ docker pull ghcr.io/hadolint/hadolint
 ```
 
 If you need a Docker container with shell access, use the Debian or Alpine
 variants of the Docker image:
 
 ```bash
-docker pull hadolint/hadolint:latest-debian
-docker pull hadolint/hadolint:latest-alpine
+$ docker pull hadolint/hadolint:latest-debian
+$ docker pull hadolint/hadolint:latest-alpine
+# or
+$ docker pull ghcr.io/hadolint/hadolint:latest-debian
+$ docker pull ghcr.io/hadolint/hadolint:latest-alpine
 ```
 
 You can also build `hadolint` locally. You need [Haskell][] and the [stack][]
@@ -124,7 +131,9 @@ To pass a custom configuration file (using relative or absolute path) to a conta
 use the following command:
 
 ```bash
-docker run --rm -i -v ./your/path/to/hadolint.yaml:/root/.config/hadolint.yaml hadolint/hadolint < Dockerfile
+$ docker run --rm -i -v ./your/path/to/hadolint.yaml:/root/.config/hadolint.yaml hadolint/hadolint < Dockerfile
+# or
+$ docker run --rm -i -v ./your/path/to/hadolint.yaml:/root/.config/hadolint.yaml ghcr.io/hadolint/hadolint < Dockerfile
 ```
 
 ## Inline ignores

--- a/docker/README.md
+++ b/docker/README.md
@@ -27,39 +27,55 @@ Default images include only `hadolint` static binary. All supported tags also ha
 - `hadolint/hadolint:EXTENDED_VERSION-alpine` refers to the same version as `hadolint --version` with short git sha, eg. `v1.9.0-0-g4c4881a-alpine`
 
 Check out [Docker Hub](https://hub.docker.com/r/hadolint/hadolint/tags/) for available tags.
+If you prefer to pull the container image from the GitHub container registry check out [hadolint organization packages](https://github.com/orgs/hadolint/packages/container/package/hadolint) for available tags.
 
 ## Usage
 
 To use this image, pull from Docker Hub, run the following command:
 
 ```bash
-docker pull hadolint/hadolint
+$ docker pull hadolint/hadolint
+# or
+$ docker pull ghcr.io/hadolint/hadolint
 ```
 
 Verify the install
 
 ```bash
-docker run --rm hadolint/hadolint hadolint --version
+$ docker run --rm hadolint/hadolint hadolint --version
+Haskell Dockerfile Linter v1.9.0-0-g4c4881a
+# or
+$ docker run --rm ghcr.io/hadolint/hadolint hadolint --version
 Haskell Dockerfile Linter v1.9.0-0-g4c4881a
 ```
 
 or use a particular version number:
 
 ```bash
-docker run --rm hadolint/hadolint:v1.9.0 hadolint --version
+$ docker run --rm hadolint/hadolint:v1.9.0 hadolint --version
+Haskell Dockerfile Linter v1.9.0-0-g4c4881a
+# or
+$ docker run --rm ghcr.io/hadolint/hadolint:v1.9.0 hadolint --version
 Haskell Dockerfile Linter v1.9.0-0-g4c4881a
 ```
 
 Lint your `Dockerfile`:
 
 ```bash
-docker run --rm -i hadolint/hadolint < Dockerfile
+$ docker run --rm -i hadolint/hadolint < Dockerfile
+# or
+$ docker run --rm -i ghcr.io/hadolint/hadolint < Dockerfile
 ```
 
 To exclude specific rules:
 
 ```bash
-docker run --rm -i hadolint/hadolint hadolint \
+$ docker run --rm -i hadolint/hadolint hadolint \
+  --ignore DL3003 \
+  --ignore DL3006 \
+  - < Dockerfile
+# or
+$ docker run --rm -i ghcr.io/hadolint/hadolint hadolint \
   --ignore DL3003 \
   --ignore DL3006 \
   - < Dockerfile

--- a/docs/INTEGRATION.md
+++ b/docs/INTEGRATION.md
@@ -15,6 +15,7 @@ with the repository attached to it:
 ```yaml
 hadolint:
   image: hadolint/hadolint:latest-debian
+  # image: ghcr.io/hadolint/hadolint:latest-debian
   volumes:
     - ./:/test
 ```
@@ -93,6 +94,7 @@ Add the following job to your project's `.gitlab-ci.yml`:
 ```yaml
 lint_dockerfile:
   image: hadolint/hadolint:latest-debian
+  # image: ghcr.io/hadolint/hadolint:latest-debian
   script:
     - hadolint Dockerfile
 ```
@@ -107,6 +109,7 @@ Add the following job to your project's `.drone.yml` pipeline (drone version 0.8
   hadolint:
     group: validate
     image: hadolint/hadolint:latest-debian
+    # image: ghcr.io/hadolint/hadolint:latest-debian
     commands:
       - hadolint --version
       - hadolint Dockerfile
@@ -117,6 +120,7 @@ Add the following job to your project's `.drone.yml` pipeline (drone version 1.0
 ```yaml
   - name: hadolint
     image: hadolint/hadolint:latest-debian
+    # image: ghcr.io/hadolint/hadolint:latest-debian
     commands:
       - hadolint --version
       - hadolint  Dockerfile
@@ -150,6 +154,7 @@ stage ("lint dockerfile") {
     agent {
         docker {
             image 'hadolint/hadolint:latest-debian'
+            //image 'ghcr.io/hadolint/hadolint:latest-debian'
         }
     }
     steps {
@@ -170,6 +175,7 @@ You can add an hadolint container to pod definition:
 ```yaml
 - name: hadolint
   image: hadolint/hadolint:latest-debian
+  # image: ghcr.io/hadolint/hadolint:latest-debian
   imagePullPolicy: Always
   command:
     - cat
@@ -202,6 +208,7 @@ pipelines:
   default:
     - step:
         image: hadolint/hadolint:latest-debian
+        # image: ghcr.io/hadolint/hadolint:latest-debian
         script:
           - hadolint Dockerfile
 ```
@@ -267,6 +274,14 @@ to
 
 ```sh
 if docker run --rm -i hadolint/hadolint < "%d/%f"
+| sed -re 's|^/dev/stdin:([0-9]*)|%d/%f:\1:WARNING:|'
+| grep -EC100 ':WARNING:' ; then exit 1 ; else exit 0 ; fi
+```
+
+or
+
+```sh
+if docker run --rm -i ghcr.io/hadolint/hadolint < "%d/%f"
 | sed -re 's|^/dev/stdin:([0-9]*)|%d/%f:\1:WARNING:|'
 | grep -EC100 ':WARNING:' ; then exit 1 ; else exit 0 ; fi
 ```


### PR DESCRIPTION
closes #503 

### What I did

I've created another workflow to build and deploy the container image to the GitHub Container Registry using the same scripts used by the DockerHub builder. This way, in case you need to modify the script, you don't have to worry about syncing the two builders.

### How I did it

I've created a secret under the repository named: `GHCR_IO_REGISTRY_TOKEN` with a personal access token with `write:packages` permissions. **Create it before triggering a new release.**

![Captura de pantalla 2020-11-30 a las 16 32 17](https://user-images.githubusercontent.com/14357604/100629474-9e73d880-3329-11eb-91dc-d391e3a3e7f3.png)

Also, you will need to **enable the improved container support** under your `hadolint` organization settings:

![Captura de pantalla 2020-11-30 a las 16 34 14](https://user-images.githubusercontent.com/14357604/100629701-e3980a80-3329-11eb-89df-057aae1de340.png)

After the first release, you have to **mark the package as publicly accessible.**

![Captura de pantalla 2020-11-30 a las 16 35 20](https://user-images.githubusercontent.com/14357604/100629837-0e825e80-332a-11eb-96e7-6a3eb390ff8a.png)

### How to verify it

I run the GitHub action in our SIGHUP's fork: https://github.com/sighupio/hadolint/runs/1474557615?check_suite_focus=true

