### PR TITLE
Adding rule for maintainer label.

### DIFF
--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -978,6 +978,20 @@ main =
       it "has no maintainer" $ ruleCatchesNot hasNoMaintainer "FROM debian"
       it "using add" $ ruleCatches copyInsteadAdd "ADD file /usr/src/app/"
 
+      it "should have maintainer label" $ ruleCatchesNot hasMaintainerLabel "FROM busybox\nLABEL maintainer=asd"
+
+      it "should have maintainer label uppercase" $ ruleCatchesNot hasMaintainerLabel "FROM busybox\nLABEL MAINTAINER=asd"
+
+      it "should have maintainer label in the last stage" $ ruleCatchesNot hasMaintainerLabel "FROM busybox AS temp\nLABEL MAINTAINER=asd\nFROM alpine\nLABEL MAINTAINER=asd"
+
+      it "should have maintainer label quotes" $ ruleCatchesNot hasMaintainerLabel "FROM busybox\nLABEL maintainer=\"asd\""
+
+      it "other labels present, but no maintainer" $ ruleCatches hasMaintainerLabel "FROM busybox\nLABEL foo=bar"
+
+      it "should have maintainer label in the last stage" $ ruleCatches hasMaintainerLabel "FROM busybox AS temp\nLABEL MAINTAINER=asd\nFROM alpine"
+
+      it "does not have maintainer label" $ ruleCatches hasMaintainerLabel "FROM busybox"
+
       it "many cmds" $
         let dockerFile =
               [ "FROM debian",


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

### What I did
Added new rule for ensuring the presence of maintainer label.

The maintainer directive in docker was deprecated. But the feature itself was moved to using label directive and there are no rules for ensuring the presence of maintainer label.
This has been mentioned as best practice in couple of articles like https://snyk.io/blog/10-docker-image-security-best-practices/

For an organization, that has hundreds of team creating images, this would be a way to identify owners for remediation and governance.

### How I did it 
Added a new rule.

### How to verify it
Added test cases in spec.hs and tested using binary on dockerfile.
