### PR TITLE
Feature: Configurable rule severity

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -5,11 +5,10 @@
 module Main where
 
 import Control.Applicative
-import Data.Semigroup ((<>))
-import qualified Data.Set as Set
-import qualified Data.Sequence as Seq
-import qualified Data.List.NonEmpty as NonEmpty
 import Data.String (IsString (fromString))
+import qualified Data.List.NonEmpty as NonEmpty
+import qualified Data.Sequence as Seq
+import qualified Data.Set as Set
 import qualified Data.Version
 import qualified Development.GitRev
 import qualified Hadolint
@@ -106,6 +105,42 @@ parseOptions =
             <> completeWith ["tty", "json", "checkstyle", "codeclimate", "gitlab_codeclimate", "codacy"]
         )
 
+    errorList =
+      many
+        ( strOption
+          ( long "error"
+              <> help "Make the rule `RULECODE` have the level `error`"
+              <> metavar "RULECODE"
+          )
+        )
+
+    warningList =
+      many
+        ( strOption
+          ( long "warning"
+              <> help "Make the rule `RULECODE` have the level `warning`"
+              <> metavar "RULECODE"
+          )
+        )
+
+    infoList =
+      many
+        ( strOption
+          ( long "info"
+              <> help "Make the rule `RULECODE` have the level `info`"
+              <> metavar "RULECODE"
+          )
+        )
+
+    styleList =
+      many
+        ( strOption
+          ( long "style"
+              <> help "Make the rule `RULECODE` have the level `style`"
+              <> metavar "RULECODE"
+          )
+        )
+
     ignoreList =
       many
         ( strOption
@@ -117,7 +152,14 @@ parseOptions =
 
     files = many (argument str (metavar "DOCKERFILE..." <> action "file"))
 
-    lintOptions = Hadolint.LintOptions <$> ignoreList <*> parseRulesConfig
+    lintOptions =
+      Hadolint.LintOptions
+        <$> errorList
+        <*> warningList
+        <*> infoList
+        <*> styleList
+        <*> ignoreList
+        <*> parseRulesConfig
 
     parseRulesConfig =
       Hadolint.RulesConfig . Set.fromList . fmap fromString

--- a/hadolint.cabal
+++ b/hadolint.cabal
@@ -60,6 +60,7 @@ library
     , colourista
     , containers
     , cryptonite
+    , deepseq ==1.4.4.*
     , directory >=1.3.0
     , filepath
     , language-docker >=9.1.2 && <10

--- a/package.yaml
+++ b/package.yaml
@@ -41,6 +41,7 @@ library:
     - colourista
     - containers
     - cryptonite
+    - deepseq == 1.4.4.*
     - directory >= 1.3.0
     - filepath
     - mtl

--- a/src/Hadolint/Config.hs
+++ b/src/Hadolint/Config.hs
@@ -2,7 +2,7 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE OverloadedStrings #-}
 
-module Hadolint.Config (applyConfig, ConfigFile (..)) where
+module Hadolint.Config (applyConfig, ConfigFile (..), OverrideConfig (..)) where
 
 import Control.Monad (filterM)
 import qualified Data.ByteString as Bytes
@@ -23,16 +23,35 @@ import System.Directory
   )
 import System.FilePath ((</>))
 
+
+data OverrideConfig = OverrideConfig
+  { overrideErrorRules :: Maybe [Lint.ErrorRule],
+    overrideWarningRules :: Maybe [Lint.WarningRule],
+    overrideInfoRules :: Maybe [Lint.InfoRule],
+    overrideStyleRules :: Maybe [Lint.StyleRule]
+  }
+  deriving (Show, Eq, Generic)
+
 data ConfigFile = ConfigFile
-  { ignoredRules :: Maybe [Lint.IgnoreRule],
+  { overrideRules :: Maybe OverrideConfig,
+    ignoredRules :: Maybe [Lint.IgnoreRule],
     trustedRegistries :: Maybe [Lint.TrustedRegistry]
   }
   deriving (Show, Eq, Generic)
 
+instance Yaml.FromYAML OverrideConfig
+  where
+    parseYAML = Yaml.withMap "OverrideConfig" $ \m -> OverrideConfig
+        <$> m .:? "error"
+        <*> m .:? "warning"
+        <*> m .:? "info"
+        <*> m .:? "style"
+
 instance Yaml.FromYAML ConfigFile where
   parseYAML = Yaml.withMap "ConfigFile" $ \m ->
     ConfigFile
-      <$> m .:? "ignored"
+      <$> m .:? "override"
+      <*> m .:? "ignored"
       <*> m .:? "trustedRegistries"
 
 -- | If both the ignoreRules and rulesConfig properties of Lint options are empty
@@ -61,9 +80,42 @@ applyConfig maybeConfig o
       contents <- Bytes.readFile configFile
       case Yaml.decode1Strict contents of
         Left (_, err) -> return $ Left (formatError err configFile)
-        Right (ConfigFile ignore trusted) -> return (Right (override ignore trusted))
+        Right (ConfigFile Nothing ignore trusted) ->
+          return $
+            Right (applyOverride Nothing Nothing Nothing Nothing ignore trusted)
+        Right (ConfigFile (Just (OverrideConfig errors warnings infos styles)) ignore trusted) ->
+          return $
+            Right (applyOverride errors warnings infos styles ignore trusted)
 
-    override ignore trusted = applyTrusted trusted . applyIgnore ignore $ o
+    applyOverride errors warnings infos styles ignore trusted =
+      applyTrusted trusted
+        . applyIgnore ignore
+        . applyStyles styles
+        . applyInfos infos
+        . applyWarnings warnings
+        . applyErrors errors
+        $ o
+
+    applyErrors errors opts =
+      case Lint.errorRules opts of
+        [] -> opts {Lint.errorRules = fromMaybe [] errors}
+        _ -> opts
+
+    applyWarnings warnings opts =
+      case Lint.warningRules opts of
+        [] -> opts {Lint.warningRules = fromMaybe [] warnings}
+        _ -> opts
+
+    applyInfos infos opts =
+      case Lint.infoRules opts of
+        [] -> opts {Lint.infoRules = fromMaybe [] infos}
+        _ -> opts
+
+    applyStyles styles opts =
+      case Lint.styleRules opts of
+        [] -> opts {Lint.styleRules = fromMaybe [] styles}
+        _ -> opts
+
     applyIgnore ignore opts =
       case Lint.ignoreRules opts of
         [] -> opts {Lint.ignoreRules = fromMaybe [] ignore}
@@ -80,10 +132,17 @@ applyConfig maybeConfig o
     formatError err config =
       unlines
         [ "Error parsing your config file in  '" ++ config ++ "':",
-          "It should contain one of the keys 'ignored' or 'trustedRegistries'. For example:\n",
+          "It should contain one of the keys 'override', 'ignored'",
+          "or 'trustedRegistries'. For example:\n",
           "ignored:",
           "\t- DL3000",
           "\t- SC1099\n\n",
+          "The key 'override' should contain only lists with names 'error',",
+          "'warning', 'info' or 'style', which each name rules to override the",
+          "severity on. For example:\n",
+          "override:",
+          "\terror:",
+          "\t\t- DL3008\n\n",
           "The key 'trustedRegistries' should contain the names of the allowed docker registries:\n",
           "allowedRegistries:",
           "\t- docker.io",

--- a/src/Hadolint/Formatter/Checkstyle.hs
+++ b/src/Hadolint/Formatter/Checkstyle.hs
@@ -12,11 +12,9 @@ import qualified Data.ByteString.Lazy.Char8 as B
 import Data.Char
 import Data.Foldable (toList)
 import Data.List (groupBy)
-import Data.Monoid (mconcat, (<>))
 import qualified Data.Text as Text
 import Hadolint.Formatter.Format
-import Hadolint.Rules (Metadata (..), RuleCheck (..))
-import ShellCheck.Interface
+import Hadolint.Rules (Metadata (..), RuleCheck (..), DLSeverity (..))
 import Text.Megaparsec (TraversableStream)
 import Text.Megaparsec.Error
 import Text.Megaparsec.Pos (sourceColumn, sourceLine, sourceName, unPos)
@@ -37,7 +35,7 @@ errorToCheckStyle err =
     { file = sourceName pos,
       line = unPos (sourceLine pos),
       column = unPos (sourceColumn pos),
-      impact = severityText ErrorC,
+      impact = severityText DLErrorC,
       msg = errorBundlePretty err,
       source = "DL1000"
     }

--- a/src/Hadolint/Formatter/Codacy.hs
+++ b/src/Hadolint/Formatter/Codacy.hs
@@ -9,7 +9,6 @@ where
 
 import Data.Aeson hiding (Result)
 import qualified Data.ByteString.Lazy.Char8 as B
-import Data.Monoid ((<>))
 import Data.Sequence (Seq)
 import qualified Data.Text as Text
 import Hadolint.Formatter.Format (Result (..), errorPosition)

--- a/src/Hadolint/Formatter/Codeclimate.hs
+++ b/src/Hadolint/Formatter/Codeclimate.hs
@@ -12,13 +12,11 @@ where
 import Crypto.Hash (Digest, SHA1 (..), hash)
 import Data.Aeson hiding (Result)
 import qualified Data.ByteString.Lazy as B
-import Data.Monoid ((<>))
 import Data.Sequence (Seq)
 import qualified Data.Text as Text
 import GHC.Generics
 import Hadolint.Formatter.Format (Result (..), errorPosition)
-import Hadolint.Rules (Metadata (..), RuleCheck (..))
-import ShellCheck.Interface
+import Hadolint.Rules (Metadata (..), RuleCheck (..), DLSeverity (..))
 import Text.Megaparsec (TraversableStream)
 import Text.Megaparsec.Error
 import Text.Megaparsec.Pos (sourceColumn, sourceLine, sourceName, unPos)
@@ -86,7 +84,7 @@ errorToIssue err =
     { checkName = "DL1000",
       description = errorBundlePretty err,
       location = LocPos (sourceName pos) Pos {..},
-      impact = severityText ErrorC
+      impact = severityText DLErrorC
     }
   where
     pos = errorPosition err
@@ -102,13 +100,14 @@ checkToIssue RuleCheck {..} =
       impact = severityText (severity metadata)
     }
 
-severityText :: Severity -> String
+severityText :: DLSeverity -> String
 severityText severity =
   case severity of
-    ErrorC -> "blocker"
-    WarningC -> "major"
-    InfoC -> "info"
-    StyleC -> "minor"
+    DLErrorC -> "blocker"
+    DLWarningC -> "major"
+    DLInfoC -> "info"
+    DLStyleC -> "minor"
+    _ -> ""
 
 generateFingerprint :: Issue -> Digest SHA1
 generateFingerprint = hash . B.toStrict . encode

--- a/src/Hadolint/Formatter/Format.hs
+++ b/src/Hadolint/Formatter/Format.hs
@@ -12,12 +12,9 @@ where
 
 import Data.List (sort)
 import qualified Data.List.NonEmpty as NE
-import Data.Monoid (Monoid)
-import Data.Semigroup
 import Data.Sequence (Seq)
 import qualified Data.Sequence as Seq
 import Hadolint.Rules
-import ShellCheck.Interface
 import Text.Megaparsec (TraversableStream (..), pstateSourcePos)
 import Text.Megaparsec.Error
 import Text.Megaparsec.Pos (SourcePos, sourcePosPretty)
@@ -41,13 +38,14 @@ toResult res =
     Left err -> Result (Seq.singleton err) mempty
     Right c -> Result mempty (Seq.fromList (sort c))
 
-severityText :: Severity -> String
+severityText :: DLSeverity -> String
 severityText s =
   case s of
-    ErrorC -> "error"
-    WarningC -> "warning"
-    InfoC -> "info"
-    StyleC -> "style"
+    DLErrorC -> "error"
+    DLWarningC -> "warning"
+    DLInfoC -> "info"
+    DLStyleC -> "style"
+    _ -> ""
 
 stripNewlines :: String -> String
 stripNewlines =

--- a/src/Hadolint/Formatter/Json.hs
+++ b/src/Hadolint/Formatter/Json.hs
@@ -9,10 +9,8 @@ where
 
 import Data.Aeson hiding (Result)
 import qualified Data.ByteString.Lazy.Char8 as B
-import Data.Monoid ((<>))
 import Hadolint.Formatter.Format (Result (..), errorPosition, severityText)
-import Hadolint.Rules (Metadata (..), RuleCheck (..))
-import ShellCheck.Interface
+import Hadolint.Rules (Metadata (..), RuleCheck (..), DLSeverity (..))
 import Text.Megaparsec (TraversableStream)
 import Text.Megaparsec.Error
 import Text.Megaparsec.Pos (sourceColumn, sourceLine, sourceName, unPos)
@@ -37,7 +35,7 @@ instance (VisualStream s, TraversableStream s, ShowErrorComponent e) => ToJSON (
       [ "file" .= sourceName pos,
         "line" .= unPos (sourceLine pos),
         "column" .= unPos (sourceColumn pos),
-        "level" .= severityText ErrorC,
+        "level" .= severityText DLErrorC,
         "code" .= ("DL1000" :: String),
         "message" .= errorBundlePretty err
       ]

--- a/src/Hadolint/Formatter/TTY.hs
+++ b/src/Hadolint/Formatter/TTY.hs
@@ -9,12 +9,10 @@ module Hadolint.Formatter.TTY
 where
 
 import Colourista
-import Data.Semigroup ((<>))
 import qualified Data.Text as Text
 import Hadolint.Formatter.Format
 import Hadolint.Rules
 import Language.Docker.Syntax
-import ShellCheck.Interface (Severity (..))
 import Text.Megaparsec (TraversableStream)
 import Text.Megaparsec.Error
 import Text.Megaparsec.Stream (VisualStream)
@@ -46,10 +44,11 @@ printResult Result {errors, checks} color = printErrors >> printChecks
     printErrors = mapM_ putStrLn (formatErrors errors)
     printChecks = mapM_ (putStrLn . Text.unpack) (formatChecks checks color)
 
-colorizedSeverity :: Severity -> Text.Text
+colorizedSeverity :: DLSeverity -> Text.Text
 colorizedSeverity s =
   case s of
-    ErrorC -> Text.pack $ formatWith [bold, red] $ severityText s
-    WarningC -> Text.pack $ formatWith [bold, yellow] $ severityText s
-    InfoC -> Text.pack $ formatWith [green] $ severityText s
-    StyleC -> Text.pack $ formatWith [cyan] $ severityText s
+    DLErrorC -> Text.pack $ formatWith [bold, red] $ severityText s
+    DLWarningC -> Text.pack $ formatWith [bold, yellow] $ severityText s
+    DLInfoC -> Text.pack $ formatWith [green] $ severityText s
+    DLStyleC -> Text.pack $ formatWith [cyan] $ severityText s
+    _ -> Text.pack $ severityText s

--- a/src/Hadolint/Rules.hs
+++ b/src/Hadolint/Rules.hs
@@ -1,15 +1,18 @@
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE DeriveGeneric, DeriveAnyClass #-}
 
 module Hadolint.Rules where
 
 import Control.Arrow ((&&&))
+import Control.DeepSeq (NFData)
 import Data.List (foldl', isInfixOf, isPrefixOf, mapAccumL, nub)
 import Data.List.NonEmpty (toList)
 import qualified Data.Map as Map
 import qualified Data.Set as Set
 import qualified Data.Text as Text
 import Data.Void (Void)
+import GHC.Generics (Generic)
 import qualified Hadolint.Shell as Shell
 import Language.Docker.Syntax
 import ShellCheck.Interface (Severity (..))
@@ -17,9 +20,17 @@ import qualified ShellCheck.Interface
 import qualified Text.Megaparsec as Megaparsec
 import qualified Text.Megaparsec.Char as Megaparsec
 
+
+data DLSeverity = DLErrorC
+                | DLWarningC
+                | DLInfoC
+                | DLStyleC
+                | DLIgnoreC
+  deriving (Show, Eq, Ord, Generic, NFData)
+
 data Metadata = Metadata
   { code :: Text.Text,
-    severity :: Severity,
+    severity :: DLSeverity,
     message :: Text.Text
   }
   deriving (Eq, Show)
@@ -106,18 +117,18 @@ mapInstructions f initialState dockerfile =
        in (newState, [RuleCheck m source linenumber False | m <- res])
 
 instructionRule ::
-  Text.Text -> Severity -> Text.Text -> (Instruction Shell.ParsedShell -> Bool) -> Rule
+  Text.Text -> DLSeverity -> Text.Text -> (Instruction Shell.ParsedShell -> Bool) -> Rule
 instructionRule code severity message check =
   instructionRuleLine code severity message (const check)
 
-instructionRuleLine :: Text.Text -> Severity -> Text.Text -> SimpleCheckerWithLine -> Rule
+instructionRuleLine :: Text.Text -> DLSeverity -> Text.Text -> SimpleCheckerWithLine -> Rule
 instructionRuleLine code severity message check =
   instructionRuleState code severity message checkAndDropState ()
   where
     checkAndDropState state line instr = (state, check line instr)
 
 instructionRuleState ::
-  Text.Text -> Severity -> Text.Text -> SimpleCheckerWithState state -> state -> Rule
+  Text.Text -> DLSeverity -> Text.Text -> SimpleCheckerWithState state -> state -> Rule
 instructionRuleState code severity message f = mapInstructions constMetadataCheck
   where
     meta = Metadata code severity message
@@ -284,8 +295,15 @@ shellcheck = mapInstructions check Shell.defaultShellOpts
 -- | Converts ShellCheck errors into our own errors type
 commentMetadata :: ShellCheck.Interface.PositionedComment -> Metadata
 commentMetadata c =
-  Metadata (Text.pack ("SC" ++ show (code c))) (severity c) (Text.pack (message c))
+  Metadata (Text.pack ("SC" ++ show (code c))) (getDLSeverity $ severity c) (Text.pack (message c))
   where
+    getDLSeverity :: Severity -> DLSeverity
+    getDLSeverity s =
+      case s of
+        WarningC -> DLWarningC
+        InfoC -> DLInfoC
+        StyleC -> DLStyleC
+        _ -> DLErrorC
     severity pc = ShellCheck.Interface.cSeverity $ ShellCheck.Interface.pcComment pc
     code pc = ShellCheck.Interface.cCode $ ShellCheck.Interface.pcComment pc
     message pc = ShellCheck.Interface.cMessage $ ShellCheck.Interface.pcComment pc
@@ -294,7 +312,7 @@ absoluteWorkdir :: Rule
 absoluteWorkdir = instructionRule code severity message check
   where
     code = "DL3000"
-    severity = ErrorC
+    severity = DLErrorC
     message = "Use absolute WORKDIR"
     check (Workdir loc)
       | "$" `Text.isPrefixOf` Text.dropAround dropQuotes loc = True
@@ -310,7 +328,7 @@ hasNoMaintainer :: Rule
 hasNoMaintainer = instructionRule code severity message check
   where
     code = "DL4000"
-    severity = ErrorC
+    severity = DLErrorC
     message = "MAINTAINER is deprecated"
     check (Maintainer _) = False
     check _ = True
@@ -323,7 +341,7 @@ multipleCmds :: Rule
 multipleCmds = instructionRuleState code severity message check False
   where
     code = "DL4003"
-    severity = WarningC
+    severity = DLWarningC
     message =
       "Multiple `CMD` instructions found. If you list more than one `CMD` then only the last \
       \`CMD` will take effect"
@@ -335,7 +353,7 @@ multipleEntrypoints :: Rule
 multipleEntrypoints = instructionRuleState code severity message check False
   where
     code = "DL4004"
-    severity = ErrorC
+    severity = DLErrorC
     message =
       "Multiple `ENTRYPOINT` instructions found. If you list more than one `ENTRYPOINT` then \
       \only the last `ENTRYPOINT` will take effect"
@@ -348,7 +366,7 @@ wgetOrCurl :: Rule
 wgetOrCurl = instructionRuleState code severity message check Set.empty
   where
     code = "DL4001"
-    severity = WarningC
+    severity = DLWarningC
     message = "Either use Wget or Curl but not both"
     check state _ (Run (RunArgs args _)) = argumentsRule (detectDoubleUsage state) args
     check _ _ (From _) = withState Set.empty True -- Reset the state for each stage
@@ -364,7 +382,7 @@ invalidCmd :: Rule
 invalidCmd = instructionRule code severity message check
   where
     code = "DL3001"
-    severity = InfoC
+    severity = DLInfoC
     message =
       "For some bash commands it makes no sense running them in a Docker container like `ssh`, \
       \`vim`, `shutdown`, `service`, `ps`, `free`, `top`, `kill`, `mount`, `ifconfig`"
@@ -377,7 +395,7 @@ noRootUser :: Rule
 noRootUser dockerfile = instructionRuleState code severity message check Nothing dockerfile
   where
     code = "DL3002"
-    severity = WarningC
+    severity = DLWarningC
     message = "Last USER should not be root"
     check _ _ (From from) = withState (Just from) True -- Remember the last FROM instruction found
     check st@(Just from) line (User user)
@@ -410,7 +428,7 @@ noCd :: Rule
 noCd = instructionRule code severity message check
   where
     code = "DL3003"
-    severity = WarningC
+    severity = DLWarningC
     message = "Use WORKDIR to switch to a directory"
     check (Run (RunArgs args _)) = argumentsRule (not . usingProgram "cd") args
     check _ = True
@@ -419,7 +437,7 @@ noSudo :: Rule
 noSudo = instructionRule code severity message check
   where
     code = "DL3004"
-    severity = ErrorC
+    severity = DLErrorC
     message =
       "Do not use sudo as it leads to unpredictable behavior. Use a tool like gosu to enforce \
       \root"
@@ -430,7 +448,7 @@ noAptGetUpgrade :: Rule
 noAptGetUpgrade = instructionRule code severity message check
   where
     code = "DL3005"
-    severity = ErrorC
+    severity = DLErrorC
     message = "Do not use apt-get upgrade or dist-upgrade"
     check (Run (RunArgs args _)) =
       argumentsRule (Shell.noCommands (Shell.cmdHasArgs "apt-get" ["upgrade", "dist-upgrade"])) args
@@ -440,7 +458,7 @@ noUntagged :: Rule
 noUntagged dockerfile = instructionRuleLine code severity message check dockerfile
   where
     code = "DL3006"
-    severity = WarningC
+    severity = DLWarningC
     message = "Always tag the version of an image explicitly"
     check _ (From BaseImage {image = (Image _ "scratch")}) = True
     check _ (From BaseImage {digest = Just _}) = True
@@ -452,7 +470,7 @@ noLatestTag :: Rule
 noLatestTag = instructionRule code severity message check
   where
     code = "DL3007"
-    severity = WarningC
+    severity = DLWarningC
     message =
       "Using latest is prone to errors if the image will ever update. Pin the version explicitly \
       \to a release tag"
@@ -463,7 +481,7 @@ aptGetVersionPinned :: Rule
 aptGetVersionPinned = instructionRule code severity message check
   where
     code = "DL3008"
-    severity = WarningC
+    severity = DLWarningC
     message =
       "Pin versions in apt get install. Instead of `apt-get install <package>` use `apt-get \
       \install <package>=<version>`"
@@ -486,7 +504,7 @@ aptGetCleanup :: Rule
 aptGetCleanup dockerfile = instructionRuleState code severity message check Nothing dockerfile
   where
     code = "DL3009"
-    severity = InfoC
+    severity = DLInfoC
     message = "Delete the apt-get lists after installing something"
 
     check _ line f@(From _) = withState (Just (line, f)) True -- Remember the last FROM instruction found
@@ -516,7 +534,7 @@ noApkUpgrade :: Rule
 noApkUpgrade = instructionRule code severity message check
   where
     code = "DL3017"
-    severity = ErrorC
+    severity = DLErrorC
     message = "Do not use apk upgrade"
     check (Run (RunArgs args _)) = argumentsRule (Shell.noCommands (Shell.cmdHasArgs "apk" ["upgrade"])) args
     check _ = True
@@ -525,7 +543,7 @@ apkAddVersionPinned :: Rule
 apkAddVersionPinned = instructionRule code severity message check
   where
     code = "DL3018"
-    severity = WarningC
+    severity = DLWarningC
     message =
       "Pin versions in apk add. Instead of `apk add <package>` use `apk add <package>=<version>`"
     check (Run (RunArgs args _)) = argumentsRule (\as -> and [versionFixed p | p <- apkAddPackages as]) args
@@ -547,7 +565,7 @@ apkAddNoCache :: Rule
 apkAddNoCache = instructionRule code severity message check
   where
     code = "DL3019"
-    severity = InfoC
+    severity = DLInfoC
     message =
       "Use the `--no-cache` switch to avoid the need to use `--update` and remove \
       \`/var/cache/apk/*` when done installing packages"
@@ -559,7 +577,7 @@ useAdd :: Rule
 useAdd = instructionRule code severity message check
   where
     code = "DL3010"
-    severity = InfoC
+    severity = DLInfoC
     message = "Use ADD for extracting archives into an image"
     check (Copy (CopyArgs srcs _ _ _)) =
       and
@@ -590,7 +608,7 @@ invalidPort :: Rule
 invalidPort = instructionRule code severity message check
   where
     code = "DL3011"
-    severity = ErrorC
+    severity = DLErrorC
     message = "Valid UNIX ports range from 0 to 65535"
     check (Expose (Ports ports)) =
       and [p <= 65535 | Port p _ <- ports]
@@ -601,7 +619,7 @@ pipVersionPinned :: Rule
 pipVersionPinned = instructionRule code severity message check
   where
     code = "DL3013"
-    severity = WarningC
+    severity = DLWarningC
     message =
       "Pin versions in pip. Instead of `pip install <package>` use `pip install \
       \<package>==<version>` or `pip install --requirement <requirements file>`"
@@ -672,7 +690,7 @@ npmVersionPinned :: Rule
 npmVersionPinned = instructionRule code severity message check
   where
     code = "DL3016"
-    severity = WarningC
+    severity = DLWarningC
     message =
       "Pin versions in npm. Instead of `npm install <package>` use `npm install \
       \<package>@<version>`"
@@ -706,7 +724,7 @@ aptGetYes :: Rule
 aptGetYes = instructionRule code severity message check
   where
     code = "DL3014"
-    severity = WarningC
+    severity = DLWarningC
     message = "Use the `-y` switch to avoid manual input `apt-get -y install <package>`"
     check (Run (RunArgs args _)) = argumentsRule (Shell.noCommands forgotAptYesOption) args
     check _ = True
@@ -718,7 +736,7 @@ aptGetNoRecommends :: Rule
 aptGetNoRecommends = instructionRule code severity message check
   where
     code = "DL3015"
-    severity = InfoC
+    severity = DLInfoC
     message = "Avoid additional packages by specifying `--no-install-recommends`"
     check (Run (RunArgs args _)) = argumentsRule (Shell.noCommands forgotNoInstallRecommends) args
     check _ = True
@@ -759,7 +777,7 @@ copyInsteadAdd :: Rule
 copyInsteadAdd = instructionRule code severity message check
   where
     code = "DL3020"
-    severity = ErrorC
+    severity = DLErrorC
     message = "Use COPY instead of ADD for files and folders"
     check (Add (AddArgs srcs _ _)) =
       and [isArchive src || isUrl src | SourcePath src <- toList srcs]
@@ -769,7 +787,7 @@ copyEndingSlash :: Rule
 copyEndingSlash = instructionRule code severity message check
   where
     code = "DL3021"
-    severity = ErrorC
+    severity = DLErrorC
     message = "COPY with more than 2 arguments requires the last argument to end with /"
     check (Copy (CopyArgs sources t _ _))
       | length sources > 1 = endsWithSlash t
@@ -781,7 +799,7 @@ copyFromExists :: Rule
 copyFromExists dockerfile = instructionRuleLine code severity message check dockerfile
   where
     code = "DL3022"
-    severity = WarningC
+    severity = DLWarningC
     message = "COPY --from should reference a previously defined FROM alias"
     check l (Copy (CopyArgs _ _ _ (CopySource s))) = s `elem` previouslyDefinedAliases l dockerfile
     check _ _ = True
@@ -790,7 +808,7 @@ copyFromAnother :: Rule
 copyFromAnother = instructionRuleState code severity message check Nothing
   where
     code = "DL3023"
-    severity = ErrorC
+    severity = DLErrorC
     message = "COPY --from should reference a previously defined FROM alias"
 
     check _ _ f@(From _) = withState (Just f) True -- Remember the last FROM instruction found
@@ -802,7 +820,7 @@ fromAliasUnique :: Rule
 fromAliasUnique dockerfile = instructionRuleLine code severity message check dockerfile
   where
     code = "DL3024"
-    severity = ErrorC
+    severity = DLErrorC
     message = "FROM aliases (stage names) must be unique"
     check line = aliasMustBe (not . alreadyTaken line)
     alreadyTaken line alias = alias `elem` previouslyDefinedAliases line dockerfile
@@ -811,7 +829,7 @@ useShell :: Rule
 useShell = instructionRule code severity message check
   where
     code = "DL4005"
-    severity = WarningC
+    severity = DLWarningC
     message = "Use SHELL to change the default shell"
     check (Run (RunArgs args _)) = argumentsRule (Shell.noCommands (Shell.cmdHasArgs "ln" ["/bin/sh"])) args
     check _ = True
@@ -820,7 +838,7 @@ useJsonArgs :: Rule
 useJsonArgs = instructionRule code severity message check
   where
     code = "DL3025"
-    severity = WarningC
+    severity = DLWarningC
     message = "Use arguments JSON notation for CMD and ENTRYPOINT arguments"
     check (Cmd (ArgumentsText _)) = False
     check (Entrypoint (ArgumentsText _)) = False
@@ -830,7 +848,7 @@ noApt :: Rule
 noApt = instructionRule code severity message check
   where
     code = "DL3027"
-    severity = WarningC
+    severity = DLWarningC
     message =
       "Do not use apt as it is meant to be a end-user tool, use apt-get or apt-cache instead"
     check (Run (RunArgs args _)) = argumentsRule (not . usingProgram "apt") args
@@ -840,7 +858,7 @@ usePipefail :: Rule
 usePipefail = instructionRuleState code severity message check False
   where
     code = "DL4006"
-    severity = WarningC
+    severity = DLWarningC
     message =
       "Set the SHELL option -o pipefail before RUN with a pipe in it. If you are using \
       \/bin/sh in an alpine image or if your shell is symlinked to busybox then consider \
@@ -869,7 +887,7 @@ registryIsAllowed :: Set.Set Registry -> Rule
 registryIsAllowed allowed = instructionRuleState code severity message check Set.empty
   where
     code = "DL3026"
-    severity = ErrorC
+    severity = DLErrorC
     message = "Use only an allowed registry in the FROM image"
     check st _ (From BaseImage {image, alias}) = withState (Set.insert alias st) (doCheck st image)
     check st _ _ = (st, True)
@@ -886,7 +904,7 @@ gemVersionPinned :: Rule
 gemVersionPinned = instructionRule code severity message check
   where
     code = "DL3028"
-    severity = WarningC
+    severity = DLWarningC
     message =
       "Pin versions in gem install. Instead of `gem install <gem>` use `gem \
       \install <gem>:<version>`"
@@ -898,7 +916,7 @@ noPlatformFlag :: Rule
 noPlatformFlag = instructionRule code severity message check
   where
     code = "DL3029"
-    severity = WarningC
+    severity = DLWarningC
     message = "Do not use --platform flag with FROM"
     check (From BaseImage {platform = Just p}) = p == ""
     check _ = True
@@ -907,7 +925,7 @@ yumYes :: Rule
 yumYes = instructionRule code severity message check
   where
     code = "DL3030"
-    severity = WarningC
+    severity = DLWarningC
     message = "Use the -y switch to avoid manual input `yum install -y <package`"
     check (Run (RunArgs args _)) = argumentsRule (Shell.noCommands forgotYumYesOption) args
     check _ = True
@@ -919,7 +937,7 @@ noYumUpdate :: Rule
 noYumUpdate = instructionRule code severity message check
   where
     code = "DL3031"
-    severity = ErrorC
+    severity = DLErrorC
     message = "Do not use yum update."
     check (Run (RunArgs args _)) =
       argumentsRule
@@ -940,7 +958,7 @@ yumCleanup :: Rule
 yumCleanup = instructionRule code severity message check
   where
     code = "DL3032"
-    severity = WarningC
+    severity = DLWarningC
     message = "`yum clean all` missing after yum command."
     check (Run (RunArgs args _)) =
       argumentsRule (Shell.noCommands yumInstall) args
@@ -955,7 +973,7 @@ yumVersionPinned :: Rule
 yumVersionPinned = instructionRule code severity message check
   where
     code = "DL3033"
-    severity = WarningC
+    severity = DLWarningC
     message = "Specify version with `yum install -y <package>-<version>`."
     check (Run (RunArgs args _)) = argumentsRule (all versionFixed . yumPackages) args
     check _ = True
@@ -972,7 +990,7 @@ zypperYes :: Rule
 zypperYes = instructionRule code severity message check
   where
     code = "DL3034"
-    severity = WarningC
+    severity = DLWarningC
     message = "Non-interactive switch missing from `zypper` command: `zypper install -y`"
     check (Run (RunArgs args _)) = argumentsRule (Shell.noCommands forgotZypperYesOption) args
     check _ = True
@@ -994,7 +1012,7 @@ noZypperUpdate :: Rule
 noZypperUpdate = instructionRule code severity message check
   where
     code = "DL3035"
-    severity = WarningC
+    severity = DLWarningC
     message = "Do not use `zypper update`."
     check (Run (RunArgs args _)) =
       argumentsRule
@@ -1015,7 +1033,7 @@ zypperCleanup :: Rule
 zypperCleanup = instructionRule code severity message check
   where
     code = "DL3036"
-    severity = WarningC
+    severity = DLWarningC
     message = "`zypper clean` missing after zypper use."
     check (Run (RunArgs args _)) =
       argumentsRule (Shell.noCommands zypperInstall) args
@@ -1030,7 +1048,7 @@ zypperVersionPinned :: Rule
 zypperVersionPinned = instructionRule code severity message check
   where
     code = "DL3037"
-    severity = WarningC
+    severity = DLWarningC
     message = "Specify version with `zypper install -y <package>=<version>`."
     check (Run (RunArgs args _)) = argumentsRule (all versionFixed . zypperPackages) args
     check _ = True
@@ -1052,7 +1070,7 @@ dnfYes :: Rule
 dnfYes = instructionRule code severity message check
   where
     code = "DL3038"
-    severity = WarningC
+    severity = DLWarningC
     message = "Use the -y switch to avoid manual input `dnf install -y <package`"
     check (Run (RunArgs args _)) = argumentsRule (Shell.noCommands forgotDnfYesOption) args
     check _ = True
@@ -1064,7 +1082,7 @@ noDnfUpdate :: Rule
 noDnfUpdate = instructionRule code severity message check
   where
     code = "DL3039"
-    severity = ErrorC
+    severity = DLErrorC
     message = "Do not use dnf update."
     check (Run (RunArgs args _)) =
       argumentsRule
@@ -1083,7 +1101,7 @@ dnfCleanup :: Rule
 dnfCleanup = instructionRule code severity message check
   where
     code = "DL3040"
-    severity = WarningC
+    severity = DLWarningC
     message = "`dnf clean all` missing after dnf command."
     check (Run (RunArgs args _)) =
       argumentsRule (Shell.noCommands dnfInstall) args
@@ -1098,7 +1116,7 @@ dnfVersionPinned :: Rule
 dnfVersionPinned = instructionRule code severity message check
   where
     code = "DL3041"
-    severity = WarningC
+    severity = DLWarningC
     message = "Specify version with `dnf install -y <package>-<version>`."
     check (Run (RunArgs args _)) = argumentsRule (all versionFixed . dnfPackages) args
     check _ = True
@@ -1115,7 +1133,7 @@ pipNoCacheDir :: Rule
 pipNoCacheDir = instructionRule code severity message check
   where
     code = "DL3042"
-    severity = WarningC
+    severity = DLWarningC
     message =
       "Avoid use of cache directory with pip. Use `pip install --no-cache-dir <package>`"
     check (Run (RunArgs args _)) = argumentsRule (Shell.noCommands forgotNoCacheDir) args
@@ -1158,7 +1176,7 @@ noIllegalInstructionInOnbuild :: Rule
 noIllegalInstructionInOnbuild = instructionRule code severity message check
   where
     code = "DL3043"
-    severity = ErrorC
+    severity = DLErrorC
     message = "`ONBUILD`, `FROM` or `MAINTAINER` triggered from within `ONBUILD` instruction."
     check (OnBuild (OnBuild _)) = False
     check (OnBuild (From _)) = False

--- a/src/Hadolint/Shell.hs
+++ b/src/Hadolint/Shell.hs
@@ -8,7 +8,6 @@ module Hadolint.Shell where
 import Control.Monad.Writer (Writer, execWriter, tell)
 import Data.Functor.Identity (runIdentity)
 import Data.Maybe (listToMaybe, mapMaybe)
-import Data.Semigroup ((<>))
 import qualified Data.Set as Set
 import Data.Text (Text)
 import qualified Data.Text as Text

--- a/test/ConfigSpec.hs
+++ b/test/ConfigSpec.hs
@@ -12,13 +12,57 @@ import Test.Hspec
 tests :: SpecWith ()
 tests =
   describe "Config" $ do
+    it "Parses config with only error severities" $
+      let configFile =
+            [ "override:",
+              "  error:",
+              "    - DL3000",
+              "    - SC1010"
+            ]
+          override = Just (OverrideConfig (Just ["DL3000", "SC1010"]) Nothing Nothing Nothing)
+          expected = ConfigFile override Nothing Nothing
+       in assertConfig expected (Bytes.unlines configFile)
+
+    it "Parses config with only warning severities" $
+      let configFile =
+            [ "override:",
+              "  warning:",
+              "    - DL3000",
+              "    - SC1010"
+            ]
+          override = Just (OverrideConfig Nothing (Just ["DL3000", "SC1010"]) Nothing Nothing)
+          expected = ConfigFile override Nothing Nothing
+       in assertConfig expected (Bytes.unlines configFile)
+
+    it "Parses config with only info severities" $
+      let configFile =
+            [ "override:",
+              "  info:",
+              "    - DL3000",
+              "    - SC1010"
+            ]
+          override = Just (OverrideConfig Nothing Nothing (Just ["DL3000", "SC1010"]) Nothing)
+          expected = ConfigFile override Nothing Nothing
+       in assertConfig expected (Bytes.unlines configFile)
+
+    it "Parses config with only style severities" $
+      let configFile =
+            [ "override:",
+              "  style:",
+              "    - DL3000",
+              "    - SC1010"
+            ]
+          override = Just (OverrideConfig Nothing Nothing Nothing (Just ["DL3000", "SC1010"]))
+          expected = ConfigFile override Nothing Nothing
+       in assertConfig expected (Bytes.unlines configFile)
+
     it "Parses config with only ignores" $
       let configFile =
             [ "ignored:",
               "- DL3000",
               "- SC1010"
             ]
-          expected = ConfigFile (Just ["DL3000", "SC1010"]) Nothing
+          expected = ConfigFile Nothing (Just ["DL3000", "SC1010"]) Nothing
        in assertConfig expected (Bytes.unlines configFile)
 
     it "Parses config with only trustedRegistries" $
@@ -27,18 +71,29 @@ tests =
               "- hub.docker.com",
               "- my.shady.xyz"
             ]
-          expected = ConfigFile Nothing (Just ["hub.docker.com", "my.shady.xyz"])
+          expected = ConfigFile Nothing Nothing (Just ["hub.docker.com", "my.shady.xyz"])
        in assertConfig expected (Bytes.unlines configFile)
 
     it "Parses full file" $
       let configFile =
-            [ "trustedRegistries:",
+            [ "override:",
+              "  info:",
+              "    - DL3002",
+              "  style:",
+              "    - DL3004",
+              "  warning:",
+              "    - DL3003",
+              "  error:",
+              "    - DL3001",
+              "",
+              "trustedRegistries:",
               "- hub.docker.com",
               "",
               "ignored:",
               "- DL3000"
             ]
-          expected = ConfigFile (Just ["DL3000"]) (Just ["hub.docker.com"])
+          override = Just (OverrideConfig (Just ["DL3001"]) (Just ["DL3003"]) (Just ["DL3002"]) (Just ["DL3004"]))
+          expected = ConfigFile override (Just ["DL3000"]) (Just ["hub.docker.com"])
        in assertConfig expected (Bytes.unlines configFile)
 
 assertConfig :: HasCallStack => ConfigFile -> Bytes.ByteString -> Assertion

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -3,7 +3,6 @@
 
 import qualified ConfigSpec
 import Control.Monad (unless, when)
-import Data.Semigroup ((<>))
 import qualified Data.Text as Text
 import Hadolint.Formatter.TTY (formatChecks, formatError)
 import Hadolint.Rules


### PR DESCRIPTION
- Make rule severity overridable with any other severity.
- Remove unnecessary imports

This feature is implemented with a custom rule severity type
`DLSeverity` which encapsulates the possible severities, including the
possibility that a rule is ignored by default.

### What I did
The is my second attempt at the long requested feature of customizable rule severeties.

It is an alternative implementation of the customizable rule severities, without using a `Maybe Severity`. Instead this is implemented with a custom `DLSeverity` type. This also is not intermingled with another different feature, which should make reviewing much easier. That said, it is missing an example of an opt-in rule.

The `DLSeverity` type is constructed analogous to the `Severity` type from `Shellcheck`, which was used before. This achieves an easy mapping of `Severity` types to `DLSeverity` types.

If this is a preferred implementation over the one included in https://github.com/hadolint/hadolint/pull/491, then I will abandon that PR and rebase the healthcheck rules onto this. I will also update this PR with updated documentation, if the code itself becomes a candidate for merging.

Just like in PR #491, the format of the config file looks like this:
```yaml
override:
  error:
    - DLXXXX
  warning:
    - DLYYYY
  info:
    - DLAAAA
  style:
    - DLBBBB

ignored:
  - DLZZZZ
```

The commandline syntax would be like so:
```
$ hadolint --ignore=DLXXXX --error=DLYYYY --style=DLZZZZ --info=DLAAAA --warning=DLBBBB Dockerfile
```