### PR TITLE
bugfix: more accurate matching on `pip`

### DIFF
--- a/src/Hadolint/Rules.hs
+++ b/src/Hadolint/Rules.hs
@@ -1121,15 +1121,23 @@ pipNoCacheDir = instructionRule code severity message check
     check (Run (RunArgs args _)) = argumentsRule (Shell.noCommands forgotNoCacheDir) args
     check _ = True
     forgotNoCacheDir cmd =
-      isPipInstall cmd && not(usesNoCacheDir cmd)
+      isPipInstall cmd && not(usesNoCacheDir cmd) && not (isPipWrapper cmd)
     usesNoCacheDir cmd   = "--no-cache-dir" `elem` Shell.getArgs cmd
 
 isPipInstall :: Shell.Command -> Bool
 isPipInstall cmd@(Shell.Command name _ _) = isStdPipInstall || isPythonPipInstall
   where
-    isStdPipInstall    = "pip" `Text.isPrefixOf` name && ["install"] `isInfixOf` Shell.getArgs cmd
+    isStdPipInstall = "pip" `Text.isPrefixOf` name
+      && ["install"] `isInfixOf` Shell.getArgs cmd
     isPythonPipInstall = "python" `Text.isPrefixOf` name
         && ["-m", "pip", "install"] `isInfixOf` Shell.getArgs cmd
+
+isPipWrapper :: Shell.Command -> Bool
+isPipWrapper cmd@(Shell.Command name _ _) = isWrapper "pipx" || isWrapper "pipenv"
+  where
+    isWrapper :: Text.Text -> Bool
+    isWrapper w = w `Text.isInfixOf` name
+      || ( "python" `Text.isPrefixOf` name && ["-m", w] `isInfixOf` Shell.getArgs cmd )
 
 gems :: Shell.ParsedShell -> [Text.Text]
 gems shell =

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -662,7 +662,12 @@ main =
       it "pip --no-cache-dir used" $ do
         ruleCatchesNot pipNoCacheDir        "RUN pip install MySQL_python --no-cache-dir"
         onBuildRuleCatchesNot pipNoCacheDir "RUN pip install MySQL_python --no-cache-dir"
-
+      it "don't match on pipx" $ do
+        ruleCatchesNot pipNoCacheDir        "RUN pipx install software"
+        onBuildRuleCatchesNot pipNoCacheDir "Run pipx install software"
+      it "don't match on pipenv" $ do
+        ruleCatchesNot pipNoCacheDir        "RUN pipenv install library"
+        onBuildRuleCatchesNot pipNoCacheDir "RUN pipenv install library"
     --
     describe "npm pinning" $ do
       it "version pinned in package.json" $ do


### PR DESCRIPTION
- Make matching pip commands more accurate

Pip has a lot of different ways of calling (`pip`, `pip3`, `python -m pip`,
...). Some rules are pip specific, while others apply to wrappers around
pip as well. These wrappers include `pipenv` and `pipx`. The addition of
a isPipWrapper command lets a rule distinguish between pip commands and
wrappers.

fixes #532
fixes #511

<!--
If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

### What I did
I added an extensible way to distinguish between genuine `pip` commands and `pip` wrappers like `pipx`, when writing rules.
Simply excluding `pip` wrappers from matching should be up to the author of the individual rules, because a rule may apply to all `pip` commands including wrapper, or just the wrappers or just the genuine `pip` commands.

Use the `isPipWrapper` function to identify `pip` wrappers when linting through `pip` commands. It is extensible because it can easily be adapted to include the newest and most popular `pip` wrapper of the week.

### How to verify it
DL3042 no longer triggers with this Dockerfile:
```
RUN pipx install bla
RUN pipenv install bla
```