### PR TITLE
Restore static compilation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,7 +84,7 @@ jobs:
     - name: Build binary
       run: |
         mkdir dist
-        cabal install exe:hadolint --install-method=copy --overwrite-policy=always --installdir=dist
+        cabal install exe:hadolint --install-method=copy --overwrite-policy=always --installdir=dist --ghc-options=-fPIC -fstatic
 
     - if: matrix.os == 'windows-latest'
       name: Set extension to .exe on Windows


### PR DESCRIPTION
I broke it by forgetting to pass the static flag and the fPIC option to
GHC when moving the build script to github actions.

closes #534