### PR TITLE
rules: refine selfreferencing env rule

### DIFF
--- a/hadolint.cabal
+++ b/hadolint.cabal
@@ -4,7 +4,7 @@ cabal-version: 2.0
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 3ecbed4531d222b63b1238f288614505607a97e91af832440541cb8c7c678fa9
+-- hash: 06df88cbceaf76da3599a8943568f912b17a63d1795839eb4da974832e1ae0d4
 
 name:           hadolint
 version:        1.23.0
@@ -63,6 +63,7 @@ library
     , deepseq ==1.4.4.*
     , directory >=1.3.0
     , filepath
+    , ilist
     , language-docker >=9.1.3 && <10
     , megaparsec >=9.0.0
     , mtl

--- a/package.yaml
+++ b/package.yaml
@@ -44,6 +44,7 @@ library:
     - deepseq == 1.4.4.*
     - directory >= 1.3.0
     - filepath
+    - ilist
     - mtl
     - parallel
     - text

--- a/src/Hadolint/Rules.hs
+++ b/src/Hadolint/Rules.hs
@@ -9,6 +9,7 @@ import Control.Arrow ((&&&))
 import Control.DeepSeq (NFData)
 import Data.List (foldl', isInfixOf, isPrefixOf, mapAccumL, nub)
 import Data.List.NonEmpty (toList)
+import Data.List.Index
 import qualified Data.Map as Map
 import qualified Data.Set as Set
 import qualified Data.Text as Text
@@ -1198,10 +1199,11 @@ noSelfreferencingEnv = instructionRuleState code severity message check Set.empt
     check st _ _ = withState st True
 
     -- generates a list of references to variable names referenced on the right
-    -- hand side of a variable definition
+    -- hand side of a variable definition, except when the variable is
+    -- referenced on its own right hand side.
     listOfReferences :: Pairs -> [Text.Text]
-    listOfReferences prs = [ var | var <- map fst prs,
-                                   var `isSubstringOfAny` map snd prs ]
+    listOfReferences prs = [ var | (idx, (var, _)) <- indexed prs,
+                                   var `isSubstringOfAny` map (snd . snd) (filter ((/= idx) . fst) (indexed prs))]
     -- is a reference of a variable substring of any text?
     -- matches ${var_name} and $var_name, but not $var_nameblafoo
     isSubstringOfAny :: Text.Text -> [Text.Text] -> Bool

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -1422,18 +1422,32 @@ main =
       it "ok with `MAINTAINER` outside of `ONBUILD`" $ ruleCatchesNot noIllegalInstructionInOnbuild "MAINTAINER \"Some Guy\""
     --
     describe "Selfreferencing `ENV`s" $ do
-      it "ok with normal ENV" $ ruleCatchesNot noSelfreferencingEnv "ENV BLA=\"blubb\"\nENV BLUBB=\"${BLA}/blubb\""
-      it "ok with partial match 1" $ ruleCatchesNot noSelfreferencingEnv "ENV BLA=\"blubb\" BLUBB=\"${FOOBLA}/blubb\""
-      it "ok with partial match 2" $ ruleCatchesNot noSelfreferencingEnv "ENV BLA=\"blubb\" BLUBB=\"${BLAFOO}/blubb\""
-      it "ok with partial match 3" $ ruleCatchesNot noSelfreferencingEnv "ENV BLA=\"blubb\" BLUBB=\"$FOOBLA/blubb\""
-      it "ok with partial match 4" $ ruleCatchesNot noSelfreferencingEnv "ENV BLA=\"blubb\" BLUBB=\"$BLAFOO/blubb\""
-      it "fail with partial match 5" $ ruleCatches noSelfreferencingEnv "ENV BLA=\"blubb\" BLUBB=\"$BLA/$BLAFOO/blubb\""
-      it "ok when previously defined in `ARG`" $ ruleCatchesNot noSelfreferencingEnv "ARG BLA\nENV BLA=${BLA}"
-      it "ok when previously defined in `ENV`" $ ruleCatchesNot noSelfreferencingEnv "ENV BLA blubb\nENV BLA=${BLA}"
+      it "ok with normal ENV" $
+        ruleCatchesNot noSelfreferencingEnv "ENV BLA=\"blubb\"\nENV BLUBB=\"${BLA}/blubb\""
+      it "ok with partial match 1" $
+        ruleCatchesNot noSelfreferencingEnv "ENV BLA=\"blubb\" BLUBB=\"${FOOBLA}/blubb\""
+      it "ok with partial match 2" $
+        ruleCatchesNot noSelfreferencingEnv "ENV BLA=\"blubb\" BLUBB=\"${BLAFOO}/blubb\""
+      it "ok with partial match 3" $
+        ruleCatchesNot noSelfreferencingEnv "ENV BLA=\"blubb\" BLUBB=\"$FOOBLA/blubb\""
+      it "ok with partial match 4" $
+        ruleCatchesNot noSelfreferencingEnv "ENV BLA=\"blubb\" BLUBB=\"$BLAFOO/blubb\""
+      it "fail with partial match 5" $
+        ruleCatches noSelfreferencingEnv "ENV BLA=\"blubb\" BLUBB=\"$BLA/$BLAFOO/blubb\""
+      it "ok when previously defined in `ARG`" $
+        ruleCatchesNot noSelfreferencingEnv "ARG BLA\nENV BLA=${BLA}"
+      it "ok when previously defined in `ENV`" $
+        ruleCatchesNot noSelfreferencingEnv "ENV BLA blubb\nENV BLA=${BLA}"
+      it "ok with referencing a variable on its own right hand side" $
+        ruleCatchesNot noSelfreferencingEnv "ENV PATH=/bla:${PATH}"
+      it "ok with referencing a variable on its own right side twice in different `ENV`s" $
+        ruleCatchesNot noSelfreferencingEnv "ENV PATH=/bla:${PATH}\nENV PATH=/blubb:${PATH}"
+      it "fail when referencing a variable on its own right side twice within the same `ENV`" $
+        ruleCatches noSelfreferencingEnv "ENV PATH=/bla:${PATH} PATH=/blubb:${PATH}"
       it "fail with selfreferencing with curly braces ENV" $
-          ruleCatches noSelfreferencingEnv "ENV BLA=\"blubb\" BLUBB=\"${BLA}/blubb\""
+        ruleCatches noSelfreferencingEnv "ENV BLA=\"blubb\" BLUBB=\"${BLA}/blubb\""
       it "fail with selfreferencing without curly braces ENV" $
-          ruleCatches noSelfreferencingEnv "ENV BLA=\"blubb\" BLUBB=\"$BLA/blubb\""
+        ruleCatches noSelfreferencingEnv "ENV BLA=\"blubb\" BLUBB=\"$BLA/blubb\""
     --
     describe "Regression Tests" $ do
       it "Comments with backslashes at the end are just comments" $


### PR DESCRIPTION
- Allow a variable to reference itself in its definition once per `ENV`
  statement
- Add tests for new behavior

A variable may legitimately be redefined with itself e.g.
`PATH=/path:${PATH}`, thus this case should not trigger DL3044. However
doing so twice or more within the same `ENV` statement will not expand
the variable twice and therefore should be an error.

see https://github.com/hadolint/hadolint/pull/548#issuecomment-785800548


### How I did it
When searching for occurrences of the variable as reference (either $VAR or ${VAR}), the right hand side value of the variable itself is no longer searched. Only the right hand sides of other variables in the same `ENV` statement is searched. To implement this, an indexed list is used to uniquely identify the variable/value pairs. This can not be done by variable name, since a variable may be defined twice within the same `ENV` statement, which may result in wrong expansion of its value.

### How to verify it
The tests have been expanded to capture the new behavior.

This should no longer trigger DL3044:
```Dockerfile
ENV PATH=/bla:$PATH
```

This however should still trigger DL3044
```Dockerfile
ENV PATH=/bla:$PATH \
    PATH=/blubb:$PATH
```