### PR TITLE
DL3005: Fix missing dist-upgrade #514

### DIFF
--- a/src/Hadolint/Rules.hs
+++ b/src/Hadolint/Rules.hs
@@ -428,7 +428,7 @@ noAptGetUpgrade = instructionRule code severity message check
     severity = ErrorC
     message = "Do not use apt-get upgrade or dist-upgrade"
     check (Run (RunArgs args _)) =
-      argumentsRule (Shell.noCommands (Shell.cmdHasArgs "apt-get" ["upgrade"])) args
+      argumentsRule (Shell.noCommands (Shell.cmdHasArgs "apt-get" ["upgrade", "dist-upgrade"])) args
     check _ = True
 
 noUntagged :: Rule

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -323,6 +323,9 @@ main =
       it "apt-get upgrade" $ do
         ruleCatches noAptGetUpgrade "RUN apt-get update && apt-get upgrade"
         onBuildRuleCatches noAptGetUpgrade "RUN apt-get update && apt-get upgrade"
+      it "apt-get dist-upgrade" $ do
+        ruleCatches noAptGetUpgrade "RUN apt-get update && apt-get dist-upgrade"
+        onBuildRuleCatches noAptGetUpgrade "RUN apt-get update && apt-get dist-upgrade"
       it "apt-get version pinning" $ do
         ruleCatches aptGetVersionPinned "RUN apt-get update && apt-get install python"
         onBuildRuleCatches aptGetVersionPinned "RUN apt-get update && apt-get install python"


### PR DESCRIPTION
- Check for `apt-get dist-upgrade` in addition to the existing
  check for `apt-get upgrade`

Performing `apt-get dist-upgrade` is to be considered bad practice for
the same reasons that `apt-get upgrade` would be considered bad
practice. Perhaps it should be considered worse in cases where an
appropriate base image is available.

### What I did
Fixes #514
### How I did it
Add "dist-upgrade" to the list of command line arguments for apt-get to be checked for.
### How to verify it
This should trigger `DL3005`:
```Dockerfile
RUN apt-get dist-upgrade
```
Unit tests are included.
