### PR TITLE
regression: Fix regression   #551

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,7 @@ Please [create an issue][] if you have an idea for a good rule.
 | [DL3041](https://github.com/hadolint/hadolint/wiki/DL3041)   | Specify version with `dnf install -y <package>-<version>`                                                                                           |
 | [DL3042](https://github.com/hadolint/hadolint/wiki/DL3042)   | Avoid cache directory with `pip install --no-cache-dir <package>`.                                                                                  |
 | [DL3043](https://github.com/hadolint/hadolint/wiki/DL3043)   | `ONBUILD`, `FROM` or `MAINTAINER` triggered from within `ONBUILD` instruction.                                                                      |
+| [DL3044](https://github.com/hadolint/hadolint/wiki/DL3044)   | Do not refer to an environment variable within the same `ENV` statement where it is defined.                                                        |
 | [DL4000](https://github.com/hadolint/hadolint/wiki/DL4000)   | MAINTAINER is deprecated.                                                                                                                           |
 | [DL4001](https://github.com/hadolint/hadolint/wiki/DL4001)   | Either use Wget or Curl but not both.                                                                                                               |
 | [DL4003](https://github.com/hadolint/hadolint/wiki/DL4003)   | Multiple `CMD` instructions found.                                                                                                                  |

--- a/src/Hadolint/Rules.hs
+++ b/src/Hadolint/Rules.hs
@@ -1187,14 +1187,14 @@ noIllegalInstructionInOnbuild = instructionRule code severity message check
     check _ = True
 
 noSelfreferencingEnv :: Rule
-noSelfreferencingEnv = instructionRuleState code severity message check []
+noSelfreferencingEnv = instructionRuleState code severity message check Set.empty
   where
     code = "DL3044"
     severity = DLErrorC
     message = "Do not refer to an environment variable within the same `ENV` statement where it is defined."
-    check st _ (Env pairs) = withState (nub $ st ++ map fst pairs) $
-        null [ env | env <- listOfReferences pairs, env `notElem` st ]
-    check st _ (Arg arg _) = withState (nub $ st ++ [arg]) True
+    check st _ (Env pairs) = withState (Set.union st (Set.fromList (map fst pairs))) $
+        null [ env | env <- listOfReferences pairs, env `Set.notMember` st ]
+    check st _ (Arg arg _) = withState (Set.insert arg st) True
     check st _ _ = withState st True
 
     -- generates a list of references to variable names referenced on the right

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -1421,6 +1421,20 @@ main =
       it "ok with `FROM` outside of `ONBUILD`" $ ruleCatchesNot noIllegalInstructionInOnbuild "FROM debian:buster"
       it "ok with `MAINTAINER` outside of `ONBUILD`" $ ruleCatchesNot noIllegalInstructionInOnbuild "MAINTAINER \"Some Guy\""
     --
+    describe "Selfreferencing `ENV`s" $ do
+      it "ok with normal ENV" $ ruleCatchesNot noSelfreferencingEnv "ENV BLA=\"blubb\"\nENV BLUBB=\"${BLA}/blubb\""
+      it "ok with partial match 1" $ ruleCatchesNot noSelfreferencingEnv "ENV BLA=\"blubb\" BLUBB=\"${FOOBLA}/blubb\""
+      it "ok with partial match 2" $ ruleCatchesNot noSelfreferencingEnv "ENV BLA=\"blubb\" BLUBB=\"${BLAFOO}/blubb\""
+      it "ok with partial match 3" $ ruleCatchesNot noSelfreferencingEnv "ENV BLA=\"blubb\" BLUBB=\"$FOOBLA/blubb\""
+      it "ok with partial match 4" $ ruleCatchesNot noSelfreferencingEnv "ENV BLA=\"blubb\" BLUBB=\"$BLAFOO/blubb\""
+      it "fail with partial match 5" $ ruleCatches noSelfreferencingEnv "ENV BLA=\"blubb\" BLUBB=\"$BLA/$BLAFOO/blubb\""
+      it "ok when previously defined in `ARG`" $ ruleCatchesNot noSelfreferencingEnv "ARG BLA\nENV BLA=${BLA}"
+      it "ok when previously defined in `ENV`" $ ruleCatchesNot noSelfreferencingEnv "ENV BLA blubb\nENV BLA=${BLA}"
+      it "fail with selfreferencing with curly braces ENV" $
+          ruleCatches noSelfreferencingEnv "ENV BLA=\"blubb\" BLUBB=\"${BLA}/blubb\""
+      it "fail with selfreferencing without curly braces ENV" $
+          ruleCatches noSelfreferencingEnv "ENV BLA=\"blubb\" BLUBB=\"$BLA/blubb\""
+    --
     describe "Regression Tests" $ do
       it "Comments with backslashes at the end are just comments" $
         let dockerFile =


### PR DESCRIPTION
- Keep track of what `ENV`s and what `ARG`s have been defined in
  rule DL3044.

When a variable is already defined, it is ok to reference it, even when
redefining that variable in an `ENV` statement.

The behavior described in #551 is tested for in unit tests.

This fix works by maintaining a list of defined variable names and excluding those when searching for occurrences of variables within the right hand side of the definition of variables. This list is fed by variables defined both in `ENV` and in `ARG` statements.

@lorenzo I think I have all possible cases of partial and full matches covered with the unit test, but please take a second and see if you can find some that I haven't covered yet.

fixes #551