### PR TITLE
Add '--no-fail' option

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -137,7 +137,8 @@ exitProgram cmd res
 runLint :: CommandOptions -> Hadolint.LintOptions -> NonEmpty.NonEmpty String -> IO()
 runLint cmd conf files = do
   res <-  Hadolint.lint conf files
-  Hadolint.printResults (format cmd) res >>  exitProgram cmd res
+  Hadolint.printResults (format cmd) res
+  exitProgram cmd res
 
 main :: IO ()
 main = do

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -5,9 +5,10 @@
 module Main where
 
 import Control.Applicative
-import qualified Data.List.NonEmpty as NonEmpty
 import Data.Semigroup ((<>))
 import qualified Data.Set as Set
+import qualified Data.Sequence as Seq
+import qualified Data.List.NonEmpty as NonEmpty
 import Data.String (IsString (fromString))
 import qualified Data.Version
 import qualified Development.GitRev
@@ -41,6 +42,7 @@ import System.Exit (exitFailure, exitSuccess)
 
 data CommandOptions = CommandOptions
   { showVersion :: Bool,
+    noFail :: Bool,
     configFile :: Maybe FilePath,
     format :: Hadolint.OutputFormat,
     dockerfiles :: [String],
@@ -68,12 +70,15 @@ parseOptions :: Parser CommandOptions
 parseOptions =
   CommandOptions
     <$> version -- CLI options parser definition
+    <*> noFail
     <*> configFile
     <*> outputFormat
     <*> files
     <*> lintOptions
   where
     version = switch (long "version" <> short 'v' <> help "Show version")
+
+    noFail = switch (long "no-fail" <> help "Don't exit with a failure status code when any rule is violated")
 
     configFile =
       optional
@@ -118,6 +123,22 @@ parseOptions =
               )
           )
 
+noFailure :: Hadolint.Result s e -> Bool
+noFailure (Hadolint.Result Seq.Empty Seq.Empty) = True
+noFailure _ = False
+
+exitProgram :: CommandOptions -> Hadolint.Result s e -> IO()
+exitProgram cmd res
+  | noFail cmd                                 = exitSuccess
+  | Hadolint.shallSkipErrorStatus (format cmd) = exitSuccess
+  | noFailure res                              = exitSuccess
+  | otherwise                                  = exitFailure
+
+runLint :: CommandOptions -> Hadolint.LintOptions -> NonEmpty.NonEmpty String -> IO()
+runLint cmd conf files = do
+  res <-  Hadolint.lint conf files
+  Hadolint.printResults (format cmd) res >>  exitProgram cmd res
+
 main :: IO ()
 main = do
   cmd <- execParser opts
@@ -131,9 +152,7 @@ main = do
       let files = NonEmpty.fromList (dockerfiles cmd)
       case lintConfig of
         Left err -> error err
-        Right conf -> do
-          res <- Hadolint.lint conf files
-          Hadolint.printResultsAndExit (format cmd) res
+        Right conf -> runLint cmd conf files
     opts =
       info
         (helper <*> parseOptions)

--- a/hadolint.cabal
+++ b/hadolint.cabal
@@ -4,10 +4,10 @@ cabal-version: 2.0
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 55058bcec2b0e9a9abd5b0da9fb86e131364e80869c98c62758de726795fa2d3
+-- hash: b934b8b20c533c2e9d0f96fc7feae25791c0c02248f0116af5b43262a186afb8
 
 name:           hadolint
-version:        1.20.0
+version:        1.21.0
 synopsis:       Dockerfile Linter JavaScript API
 description:    A smarter Dockerfile linter that helps you build best practice Docker images.
 category:       Development

--- a/src/Hadolint.hs
+++ b/src/Hadolint.hs
@@ -2,9 +2,11 @@ module Hadolint
   ( module Hadolint.Lint,
     module Hadolint.Rules,
     module Hadolint.Config,
+    Result (..)
   )
 where
 
 import Hadolint.Config
 import Hadolint.Lint
 import Hadolint.Rules
+import Hadolint.Formatter.Format (Result (..))

--- a/src/Hadolint/Formatter/Format.hs
+++ b/src/Hadolint/Formatter/Format.hs
@@ -6,7 +6,6 @@ module Hadolint.Formatter.Format
     errorPositionPretty,
     Text.Megaparsec.Error.errorBundlePretty,
     Result (..),
-    isEmpty,
     toResult,
   )
 where
@@ -35,10 +34,6 @@ instance Semigroup (Result s e) where
 instance Monoid (Result s e) where
   mappend = (<>)
   mempty = Result mempty mempty
-
-isEmpty :: Result s e -> Bool
-isEmpty (Result Seq.Empty Seq.Empty) = True
-isEmpty _ = False
 
 toResult :: Either (ParseErrorBundle s e) [RuleCheck] -> Result s e
 toResult res =

--- a/src/Hadolint/Lint.hs
+++ b/src/Hadolint/Lint.hs
@@ -17,7 +17,6 @@ import qualified Hadolint.Rules as Rules
 import qualified Language.Docker as Docker
 import Language.Docker.Parser (DockerfileError, Error)
 import Language.Docker.Syntax (Dockerfile)
-import System.Exit (exitFailure, exitSuccess)
 
 type IgnoreRule = Text
 
@@ -38,21 +37,19 @@ data OutputFormat
   | Codacy
   deriving (Show, Eq)
 
-printResultsAndExit :: OutputFormat -> Format.Result Text DockerfileError -> IO ()
-printResultsAndExit format allResults = do
-  printResult allResults
-  if not . Format.isEmpty $ allResults
-    then exitFailure
-    else exitSuccess
-  where
-    printResult res =
-      case format of
-        TTY -> TTY.printResult res
-        Json -> Json.printResult res
-        Checkstyle -> Checkstyle.printResult res
-        CodeclimateJson -> Codeclimate.printResult res >> exitSuccess
-        GitlabCodeclimateJson -> Codeclimate.printGitlabResult res >> exitSuccess
-        Codacy -> Codacy.printResult res >> exitSuccess
+printResults :: OutputFormat -> Format.Result Text DockerfileError -> IO ()
+printResults format allResults = do
+  case format of
+    TTY -> TTY.printResult allResults
+    Json -> Json.printResult allResults
+    Checkstyle -> Checkstyle.printResult allResults
+    CodeclimateJson -> Codeclimate.printResult allResults
+    GitlabCodeclimateJson -> Codeclimate.printGitlabResult allResults
+    Codacy -> Codacy.printResult allResults
+
+shallSkipErrorStatus:: OutputFormat -> Bool
+shallSkipErrorStatus format  = elem format [CodeclimateJson, Codacy]
+
 
 -- | Performs the process of parsing the dockerfile and analyzing it with all the applicable
 -- rules, depending on the list of ignored rules.


### PR DESCRIPTION
Each formatter shall exit non 0 code when any error occurs unless '--no-fail' option specified. If so, a 0 status code is returned even if any rule is violated

Closes #391


### What I did

Make program return non zero code if failure occurs, whenever the formatter. If `--no-fail` is specified , the programm returns `0` status code, whatever rules are violated or not.

### How I did it

- remove treatment of exit in lint and put it in main
- added option
- print result and analyse the exit method that shall be called

### How to verify it

- launch binary with invalid `Dockerfile` with `-f gitlab_codeclimate` and expects `1`status code
- launch binary with invalid `Dockerfile` with `-f gitlab_codeclimate` and `--no-fail` and expects `0`status code
- launch binary with valid `Dockerfile` with `-f gitlab_codeclimate` and expects `0`status code
- launch binary with valid `Dockerfile` with `-f gitlab_codeclimate` and `--no-fail` and expects `0`status code
