### PR TITLE
bump: language-docker v9.1.3, hadolint 1.22.2

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: hadolint
-version: "1.22.1"
+version: "1.22.2"
 synopsis: Dockerfile Linter JavaScript API
 description: A smarter Dockerfile linter that helps you build best practice Docker images.
 category: Development
@@ -25,7 +25,7 @@ ghc-options:
 dependencies:
   - base >=4.8 && <5
   - megaparsec >= 9.0.0
-  - language-docker >=9.1.2 && < 10
+  - language-docker >=9.1.3 && < 10
 library:
   source-dirs: src
   generated-other-modules:

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: hadolint
-version: "1.22.2"
+version: "1.23.0"
 synopsis: Dockerfile Linter JavaScript API
 description: A smarter Dockerfile linter that helps you build best practice Docker images.
 category: Development

--- a/stack.yaml
+++ b/stack.yaml
@@ -6,7 +6,7 @@ resolver: lts-16.18
 extra-deps:
   - ShellCheck-0.7.1@sha256:94a6ee5a38e2668204bc95fdc7539a9a4ca7230984157694409444530c23b5a4,3170
   - colourista-0.1.0.0
-  - language-docker-9.1.2
+  - language-docker-9.1.3
   - megaparsec-9.0.0@sha256:920d1e469056c746b532333a078c2a9a195fab5e860e0c9734ee92a28c2bfb65,3117
 ghc-options:
   "$everything": -haddock

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -1422,7 +1422,7 @@ main =
       it "ok with `FROM` outside of `ONBUILD`" $ ruleCatchesNot noIllegalInstructionInOnbuild "FROM debian:buster"
       it "ok with `MAINTAINER` outside of `ONBUILD`" $ ruleCatchesNot noIllegalInstructionInOnbuild "MAINTAINER \"Some Guy\""
     --
-    describe "Regression Tests" $
+    describe "Regression Tests" $ do
       it "Comments with backslashes at the end are just comments" $
         let dockerFile =
               [ "FROM alpine:3.6",
@@ -1434,6 +1434,16 @@ main =
                 "RUN echo \"kaka\" | sed 's/a/o/g' >> /root/afile"
               ]
          in ruleCatches usePipefail $ Text.unlines dockerFile
+      it "`ARG` can correctly unset variables" $
+        let dockerFile =
+              [ "ARG A_WITHOUT_EQ",
+                "ARG A_WITH_EQ=",
+                "RUN echo bla"
+              ]
+         in assertChecks
+              shellcheck
+              (Text.unlines dockerFile)
+              (assertBool "No Warnings or Errors should be triggered" . null)
 
     -- Run tests for the Config module
     ConfigSpec.tests


### PR DESCRIPTION
- Bump version of language-docker to 9.1.3
- Bump version of Hadolint to 1.22.2
- Add regression test for #510

fixes #510

<!--
If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

Parsing an `ARG` with an equals sign, but without a value was fixed upstream. This version bump pulls the upstream fix into Hadolint.
The following Dockerfile should no longer confuse the parser and generate misleading errors:
```Dockerfile
ARG BLA=
RUN echo
```
