### PR TITLE
DL3045: fix when destination is a variable

### DIFF
--- a/src/Hadolint/Rules.hs
+++ b/src/Hadolint/Rules.hs
@@ -1255,7 +1255,14 @@ relativeCopyWithoutWorkdir = instructionRuleState code severity message check ("
         withState (fst st, Map.insert (fst st) True (snd st)) True
     check st _ (Copy (CopyArgs _ (TargetPath dest) _ _))
         | uncurry Map.member st = withState st True  -- workdir has been set
-        | "/" `Text.isPrefixOf` dest = withState st True  -- absolute dest. normal
-        | ":\\" `Text.isPrefixOf` Text.drop 1 dest = withState st True  -- absolute dest. windows
+        | "/" `Text.isPrefixOf` Text.dropAround quotePredicate dest = withState st True  -- absolute dest. normal
+        | ":\\" `Text.isPrefixOf` Text.drop 1 (Text.dropAround quotePredicate dest) = withState st True  -- absolute dest. windows
+        | "$" `Text.isPrefixOf` Text.dropAround quotePredicate dest = withState st True -- dest is a variable
         | otherwise = withState st False
     check st _ _ = withState st True
+
+    quotePredicate :: Char -> Bool
+    quotePredicate c
+        | c == '"' = True
+        | c == '\'' = True
+        | otherwise = False

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -912,18 +912,39 @@ main =
       it "ok: `COPY` with absolute destination and no `WORKDIR` set" $ do
         ruleCatchesNot relativeCopyWithoutWorkdir "COPY bla.sh /usr/local/bin/blubb.sh"
         onBuildRuleCatchesNot relativeCopyWithoutWorkdir "COPY bla.sh /usr/local/bin/blubb.sh"
+      it "ok: `COPY` with absolute destination and no `WORKDIR` set with quotes" $ do
+        ruleCatchesNot relativeCopyWithoutWorkdir "COPY bla.sh \"/usr/local/bin/blubb.s\""
+        onBuildRuleCatchesNot relativeCopyWithoutWorkdir "COPY bla.sh \"/usr/local/bin/blubb.sh\""
       it "ok: `COPY` with absolute destination and no `WORKDIR` set - windows" $ do
         ruleCatchesNot relativeCopyWithoutWorkdir "COPY bla.sh c:\\system32\\blubb.sh"
         onBuildRuleCatchesNot relativeCopyWithoutWorkdir "COPY bla.sh d:\\mypath\\blubb.sh"
+      it "ok: `COPY` with absolute destination and no `WORKDIR` set - windows with quotes" $ do
+        ruleCatchesNot relativeCopyWithoutWorkdir "COPY bla.sh \"c:\\system32\\blubb.sh\""
+        onBuildRuleCatchesNot relativeCopyWithoutWorkdir "COPY bla.sh \"d:\\mypath\\blubb.sh\""
       it "ok: `COPY` with relative destination and `WORKDIR` set" $ do
         ruleCatchesNot relativeCopyWithoutWorkdir "WORKDIR /usr\nCOPY bla.sh blubb.sh"
         onBuildRuleCatchesNot relativeCopyWithoutWorkdir "WORKDIR /usr\nCOPY bla.sh blubb.sh"
       it "ok: `COPY` with relative destination and `WORKDIR` set - windows" $ do
         ruleCatchesNot relativeCopyWithoutWorkdir "WORKDIR c:\\system32\nCOPY bla.sh blubb.sh"
         onBuildRuleCatchesNot relativeCopyWithoutWorkdir "WORKDIR c:\\system32\nCOPY bla.sh blubb.sh"
+      it "ok: `COPY` with destination being an environment variable 1" $ do
+        ruleCatchesNot relativeCopyWithoutWorkdir "COPY src.sh ${SRC_BASE_ENV}"
+        onBuildRuleCatchesNot relativeCopyWithoutWorkdir "COPY src.sh ${SRC_BASE_ENV}"
+      it "ok: `COPY` with destination being an environment variable 2" $ do
+        ruleCatchesNot relativeCopyWithoutWorkdir "COPY src.sh $SRC_BASE_ENV"
+        onBuildRuleCatchesNot relativeCopyWithoutWorkdir "COPY src.sh $SRC_BASE_ENV"
+      it "ok: `COPY` with destination being an environment variable 3" $ do
+        ruleCatchesNot relativeCopyWithoutWorkdir "COPY src.sh \"${SRC_BASE_ENV}\""
+        onBuildRuleCatchesNot relativeCopyWithoutWorkdir "COPY src.sh \"${SRC_BASE_ENV}\""
+      it "ok: `COPY` with destination being an environment variable 4" $ do
+        ruleCatchesNot relativeCopyWithoutWorkdir "COPY src.sh \"$SRC_BASE_ENV\""
+        onBuildRuleCatchesNot relativeCopyWithoutWorkdir "COPY src.sh \"$SRC_BASE_ENV\""
       it "not ok: `COPY` with relative destination and no `WORKDIR` set" $ do
         ruleCatches relativeCopyWithoutWorkdir "COPY bla.sh blubb.sh"
         onBuildRuleCatches relativeCopyWithoutWorkdir "COPY bla.sh blubb.sh"
+      it "not ok: `COPY` with relative destination and no `WORKDIR` set with quotes" $ do
+        ruleCatches relativeCopyWithoutWorkdir "COPY bla.sh \"blubb.sh\""
+        onBuildRuleCatches relativeCopyWithoutWorkdir "COPY bla.sh \"blubb.sh\""
       it "not ok: `COPY` to relative destination if `WORKDIR` is set in a previous stage but not inherited" $
         let dockerFile =
               Text.unlines


### PR DESCRIPTION
- do not trigger DL3045 when the destination of the `COPY`
  statement is or begins with a variable.
- strip quotes from destination string

When the destination of a `COPY` statement is or begins with a
variable, it can be assumed, that the programer takes responsibility for
setting that variable.

fixes #560

### What I did
Exclude the case where the destination is a variable from DL3045. When looking at the original feature request https://github.com/hadolint/hadolint/issues/390, the case where the destination of the `COPY` statement is a variable is not really a problem this rule should warn about, since it is unaffected by unwanted interaction of the `WORKDIR` and `COPY` statements.
One can argue, that `COPY`ing to a destination that is a variable that has not been set or has been set to a relative directory both are situations to warn about, but that is perhaps not the scope of DL3045.

Also strip quotes from destination. This prevents false positives in cases like: `COPY src.sh "/destination"`

### How to verify it
Test cases included. This should no longer trigger DL3045:
```Dockerfile
FROM debian:buster
COPY src.sh ${DEST}
```
neither should this:
```Dockerfile
FROM debian:buster
COPY src.sh "/dest"
```