### PR TITLE
Implement codeclimate report compatible with gitlab

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -51,6 +51,7 @@ toOutputFormat :: String -> Maybe Hadolint.OutputFormat
 toOutputFormat "json" = Just Hadolint.Json
 toOutputFormat "tty" = Just Hadolint.TTY
 toOutputFormat "codeclimate" = Just Hadolint.CodeclimateJson
+toOutputFormat "gitlab_codeclimate" = Just Hadolint.GitlabCodeclimateJson
 toOutputFormat "checkstyle" = Just Hadolint.Checkstyle
 toOutputFormat "codacy" = Just Hadolint.Codacy
 toOutputFormat _ = Nothing
@@ -59,6 +60,7 @@ showFormat :: Hadolint.OutputFormat -> String
 showFormat Hadolint.Json = "json"
 showFormat Hadolint.TTY = "tty"
 showFormat Hadolint.CodeclimateJson = "codeclimate"
+showFormat Hadolint.GitlabCodeclimateJson = "gitlab_codeclimate"
 showFormat Hadolint.Checkstyle = "checkstyle"
 showFormat Hadolint.Codacy = "codacy"
 
@@ -87,10 +89,10 @@ parseOptions =
         ( long "format"
             <> short 'f' -- options for the output format
             <> help
-              "The output format for the results [tty | json | checkstyle | codeclimate | codacy]"
+              "The output format for the results [tty | json | checkstyle | codeclimate | gitlab_codeclimate | codacy]"
             <> value Hadolint.TTY
             <> showDefaultWith showFormat -- The default value
-            <> completeWith ["tty", "json", "checkstyle", "codeclimate", "codacy"]
+            <> completeWith ["tty", "json", "checkstyle", "codeclimate", "gitlab_codeclimate", "codacy"]
         )
 
     ignoreList =

--- a/docs/INTEGRATION.md
+++ b/docs/INTEGRATION.md
@@ -98,6 +98,28 @@ lint_dockerfile:
   script:
     - hadolint Dockerfile
 ```
+<!--lint disable remark-lint-maximum-line-length-->
+Moreover, you can publish a [gitlab compatible codeclimate report](https://docs.gitlab.com/ee/user/project/merge_requests/code_quality.html#implementing-a-custom-tool) 
+as follows:
+
+```yaml
+docker-hadolint:
+  image: hadolint/hadolint:latest-debian
+  script:
+    - mkdir -p reports
+    - hadolint -f gitlab_codeclimate Dockerfile > reports/hadolint-$(md5sum Dockerfile | cut -d" " -f1).json
+  artifacts:
+    name: "$CI_JOB_NAME artifacts from $CI_PROJECT_NAME on $CI_COMMIT_REF_SLUG"
+    expire_in: 1 day
+    when: always
+    reports:
+      codequality:
+        - "reports/*"
+    paths:
+      - "reports/*"
+```
+
+This way, a widget will be integrated to your merge requests alerting potential changes.
 
 ### Drone CI
 

--- a/hadolint.cabal
+++ b/hadolint.cabal
@@ -4,7 +4,7 @@ cabal-version: 2.0
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 196183dccc95114462aa7b27a5c15b007a0aa09fdddf2c00d154df003854e6ad
+-- hash: 55058bcec2b0e9a9abd5b0da9fb86e131364e80869c98c62758de726795fa2d3
 
 name:           hadolint
 version:        1.20.0
@@ -58,6 +58,7 @@ library
     , base >=4.8 && <5
     , bytestring
     , containers
+    , cryptonite
     , directory >=1.3.0
     , filepath
     , language-docker >=9.1.2 && <10

--- a/package.yaml
+++ b/package.yaml
@@ -45,6 +45,7 @@ library:
     - directory >= 1.3.0
     - async
     - parallel
+    - cryptonite
 executables:
   hadolint:
     main: Main.hs

--- a/src/Hadolint/Lint.hs
+++ b/src/Hadolint/Lint.hs
@@ -33,6 +33,7 @@ data OutputFormat
   = Json
   | TTY
   | CodeclimateJson
+  | GitlabCodeclimateJson
   | Checkstyle
   | Codacy
   deriving (Show, Eq)
@@ -50,6 +51,7 @@ printResultsAndExit format allResults = do
         Json -> Json.printResult res
         Checkstyle -> Checkstyle.printResult res
         CodeclimateJson -> Codeclimate.printResult res >> exitSuccess
+        GitlabCodeclimateJson -> Codeclimate.printGitlabResult res >> exitSuccess
         Codacy -> Codacy.printResult res >> exitSuccess
 
 -- | Performs the process of parsing the dockerfile and analyzing it with all the applicable


### PR DESCRIPTION
Close #521

### What I did

First, I suffered a lot cause I am a newbie in haskell... :cry: 

Then, I implemented a formatter named   'gitlab_codeclimate' compatible with gitlab. This report will be json list of json object. Each object will contain a 'fingerprint' attribute containing sha1 of string representation of the object

### How I did it

 - added cryptonic dependency
 - added the option `gitlab_codeclimate`
 - putting in each object a `fingerprint` attribute containing a `sha1` of the json representation of the object (without `fingerprint`attribute)

### How to verify it

Launch binary with `gitlab_codeclimate`. The result will be


```
[{"location":{"path":"path/Dockerfile","lines":{"begin":49,"end":49}},"fingerprint":"d4b3531cf24f32c5d2a58671461ddd9ba9410c02","severity":"major","check_name":"SC1007","categories":["Bug Risk"],"type":"issue","description":"Remove space after = if trying to assign a value (for empty string, use var='' ... )."},{"location":{"path":"path/Dockerfile","lines":{"begin":49,"end":49}},"fingerprint":"ceace3a6e503e478145b4ab83141375267b0b7ed","severity":"major","check_name":"SC2154","categories":["Bug Risk"],"type":"issue","description":"node_verson is referenced but not assigned."},{"location":{"path":"path/Dockerfile","lines":{"begin":49,"end":49}},"fingerprint":"98979739fe8780591082195569e2e37ec30fc968","severity":"major","check_name":"DL3003","categories":["Bug Risk"],"type":"issue","description":"Use WORKDIR to switch to a directory"}]
```


