### PR TITLE
rules: Add rule checking agains selfreferencing `ENV`s

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,7 @@ Please [create an issue][] if you have an idea for a good rule.
 | [DL3041](https://github.com/hadolint/hadolint/wiki/DL3041)   | Specify version with `dnf install -y <package>-<version>`                                                                                           |
 | [DL3042](https://github.com/hadolint/hadolint/wiki/DL3042)   | Avoid cache directory with `pip install --no-cache-dir <package>`.                                                                                  |
 | [DL3043](https://github.com/hadolint/hadolint/wiki/DL3043)   | `ONBUILD`, `FROM` or `MAINTAINER` triggered from within `ONBUILD` instruction.                                                                      |
+| [DL3043](https://github.com/hadolint/hadolint/wiki/DL3044)   | Do not refer to an environment variable within the same `ENV` statement where it is defined.                                                        |
 | [DL4000](https://github.com/hadolint/hadolint/wiki/DL4000)   | MAINTAINER is deprecated.                                                                                                                           |
 | [DL4001](https://github.com/hadolint/hadolint/wiki/DL4001)   | Either use Wget or Curl but not both.                                                                                                               |
 | [DL4003](https://github.com/hadolint/hadolint/wiki/DL4003)   | Multiple `CMD` instructions found.                                                                                                                  |

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -1422,6 +1422,15 @@ main =
       it "ok with `FROM` outside of `ONBUILD`" $ ruleCatchesNot noIllegalInstructionInOnbuild "FROM debian:buster"
       it "ok with `MAINTAINER` outside of `ONBUILD`" $ ruleCatchesNot noIllegalInstructionInOnbuild "MAINTAINER \"Some Guy\""
     --
+    describe "Selfreferencing `ENV`s" $ do
+      it "ok with normal ENV" $ ruleCatchesNot noSelfreferencingEnv "ENV BLA=\"blubb\"\nENV BLUBB=\"${BLA}/blubb\""
+      it "ok with partial match 1" $ ruleCatchesNot noSelfreferencingEnv "ENV BLA=\"blubb\" BLUBB=\"${FOOBLA}/blubb\""
+      it "ok with partial match 2" $ ruleCatchesNot noSelfreferencingEnv "ENV BLA=\"blubb\" BLUBB=\"${BLAFOO}/blubb\""
+      it "fail with selfreferencing with curly braces ENV" $
+          ruleCatches noSelfreferencingEnv "ENV BLA=\"blubb\" BLUBB=\"${BLA}/blubb\""
+      it "fail with selfreferencing without curly braces ENV" $
+          ruleCatches noSelfreferencingEnv "ENV BLA=\"blubb\" BLUBB=\"$BLA/blubb\""
+    --
     describe "Regression Tests" $
       it "Comments with backslashes at the end are just comments" $
         let dockerFile =


### PR DESCRIPTION
- Add Rule to check agains `ENV` statements where one variable
  references another variable defined within the same `ENV` statement.
- fixes #509
- Add tests for that rule

Docker will not expand environment variables within the same `ENV`
statement where they are defined.

<!--
If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

The following Dockerfile will produce error DL3044:
```
ENV BLA="blubb" \
    BLUBB="${BLA}/blubb"
```
That is because Docker will expand the environment variable `BLUBB` to `"/blubb"`, not as expected to `"blubb/blubb"`. This behaviour could cause bugs and build errors in docker images and therefore Hadolint should notice these situations.
