### PR TITLE
feature: colorize TTY output  #267

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -43,6 +43,7 @@ import System.Exit (exitFailure, exitSuccess)
 data CommandOptions = CommandOptions
   { showVersion :: Bool,
     noFail :: Bool,
+    color :: Bool,
     configFile :: Maybe FilePath,
     format :: Hadolint.OutputFormat,
     dockerfiles :: [String],
@@ -71,6 +72,7 @@ parseOptions =
   CommandOptions
     <$> version -- CLI options parser definition
     <*> noFail
+    <*> color
     <*> configFile
     <*> outputFormat
     <*> files
@@ -79,6 +81,8 @@ parseOptions =
     version = switch (long "version" <> short 'v' <> help "Show version")
 
     noFail = switch (long "no-fail" <> help "Don't exit with a failure status code when any rule is violated")
+
+    color = switch (long "color" <> help "Colorize output")
 
     configFile =
       optional
@@ -137,7 +141,7 @@ exitProgram cmd res
 runLint :: CommandOptions -> Hadolint.LintOptions -> NonEmpty.NonEmpty String -> IO()
 runLint cmd conf files = do
   res <-  Hadolint.lint conf files
-  Hadolint.printResults (format cmd) res
+  Hadolint.printResults (format cmd) (color cmd) res
   exitProgram cmd res
 
 main :: IO ()

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -13,6 +13,7 @@ import Data.String (IsString (fromString))
 import qualified Data.Version
 import qualified Development.GitRev
 import qualified Hadolint
+import Data.Maybe
 import Options.Applicative
   ( Parser,
     action,
@@ -38,12 +39,13 @@ import Options.Applicative
   )
 -- version from hadolint.cabal file
 import qualified Paths_hadolint as Meta
+import System.Environment
 import System.Exit (exitFailure, exitSuccess)
 
 data CommandOptions = CommandOptions
   { showVersion :: Bool,
     noFail :: Bool,
-    color :: Bool,
+    nocolor :: Bool,
     configFile :: Maybe FilePath,
     format :: Hadolint.OutputFormat,
     dockerfiles :: [String],
@@ -72,7 +74,7 @@ parseOptions =
   CommandOptions
     <$> version -- CLI options parser definition
     <*> noFail
-    <*> color
+    <*> nocolor
     <*> configFile
     <*> outputFormat
     <*> files
@@ -82,7 +84,7 @@ parseOptions =
 
     noFail = switch (long "no-fail" <> help "Don't exit with a failure status code when any rule is violated")
 
-    color = switch (long "color" <> help "Colorize output")
+    nocolor = switch (long "no-color" <> help "Don't colorize output")
 
     configFile =
       optional
@@ -141,7 +143,9 @@ exitProgram cmd res
 runLint :: CommandOptions -> Hadolint.LintOptions -> NonEmpty.NonEmpty String -> IO()
 runLint cmd conf files = do
   res <-  Hadolint.lint conf files
-  Hadolint.printResults (format cmd) (color cmd) res
+  noColorEnv <- lookupEnv "NO_COLOR"
+  let noColor = nocolor cmd || isJust noColorEnv
+  Hadolint.printResults (format cmd) noColor res
   exitProgram cmd res
 
 main :: IO ()

--- a/hadolint.cabal
+++ b/hadolint.cabal
@@ -4,7 +4,7 @@ cabal-version: 2.0
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: b62585868ea4e7cd1b565df9b434889d4b50d5a74d5984ceecc46973f5b2e1d9
+-- hash: 57c29478859116ae6879a5ab2dcdfe0ebb3703d11e66b4cba9af307566bdf072
 
 name:           hadolint
 version:        1.22.1
@@ -57,6 +57,7 @@ library
     , async
     , base >=4.8 && <5
     , bytestring
+    , colourista
     , containers
     , cryptonite
     , directory >=1.3.0

--- a/package.yaml
+++ b/package.yaml
@@ -31,21 +31,22 @@ library:
   generated-other-modules:
     - Paths_hadolint
   dependencies:
+    - &ShellCheck ShellCheck >=0.7.1
     - &bytestring bytestring >=0.10
     - &split split >=0.2
-    - &ShellCheck ShellCheck >=0.7.1
-    - aeson
-    - text
-    - bytestring
-    - containers
-    - void
-    - mtl
     - HsYAML
-    - filepath
-    - directory >= 1.3.0
+    - aeson
     - async
-    - parallel
+    - bytestring
+    - colourista
+    - containers
     - cryptonite
+    - directory >= 1.3.0
+    - filepath
+    - mtl
+    - parallel
+    - text
+    - void
 executables:
   hadolint:
     main: Main.hs

--- a/src/Hadolint/Formatter/TTY.hs
+++ b/src/Hadolint/Formatter/TTY.hs
@@ -13,6 +13,7 @@ import qualified Data.Text as Text
 import Hadolint.Formatter.Format
 import Hadolint.Rules
 import Language.Docker.Syntax
+import ShellCheck.Interface (Severity (..))
 import Text.Megaparsec (TraversableStream)
 import Text.Megaparsec.Error
 import Text.Megaparsec.Stream (VisualStream)
@@ -23,17 +24,35 @@ formatErrors = fmap formatError
 formatError :: (VisualStream s, TraversableStream s, ShowErrorComponent e) => ParseErrorBundle s e -> String
 formatError err = stripNewlines (errorMessageLine err)
 
-formatChecks :: Functor f => f RuleCheck -> f Text.Text
-formatChecks = fmap formatCheck
+formatChecks :: Functor f => f RuleCheck -> Bool -> f Text.Text
+formatChecks rc color = fmap formatCheck rc
   where
     formatCheck (RuleCheck meta source line _) =
-      formatPos source line <> code meta <> " " <> Text.pack (severityText (severity meta)) <> ": " <> message meta
+      formatPos source line
+          <> code meta
+          <> " "
+          <> (if color then Text.pack (colorFromSeverity (severity meta)) else "")
+          <> Text.pack (severityText (severity meta))
+          <> (if color then Text.pack (ansi 0) else "")
+          <> ": "
+          <> message meta
 
 formatPos :: Filename -> Linenumber -> Text.Text
 formatPos source line = source <> ":" <> Text.pack (show line) <> " "
 
-printResult :: (VisualStream s, TraversableStream s, ShowErrorComponent e) => Result s e -> IO ()
-printResult Result {errors, checks} = printErrors >> printChecks
+printResult :: (VisualStream s, TraversableStream s, ShowErrorComponent e) => Result s e -> Bool -> IO ()
+printResult Result {errors, checks} color = printErrors >> printChecks
   where
     printErrors = mapM_ putStrLn (formatErrors errors)
-    printChecks = mapM_ (putStrLn . Text.unpack) (formatChecks checks)
+    printChecks = mapM_ (putStrLn . Text.unpack) (formatChecks checks color)
+
+colorFromSeverity :: Severity -> String
+colorFromSeverity s =
+  case s of
+    ErrorC -> ansi 1 ++ ansi 31    -- bold red
+    WarningC -> ansi 1 ++ ansi 33  -- bold yellow
+    InfoC -> ansi 32               -- green
+    StyleC  -> ansi 36             -- cyan
+
+ansi :: Int -> String
+ansi n = "\x1B[" ++ show n ++ "m"

--- a/src/Hadolint/Lint.hs
+++ b/src/Hadolint/Lint.hs
@@ -37,10 +37,10 @@ data OutputFormat
   | Codacy
   deriving (Show, Eq)
 
-printResults :: OutputFormat -> Format.Result Text DockerfileError -> IO ()
-printResults format allResults = do
+printResults :: OutputFormat -> Bool -> Format.Result Text DockerfileError -> IO ()
+printResults format color allResults =
   case format of
-    TTY -> TTY.printResult allResults
+    TTY -> TTY.printResult allResults color
     Json -> Json.printResult allResults
     Checkstyle -> Checkstyle.printResult allResults
     CodeclimateJson -> Codeclimate.printResult allResults

--- a/src/Hadolint/Lint.hs
+++ b/src/Hadolint/Lint.hs
@@ -38,9 +38,9 @@ data OutputFormat
   deriving (Show, Eq)
 
 printResults :: OutputFormat -> Bool -> Format.Result Text DockerfileError -> IO ()
-printResults format color allResults =
+printResults format nocolor allResults =
   case format of
-    TTY -> TTY.printResult allResults color
+    TTY -> TTY.printResult allResults nocolor
     Json -> Json.printResult allResults
     Checkstyle -> Checkstyle.printResult allResults
     CodeclimateJson -> Codeclimate.printResult allResults

--- a/stack.yaml
+++ b/stack.yaml
@@ -4,8 +4,9 @@ packages:
   - .
 resolver: lts-16.18
 extra-deps:
-  - megaparsec-9.0.0@sha256:920d1e469056c746b532333a078c2a9a195fab5e860e0c9734ee92a28c2bfb65,3117
   - ShellCheck-0.7.1@sha256:94a6ee5a38e2668204bc95fdc7539a9a4ca7230984157694409444530c23b5a4,3170
+  - colourista-0.1.0.0
   - language-docker-9.1.2
+  - megaparsec-9.0.0@sha256:920d1e469056c746b532333a078c2a9a195fab5e860e0c9734ee92a28c2bfb65,3117
 ghc-options:
   "$everything": -haddock

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -1471,7 +1471,7 @@ onBuildRuleCatches rule s = assertOnBuildChecks rule s f
   where
     f checks = do
       when (length checks /= 1) $
-        assertFailure (Text.unpack . Text.unlines . formatChecks $ checks)
+        assertFailure (Text.unpack . Text.unlines . formatChecksNoColor $ checks)
       assertBool "Incorrect line number for result" $ null $ selectChecksWithLines checks
 
 ruleCatchesNot :: HasCallStack => Rule -> Text.Text -> Assertion
@@ -1481,7 +1481,7 @@ ruleCatchesNot rule s = assertChecks rule s f
       unless (null checks) $
         assertFailure $
           "Not expecting the following errors: \n"
-            ++ (Text.unpack . Text.unlines . formatChecks $ checks)
+            ++ (Text.unpack . Text.unlines . formatChecksNoColor $ checks)
 
 onBuildRuleCatchesNot :: HasCallStack => Rule -> Text.Text -> Assertion
 onBuildRuleCatchesNot rule s = assertOnBuildChecks rule s f
@@ -1490,4 +1490,7 @@ onBuildRuleCatchesNot rule s = assertOnBuildChecks rule s f
       unless (null checks) $
         assertFailure $
           "Not expecting the following errors: \n"
-            ++ (Text.unpack . Text.unlines . formatChecks $ checks)
+            ++ (Text.unpack . Text.unlines . formatChecksNoColor $ checks)
+
+formatChecksNoColor :: Functor f => f RuleCheck -> f Text.Text
+formatChecksNoColor checks = formatChecks checks False


### PR DESCRIPTION
- add `--color` flag to switch on colorization
- default off
- colorize TTY output:
    error - bold red
    warning - bold yellow
    info - green
    style - cyan/blue

As elaborated in issue #267, this enhances the experience with Hadolint
on the console.
![hadolint-colors](https://user-images.githubusercontent.com/17141774/108137210-be5ea100-70bb-11eb-8a00-8538554941ee.png)

Since currently there are no rules with the `style` severity, I can not showcase its color.