### PR TITLE
rules: Check against illegal instructions within `ONBUILD` #512

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,7 @@ Please [create an issue][] if you have an idea for a good rule.
 | [DL3040](https://github.com/hadolint/hadolint/wiki/DL3040)   | `dnf clean all` missing after dnf command.                                                                                                          |
 | [DL3041](https://github.com/hadolint/hadolint/wiki/DL3041)   | Specify version with `dnf install -y <package>-<version>`                                                                                           |
 | [DL3042](https://github.com/hadolint/hadolint/wiki/DL3042)   | Avoid cache directory with `pip install --no-cache-dir <package>`.                                                                                  |
+| [DL3043](https://github.com/hadolint/hadolint/wiki/DL3043)   | `ONBUILD`, `FROM` or `MAINTAINER` triggered from within `ONBUILD` instruction.                                                                      |
 | [DL4000](https://github.com/hadolint/hadolint/wiki/DL4000)   | MAINTAINER is deprecated.                                                                                                                           |
 | [DL4001](https://github.com/hadolint/hadolint/wiki/DL4001)   | Either use Wget or Curl but not both.                                                                                                               |
 | [DL4003](https://github.com/hadolint/hadolint/wiki/DL4003)   | Multiple `CMD` instructions found.                                                                                                                  |

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -1380,6 +1380,40 @@ main =
                     (length checks == 2)
               )
     --
+    describe "ONBUILD" $ do
+      it "error when using `ONBUILD` within `ONBUILD`" $
+        let dockerFile =
+              [ "ONBUILD ONBUILD RUN anything"
+              ]
+        in ruleCatches noIllegalInstructionInOnbuild $ Text.unlines dockerFile
+      it "error when using `FROM` within `ONBUILD`" $
+        let dockerFile =
+              [ "ONBUILD FROM debian:buster"
+              ]
+        in ruleCatches noIllegalInstructionInOnbuild $ Text.unlines dockerFile
+      it "error when using `MAINTAINER` within `ONBUILD`" $
+        let dockerFile =
+              [ "ONBUILD MAINTAINER \"BoJack Horseman\""
+              ]
+        in ruleCatches noIllegalInstructionInOnbuild $ Text.unlines dockerFile
+      it "ok with `ADD`" $ ruleCatchesNot noIllegalInstructionInOnbuild "ONBUILD ADD anything anywhere"
+      it "ok with `USER`" $ ruleCatchesNot noIllegalInstructionInOnbuild "ONBUILD USER anything"
+      it "ok with `LABEL`" $ ruleCatchesNot noIllegalInstructionInOnbuild "ONBUILD LABEL bla=\"blubb\""
+      it "ok with `STOPSIGNAL`" $ ruleCatchesNot noIllegalInstructionInOnbuild "ONBUILD STOPSIGNAL anything"
+      it "ok with `COPY`" $ ruleCatchesNot noIllegalInstructionInOnbuild "ONBUILD COPY anything anywhere"
+      it "ok with `RUN`" $ ruleCatchesNot noIllegalInstructionInOnbuild "ONBUILD RUN anything"
+      it "ok with `CMD`" $ ruleCatchesNot noIllegalInstructionInOnbuild "ONBUILD CMD anything"
+      it "ok with `SHELL`" $ ruleCatchesNot noIllegalInstructionInOnbuild "ONBUILD SHELL anything"
+      it "ok with `WORKDIR`" $ ruleCatchesNot noIllegalInstructionInOnbuild "ONBUILD WORKDIR anything"
+      it "ok with `EXPOSE`" $ ruleCatchesNot noIllegalInstructionInOnbuild "ONBUILD EXPOSE 69"
+      it "ok with `VOLUME`" $ ruleCatchesNot noIllegalInstructionInOnbuild "ONBUILD VOLUME anything"
+      it "ok with `ENTRYPOINT`" $ ruleCatchesNot noIllegalInstructionInOnbuild "ONBUILD ENTRYPOINT anything"
+      it "ok with `ENV`" $ ruleCatchesNot noIllegalInstructionInOnbuild "ONBUILD ENV MYVAR=\"bla\""
+      it "ok with `ARG`" $ ruleCatchesNot noIllegalInstructionInOnbuild "ONBUILD ARG anything"
+      it "ok with `HEALTHCHECK`" $ ruleCatchesNot noIllegalInstructionInOnbuild "ONBUILD HEALTHCHECK NONE"
+      it "ok with `FROM` outside of `ONBUILD`" $ ruleCatchesNot noIllegalInstructionInOnbuild "FROM debian:buster"
+      it "ok with `MAINTAINER` outside of `ONBUILD`" $ ruleCatchesNot noIllegalInstructionInOnbuild "MAINTAINER \"Some Guy\""
+    --
     describe "Regression Tests" $
       it "Comments with backslashes at the end are just comments" $
         let dockerFile =


### PR DESCRIPTION
- Add rule to check agains illegal instructions within `ONBUILD`
  instructions
- Modify rule parsing to do a pass with and a pass without automatically
  expanded `ONBUILD` instructions
- Merge results of the two passes such that all rules appear once only
- Add tests for new rule

<!--
If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

I'd like to point out two things for discussion regarding this change:
- In addition to the three cases checked here, IMO not all other combination that are legal by this rule make a lot of sense.
  For example `ONBUILD EXPOSE` or `ONBUILD LABEL` do not appear very useful to me - maybe we should warn on them?
  The requested three cases are to be avoided as per official docker documentation, so I think there is no need to discuss the necessity of linting for them.
- Checking the `ONBUILD` instructions themselves requires a second pass through all instructions. This is not too bad IMO, but
  maybe there is a better way. I tried to use pattern matching to only check the `ONBUILD` instructions twice, but failed to come up with something due to my limited Haskell knowledge.
  The reason the `ONBUILD` instructions absolutely need to be checked twice is that `hadolint` must also lint whatever is inside the `ONBUILD` instruction. Maybe there is a better way that I just can't see right now?

### How to check
This dockerfile should trigger error `DL3043` on all three lines:
```Dockerfile
ONBUILD FROM debian:buster
ONBUILD MAINTAINER "Some Guy"
ONBUILD ONBUILD RUN something
```

This dockerfile does not trigger `DL3043`:
```Dockerfile
FROM debian:buster
MAINTAINER "Some Guy"
ONBUILD RUN something
```