### PR TITLE
rules: add rule linting `useradd`  #553

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,7 @@ Please [create an issue][] if you have an idea for a good rule.
 | [DL3043](https://github.com/hadolint/hadolint/wiki/DL3043)   | `ONBUILD`, `FROM` or `MAINTAINER` triggered from within `ONBUILD` instruction.                                                                      |
 | [DL3044](https://github.com/hadolint/hadolint/wiki/DL3044)   | Do not refer to an environment variable within the same `ENV` statement where it is defined.                                                        |
 | [DL3045](https://github.com/hadolint/hadolint/wiki/DL3045)   | `COPY` to a relative destination without `WORKDIR` set.                                                                                             |
+| [DL3046](https://github.com/hadolint/hadolint/wiki/DL3046)   | `useradd` without flag `-l` and high UID will result in excessively large Image.                                                                    |
 | [DL4000](https://github.com/hadolint/hadolint/wiki/DL4000)   | MAINTAINER is deprecated.                                                                                                                           |
 | [DL4001](https://github.com/hadolint/hadolint/wiki/DL4001)   | Either use Wget or Curl but not both.                                                                                                               |
 | [DL4003](https://github.com/hadolint/hadolint/wiki/DL4003)   | Multiple `CMD` instructions found.                                                                                                                  |

--- a/hadolint.cabal
+++ b/hadolint.cabal
@@ -4,7 +4,7 @@ cabal-version: 2.0
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 06df88cbceaf76da3599a8943568f912b17a63d1795839eb4da974832e1ae0d4
+-- hash: 86f9cfdca9eaa4b16ecd3292135ace357a7834b995350e9ce3b70acf1f9cfa63
 
 name:           hadolint
 version:        1.23.0
@@ -98,6 +98,7 @@ test-suite hadolint-unit-tests
   main-is: Spec.hs
   other-modules:
       ConfigSpec
+      ShellSpec
       Paths_hadolint
   hs-source-dirs:
       test

--- a/src/Hadolint/Shell.hs
+++ b/src/Hadolint/Shell.hs
@@ -201,5 +201,14 @@ dropFlagArg flagsToDrop Command {name, arguments, flags} = Command name filterdA
     idsToDrop = Set.fromList [getValueId fId arguments | CmdPart f fId <- flags, f `elem` flagsToDrop]
     filterdArgs = [arg | arg@(CmdPart _ aId) <- arguments, not (aId `Set.member` idsToDrop)]
 
+-- given a flag and a command, return list of arguments for that particulat
+-- flag. E.g., if the command is `useradd -u 12345 luser` and this function is
+-- called for the command `u`, it returns ["12345"].
+getFlagArg :: Text.Text -> Command -> [Text.Text]
+getFlagArg flag Command {arguments, flags} = extractArgs
+  where
+    idsToGet = [getValueId fId arguments | CmdPart f fId <- flags, f == flag]
+    extractArgs = [arg | (CmdPart arg aId) <- arguments, aId `elem` idsToGet]
+
 getValueId :: Int -> [CmdPart] -> Int
 getValueId fId flags = foldl min (maxBound :: Int) $ filter (> fId) $ map partId flags

--- a/test/ShellSpec.hs
+++ b/test/ShellSpec.hs
@@ -1,0 +1,42 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module ShellSpec where
+
+import Data.Text as Text
+import Hadolint.Shell
+import Test.Hspec
+
+tests :: SpecWith ()
+tests =
+  describe "Shell unit tests" $ do
+  --
+    it "getFlagArgs" $ do
+      let cmd = Command (Text.pack "useradd")
+                        [ CmdPart (Text.pack "12345") 2,
+                          CmdPart (Text.pack "67890") 4,
+                          CmdPart (Text.pack "luser") 5 ]
+                        [ CmdPart (Text.pack "u") 1,
+                          CmdPart (Text.pack "u") 3 ]
+       in getFlagArg (Text.pack "u") cmd `shouldBe` [ Text.pack "12345",
+                                                      Text.pack "67890" ]
+      let cmd = Command (Text.pack "useradd")
+                        [ CmdPart (Text.pack "12345") 2,
+                          CmdPart (Text.pack "luser") 3 ]
+                        [ CmdPart (Text.pack "u") 1 ]
+       in getFlagArg (Text.pack "u") cmd `shouldBe` [ Text.pack "12345" ]
+
+      let cmd = Command (Text.pack "useradd")
+                        [ CmdPart (Text.pack "12345") 2,
+                          CmdPart (Text.pack "luser") 3 ]
+                        [ CmdPart (Text.pack "u") 1 ]
+       in getFlagArg (Text.pack "f") cmd `shouldBe` []
+  --
+    it "hasFlag" $ do
+      let cmd = Command (Text.pack "useradd")
+                        [ CmdPart (Text.pack "luser") 1 ]
+                        [ CmdPart (Text.pack "l") 0 ]
+       in hasFlag (Text.pack "l") cmd `shouldBe` True
+      let cmd = Command (Text.pack "useradd")
+                        [ CmdPart (Text.pack "luser") 1 ]
+                        [ CmdPart (Text.pack "l") 0 ]
+       in hasFlag (Text.pack "f") cmd `shouldBe` False


### PR DESCRIPTION
- Add rule to lint for missing flag `-l` during usage of `useradd` with
  long UIDs.
- Number is DL3045 in anticipation of DL3044 being merged
- Add tests for that rule

- Add function to exctract arguments to a flag from shell command arguments
- Add unit test module for the `Hadolint.Shell` module
- Add test the functions `getFlagArg` and `hasFlag`

fixes #553


# How I did it
This rule triggers when the argument following the `-u` flag of `useradd` is longer than 5 characters and the `-l` flag is absent.
The threshold of 5 was determined experimentally by increasing the UID until the resulting image size changed, but also matches the default UID_MAX value of 65535 for most Linux systems.

Also notable is the addition of unit tests for the `Hadolint.Shell` module.

### How to verify it
Either of these Dockerfiles should be ok:
```Dockerfile
RUN useradd -l -u 123456 luser
```
```Dockerfile
RUN useradd -u 12345 luser
```
This Dockerfile however should emit a warning:
```Dockerfile
RUN useradd -u 123456
```
