### PR TITLE
Improve pre-commit file-type detection for dockerfiles

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -9,5 +9,5 @@
   name: Lint Dockerfiles
   description: Runs hadolint to lint Dockerfiles
   language: system
+  types: ["dockerfile"]
   entry: hadolint
-  files: Dockerfile


### PR DESCRIPTION
This change updates the pre-commit hook for a local hadolint install to detect via filetype instead of filename.

The hadolint docker pre-commit hook already has this configuration but I missed setting it for the system hook in the initial PR.

This will allow pre-commit to detect Dockerfiles that don't have the exact filename of `Dockerfile` as there may be multiple Dockerfiles with different names in the same directory.