### PR TITLE
Fix Codeclimate JSON report format

### DIFF
--- a/src/Hadolint/Formatter/Codeclimate.hs
+++ b/src/Hadolint/Formatter/Codeclimate.hs
@@ -99,8 +99,4 @@ formatResult (Result errors checks) = allIssues
     checkMessages = fmap checkToIssue checks
 
 printResult :: (VisualStream s, TraversableStream s, ShowErrorComponent e) => Result s e -> IO ()
-printResult result = mapM_ output (formatResult result)
-  where
-    output value = do
-      B.putStr (encode value)
-      B.putStr (B.singleton 0x00)
+printResult result = B.putStrLn (encode (formatResult result))


### PR DESCRIPTION
Fixes #519 

### What I did

First of all, I must mention I don't know Haskell **at all**. 

But I noticed the JSON formatting is okay with the JSON formatter.

### How I did it

I just replaced the Codeclimate `printResult` function with the one from the JSON formatter class (that actually works).

### How to verify it

Sorry I have no idea how to develop unit tests in Haskell... 

I just ran `hadolint -f codeclimate Dockerfile` afterwards and obtained something satisfactory:

```json
[{"location":{"path":"Dockerfile_ko","lines":{"begin":18,"end":18}},"severity":"major","check_name":"DL3027","categories":["Bug Risk"],"type":"issue","description":"Do not use apt as it is meant to be a end-user tool, use apt-get or apt-cache instead"},{"location":{"path":"Dockerfile_ko","lines":{"begin":48,"end":48}},"severity":"major","check_name":"SC1007","categories":["Bug Risk"],"type":"issue","description":"Remove space after = if trying to assign a value (for empty string, use var='' ... )."},{"location":{"path":"Dockerfile_ko","lines":{"begin":48,"end":48}},"severity":"major","check_name":"SC2154","categories":["Bug Risk"],"type":"issue","description":"node_verson is referenced but not assigned."},{"location":{"path":"Dockerfile_ko","lines":{"begin":48,"end":48}},"severity":"major","check_name":"DL3003","categories":["Bug Risk"],"type":"issue","description":"Use WORKDIR to switch to a directory"}]
```

What I had before (and what is returned by actual Docker images):

```
{"location":{"path":"Dockerfile_ko","lines":{"begin":18,"end":18}},"severity":"major","check_name":"DL3027","categories":["Bug Risk"],"type":"issue","description":"Do not use apt as it is meant to be a end-user tool, use apt-get or apt-cache instead"}{"location":{"path":"Dockerfile_ko","lines":{"begin":48,"end":48}},"severity":"major","check_name":"SC1007","categories":["Bug Risk"],"type":"issue","description":"Remove space after = if trying to assign a value (for empty string, use var='' ... )."}{"location":{"path":"Dockerfile_ko","lines":{"begin":48,"end":48}},"severity":"major","check_name":"SC2154","categories":["Bug Risk"],"type":"issue","description":"node_verson is referenced but not assigned."}{"location":{"path":"Dockerfile_ko","lines":{"begin":48,"end":48}},"severity":"major","check_name":"DL3003","categories":["Bug Risk"],"type":"issue","description":"Use WORKDIR to switch to a directory"}
```