### PR TITLE
add pre-commit hook configuration

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,13 @@
+---
+- id: hadolint-docker
+  name: Lint Dockerfiles
+  description: Runs hadolint Docker image to lint Dockerfiles
+  language: docker_image
+  types: ["dockerfile"]
+  entry: hadolint/hadolint hadolint
+- id: hadolint
+  name: Lint Dockerfiles
+  description: Runs hadolint to lint Dockerfiles
+  language: system
+  entry: hadolint
+  files: Dockerfile

--- a/README.md
+++ b/README.md
@@ -155,12 +155,13 @@ Inline ignores will only work if place directly above the instruction.
 ## Integrations
 
 To get most of `hadolint` it is useful to integrate it as a check to your CI
-or to your editor to lint your `Dockerfile` as you write it. See our
-[Integration][] docs.
+or to your editor, or as a pre-commit hook, to lint your `Dockerfile` as you
+write it. See our [Integration][] docs.
 
 - [Code Review Platform Integrations][]
 - [Continuous Integrations][]
 - [Editor Integrations][]
+- [Version Control Integrations][]
 
 ## Rules
 
@@ -335,6 +336,7 @@ a look at [Syntax.hs][] in the `language-docker` project to see the AST definiti
 [code review platform integrations]: docs/INTEGRATION.md#code-review
 [continuous integrations]: docs/INTEGRATION.md#continuous-integration
 [editor integrations]: docs/INTEGRATION.md#editors
+[version control integrations]: docs/INTEGRATION.md#version-control
 [create an issue]: https://github.com/hadolint/hadolint/issues/new
 [dockerfile reference]: http://docs.docker.com/engine/reference/builder/
 [syntax.hs]: https://www.stackage.org/haddock/nightly-2018-01-07/language-docker-2.0.1/Language-Docker-Syntax.html

--- a/docs/INTEGRATION.md
+++ b/docs/INTEGRATION.md
@@ -290,11 +290,13 @@ if docker run --rm -i ghcr.io/hadolint/hadolint < "%d/%f"
 
 ### pre-commit
 
-[pre-commit](https://pre-commit.com) is a framework for managing and maintaining multi-language Git pre-commit hooks.
+[pre-commit](https://pre-commit.com) is a framework for managing and maintaining multi-language Git
+pre-commit hooks.
 
 Hadolint is available as a pre-commit hook.
 
-If you have the `hadolint` binary installed locally, add this to your `.pre-commit-config.yaml` in your repository:
+If you have the `hadolint` binary installed locally, add this to your `.pre-commit-config.yaml` in
+your repository:
 ```yaml
 ---
 repos:

--- a/docs/INTEGRATION.md
+++ b/docs/INTEGRATION.md
@@ -286,6 +286,33 @@ if docker run --rm -i ghcr.io/hadolint/hadolint < "%d/%f"
 | grep -EC100 ':WARNING:' ; then exit 1 ; else exit 0 ; fi
 ```
 
+## Version Control
+
+### pre-commit
+
+[pre-commit](https://pre-commit.com) is a framework for managing and maintaining multi-language Git pre-commit hooks.
+
+Hadolint is available as a pre-commit hook.
+
+If you have the `hadolint` binary installed locally, add this to your `.pre-commit-config.yaml` in your repository:
+```yaml
+---
+repos:
+  - repo: https://github.com/hadolint/hadolint
+    rev: master
+    hooks:
+      - id: hadolint
+```
+or alternatively use this to run Hadolint with Docker:
+```yaml
+---
+repos:
+  - repo: https://github.com/hadolint/hadolint
+    rev: master
+    hooks:
+      - id: hadolint-docker
+```
+
 ## Other
 
 Following section contains different angles on `hadolint` usage 


### PR DESCRIPTION
### What I did

Add a yaml configuration file to allow running hadolint as a git pre-commit hook with [pre-commit](https://pre-commit.com/).  Once set, the yaml hook configuration file doesn't need to change.  The hook allows either using a local hadolint binary or using the official hadolint Docker image.

### How to verify it

Install pre-commit from the docs at https://pre-commit.com/ and install the hooks with `pre-commit install` in the git repository.  Add a `.pre-commit-config.yaml` file following the docs in this pull request, and then attempt to commit some staged changes to any Dockerfile into git.  `pre-commit` only runs on changed files by default so it won't run on any Dockerfiles that are not included in the current commit.