### PR TITLE
Add rule for `COPY` when no `WORKDIR` is set  #390

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,7 @@ Please [create an issue][] if you have an idea for a good rule.
 | [DL3042](https://github.com/hadolint/hadolint/wiki/DL3042)   | Avoid cache directory with `pip install --no-cache-dir <package>`.                                                                                  |
 | [DL3043](https://github.com/hadolint/hadolint/wiki/DL3043)   | `ONBUILD`, `FROM` or `MAINTAINER` triggered from within `ONBUILD` instruction.                                                                      |
 | [DL3044](https://github.com/hadolint/hadolint/wiki/DL3044)   | Do not refer to an environment variable within the same `ENV` statement where it is defined.                                                        |
+| [DL3045](https://github.com/hadolint/hadolint/wiki/DL3045)   | `COPY` to a relative destination without `WORKDIR` set.                                                                                             |
 | [DL4000](https://github.com/hadolint/hadolint/wiki/DL4000)   | MAINTAINER is deprecated.                                                                                                                           |
 | [DL4001](https://github.com/hadolint/hadolint/wiki/DL4001)   | Either use Wget or Curl but not both.                                                                                                               |
 | [DL4003](https://github.com/hadolint/hadolint/wiki/DL4003)   | Multiple `CMD` instructions found.                                                                                                                  |

--- a/src/Hadolint/Rules.hs
+++ b/src/Hadolint/Rules.hs
@@ -11,6 +11,7 @@ import Data.List (foldl', isInfixOf, isPrefixOf, mapAccumL, nub)
 import Data.List.NonEmpty (toList)
 import Data.List.Index
 import qualified Data.Map as Map
+import Data.Maybe (isNothing, isJust, fromJust)
 import qualified Data.Set as Set
 import qualified Data.Text as Text
 import Data.Void (Void)
@@ -237,7 +238,8 @@ rules =
     dnfVersionPinned,
     pipNoCacheDir,
     noIllegalInstructionInOnbuild,
-    noSelfreferencingEnv
+    noSelfreferencingEnv,
+    relativeCopyWithoutWorkdir
   ]
 
 optionalRules :: RulesConfig -> [Rule]
@@ -1234,3 +1236,21 @@ noSelfreferencingEnv = instructionRuleState code severity message check Set.empt
         -- all characters valid in the inner of a shell variable name
         varChar :: String
         varChar = ['0'..'9'] ++ ['a'..'z'] ++ ['A'..'Z'] ++ ['_']
+
+relativeCopyWithoutWorkdir :: Rule
+relativeCopyWithoutWorkdir = instructionRuleState code severity message check ("", [])
+  where
+    code = "DL3045"
+    severity = DLWarningC
+    message = "`COPY` to a relative destination without `WORKDIR` set."
+    check st _ (From BaseImage {image, alias = Just als}) =
+        withState (unImageAlias als,
+                   snd st ++ [(unImageAlias als, dir) | (img, dir) <- snd st,
+                                                        img == imageName image]) True
+    check st _ (From BaseImage {image, alias = Nothing}) =
+        withState (imageName image, snd st) True
+    check st _ (Workdir dir) = withState (fst st, snd st ++ [(fst st, dir)]) True
+    check st _ (Copy (CopyArgs _ (TargetPath dest) _ _))
+      | fst st `elem` map fst (snd st) || "/" `Text.isPrefixOf` dest = withState st True
+      | otherwise = withState st False
+    check st _ _ = withState st True


### PR DESCRIPTION
- Add rule finding instance of `COPY` with a relative destination when
  no `WORKDIR` has been set.
- Add tests for that rule

The rule permits not setting a `WORKDIR` in case the `WORKDIR` is
already set in a previous build stage (in the same Dockerfile)
form which it is inherited.
The rule always permits absolute destinations.

fixes  #390

### What I did
This Rule tracks whether or not a `WORKDIR` has been set in a build stage. In case a `COPY` with a relative destination occurs, but the `WORKDIR` has not been set (yet) in that build stage or any previous build stage that stage inherits from, it raises a warning.

The most complicated part is tracking which stage has a `WORKDIR` set, since they can inherit a `WORKDIR` from a previous stage and can have multiple `WOKRDIR` instructions. Therefore, the rule state accumulates a list of `(image or alias name, workdir)` pairs. In addition to that, it keeps track of which stage is is currently evaluated in.

### How to verify it
Tests are included.

This should raise a warning:
```Dockerfile
COPY foo bar
```

This should not raise a warning:
```Dockerfile
COPY ffoooo /bbaarr
WORKDIR /usr
COPY foo bar
```

Neither should this raise a warning
```Dockerfile
FROM debian:buster as base1
WORKDIR /usr
FROM base1 as base2
RUN foo
FROM base2
COPY ffoooo bbaarr
```