### PR TITLE
Allow dependabot to check github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+---
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

### What I did

This change allows dependabot to check any GitHub action which this project uses on a weekly basis and submit pull requests automatically with version bumps in order to keep packages up-to-date.

### How I did it

https://docs.github.com/en/github/administering-a-repository/keeping-your-actions-up-to-date-with-dependabot

### How to verify it

There should be a syntax checker native to GitHub that will check whether this configuration file is valid.