### PR TITLE
label-schema: Add configurable rules checking a label schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,62 @@ RUN cd /tmp && echo "hello!"
 
 Inline ignores will only work if place directly above the instruction.
 
+## Linting Labels
+
+Hadolint has the ability to check that specific labels be present and conform
+to a predefined label schema.
+First a label schema must be defined either via commandline:
+```bash
+$ hadolint --require-label author:text --require-label version:semver Dockerfile
+```
+or via config file:
+
+```yaml
+label-schema:
+  author: text
+  created: rfc3339
+  version: semver
+  documentation: url
+  git-revision: hash
+  license: spdx
+```
+The value of a label can be either of `text`, `url`, `semver`, `hash` or
+`rfc3339`:
+| Schema  | Description                                        |
+|:--------|:---------------------------------------------------|
+| text    | Anything                                           |
+| rfc3339 | A time, formatted according to [RFC 3339][rfc3339] |
+| semver  | A [semantic version][semver]                       |
+| url     | A URI as described in [RFC 3986][rfc3986]          |
+| hash    | Either a short or a long [Git hash][githash]       |
+| spdx    | An [SPDX license identifier][spdxid]               |
+
+By default, Hadolint ignores any label not specified in the label schema. To
+warn on such additional labels, turn on strict labels:
+```bash
+$ hadolint --strict-labels --require-label version:semver Dockerfile
+```
+or in the config file:
+```yaml
+strict-labels: true
+```
+When strict labels is enabled, but no label schema has been specified, Hadolint
+will warn if any label is present.
+
+### Note on dealing with variables in labels
+It is a common pattern to fill the value of a label not statically, but rather
+dynamically at build time by using a variable:
+```dockerfile
+FROM debian:buster
+ARG VERSION="du-jour"
+LABEL version="${VERSION}"
+```
+To allow this, the label schema must specify `text` as value for that label:
+```yaml
+label-schema:
+  version: text
+```
+
 ## Integrations
 
 To get most of `hadolint` it is useful to integrate it as a check to your CI
@@ -226,6 +282,15 @@ Please [create an issue][] if you have an idea for a good rule.
 | [DL3045](https://github.com/hadolint/hadolint/wiki/DL3045)   | `COPY` to a relative destination without `WORKDIR` set.                                                                                             |
 | [DL3046](https://github.com/hadolint/hadolint/wiki/DL3046)   | `useradd` without flag `-l` and high UID will result in excessively large Image.                                                                    |
 | [DL3047](https://github.com/hadolint/hadolint/wiki/DL3047)   | `wget` without flag `--progress` will result in excessively bloated build logs when downloading larger files.                                       |
+| [DL3048](https://github.com/hadolint/hadolint/wiki/DL3048)   | Invalid Label Key                                                                                                                                   |
+| [DL3049](https://github.com/hadolint/hadolint/wiki/DL3049)   | Label `<label>` is missing.                                                                                                                         |
+| [DL3050](https://github.com/hadolint/hadolint/wiki/DL3050)   | Superfluous label(s) present.                                                                                                                       |
+| [DL3051](https://github.com/hadolint/hadolint/wiki/DL3051)   | Label `<label>` is empty.                                                                                                                           |
+| [DL3052](https://github.com/hadolint/hadolint/wiki/DL3052)   | Label `<label>` is not a valid URL.                                                                                                                 |
+| [DL3053](https://github.com/hadolint/hadolint/wiki/DL3053)   | Label `<label>` is not a valid time format - must be conform to RFC3339.                                                                            |
+| [DL3054](https://github.com/hadolint/hadolint/wiki/DL3054)   | Label `<label>` is not a valid SPDX license identifier.                                                                                             |
+| [DL3055](https://github.com/hadolint/hadolint/wiki/DL3055)   | Label `<label>` is not a valid git hash.                                                                                                            |
+| [DL3056](https://github.com/hadolint/hadolint/wiki/DL3056)   | Label `<label>` does not conform to semantic versioning.                                                                                            |
 | [DL4000](https://github.com/hadolint/hadolint/wiki/DL4000)   | MAINTAINER is deprecated.                                                                                                                           |
 | [DL4001](https://github.com/hadolint/hadolint/wiki/DL4001)   | Either use Wget or Curl but not both.                                                                                                               |
 | [DL4003](https://github.com/hadolint/hadolint/wiki/DL4003)   | Multiple `CMD` instructions found.                                                                                                                  |
@@ -345,3 +410,8 @@ a look at [Syntax.hs][] in the `language-docker` project to see the AST definiti
 [create an issue]: https://github.com/hadolint/hadolint/issues/new
 [dockerfile reference]: http://docs.docker.com/engine/reference/builder/
 [syntax.hs]: https://www.stackage.org/haddock/nightly-2018-01-07/language-docker-2.0.1/Language-Docker-Syntax.html
+[rfc3339]: https://www.ietf.org/rfc/rfc3339.txt
+[semver]: https://semver.org/
+[rfc3986]: https://www.ietf.org/rfc/rfc3986.txt
+[githash]: https://git-scm.com/book/en/v2/Git-Tools-Revision-Selection
+[spdxid]: https://spdx.org/licenses/

--- a/hadolint.cabal
+++ b/hadolint.cabal
@@ -4,7 +4,7 @@ cabal-version: 2.0
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 9005197a6ffe91fc38b440f234b96e25dbb18c603db1ceb521f1026e4f24e4a7
+-- hash: 6dc5574db9b4edf093ae954fa31aa254d6a3b1a37aa6dc0bf793182d24daf375
 
 name:           hadolint
 version:        2.0.0
@@ -138,6 +138,7 @@ library
     , mtl
     , network-uri
     , parallel
+    , parsec >=3.1.14
     , semver
     , spdx
     , split >=0.2

--- a/hadolint.cabal
+++ b/hadolint.cabal
@@ -92,6 +92,15 @@ library
       Hadolint.Rule.DL3045
       Hadolint.Rule.DL3046
       Hadolint.Rule.DL3047
+      Hadolint.Rule.DL3048
+      Hadolint.Rule.DL3049
+      Hadolint.Rule.DL3050
+      Hadolint.Rule.DL3051
+      Hadolint.Rule.DL3052
+      Hadolint.Rule.DL3053
+      Hadolint.Rule.DL3054
+      Hadolint.Rule.DL3055
+      Hadolint.Rule.DL3056
       Hadolint.Rule.DL3057
       Hadolint.Rule.DL4000
       Hadolint.Rule.DL4001
@@ -110,7 +119,8 @@ library
   default-extensions: OverloadedStrings NamedFieldPuns DeriveGeneric DeriveAnyClass RecordWildCards StrictData ScopedTypeVariables PatternSynonyms
   ghc-options: -Wall -Wcompat -Wincomplete-record-updates -Wincomplete-uni-patterns -Wredundant-constraints -optP-Wno-nonportable-include-path -flate-dmd-anal
   build-depends:
-      HsYAML
+      Cabal
+    , HsYAML
     , ShellCheck >=0.7.1
     , aeson
     , base >=4.8 && <5
@@ -126,9 +136,14 @@ library
     , language-docker >=9.1.3 && <10
     , megaparsec >=9.0.0
     , mtl
+    , network-uri
     , parallel
+    , semver
+    , spdx
     , split >=0.2
     , text
+    , time
+    , timerep >=2.0
     , void
   default-language: Haskell2010
 

--- a/package.yaml
+++ b/package.yaml
@@ -57,6 +57,7 @@ library:
     - ilist
     - mtl
     - network-uri
+    - parsec >= 3.1.14
     - parallel
     - semver
     - spdx

--- a/package.yaml
+++ b/package.yaml
@@ -44,6 +44,7 @@ library:
     - &ShellCheck ShellCheck >=0.7.1
     - &bytestring bytestring >=0.10
     - &split split >=0.2
+    - Cabal
     - HsYAML
     - aeson
     - bytestring
@@ -55,8 +56,13 @@ library:
     - filepath
     - ilist
     - mtl
+    - network-uri
     - parallel
+    - semver
+    - spdx
     - text
+    - time
+    - timerep >= 2.0
     - void
     - foldl
 executables:

--- a/src/Hadolint/Config.hs
+++ b/src/Hadolint/Config.hs
@@ -2,19 +2,24 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE OverloadedStrings #-}
 
-module Hadolint.Config (applyConfig, ConfigFile (..), OverrideConfig (..)) where
+module Hadolint.Config
+  ( applyConfig,
+    ConfigFile (..),
+    OverrideConfig (..)
+  ) where
 
 import qualified Control.Foldl.Text as Text
 import Control.Monad (filterM)
 import qualified Data.ByteString as Bytes
 import Data.Coerce (coerce)
 import Data.Maybe (fromMaybe, listToMaybe)
+import Data.Map as Map
 import qualified Data.Set as Set
 import Data.YAML ((.:?))
 import qualified Data.YAML as Yaml
 import GHC.Generics (Generic)
 import qualified Hadolint.Lint as Lint
-import qualified Hadolint.Process
+import qualified Hadolint.Process as Process
 import qualified Hadolint.Rule
 import qualified Language.Docker as Docker
 import System.Directory
@@ -36,7 +41,9 @@ data OverrideConfig = OverrideConfig
 data ConfigFile = ConfigFile
   { overrideRules :: Maybe OverrideConfig,
     ignoredRules :: Maybe [Lint.IgnoreRule],
-    trustedRegistries :: Maybe [Lint.TrustedRegistry]
+    trustedRegistries :: Maybe [Lint.TrustedRegistry],
+    labelSchemaConfig :: Maybe Hadolint.Rule.LabelSchema,
+    strictLabelSchema :: Maybe Bool
   }
   deriving (Show, Eq, Generic)
 
@@ -54,6 +61,8 @@ instance Yaml.FromYAML ConfigFile where
     ignored <- m .:? "ignored"
     let ignoredRules = coerce (ignored :: Maybe [Text.Text])
     trustedRegistries <- m .:? "trustedRegistries"
+    labelSchemaConfig <- m .:? "label-schema"
+    strictLabelSchema <- m .:? "strict-labels"
     return ConfigFile {..}
 
 -- | If both the ignoreRules and rulesConfig properties of Lint options are empty
@@ -62,7 +71,7 @@ instance Yaml.FromYAML ConfigFile where
 -- return the error string.
 applyConfig :: Maybe FilePath -> Lint.LintOptions -> IO (Either String Lint.LintOptions)
 applyConfig maybeConfig o
-  | not (null (Lint.ignoreRules o)) && Lint.rulesConfig o /= mempty = return (Right o)
+  | not (Prelude.null (Lint.ignoreRules o)) && Lint.rulesConfig o /= mempty = return (Right o)
   | otherwise = do
     theConfig <-
       case maybeConfig of
@@ -82,15 +91,15 @@ applyConfig maybeConfig o
       contents <- Bytes.readFile configFile
       case Yaml.decode1Strict contents of
         Left (_, err) -> return $ Left (formatError err configFile)
-        Right (ConfigFile Nothing ignore trusted) ->
+        Right (ConfigFile Nothing ignore trusted labelschema strictlabels) ->
           return $
-            Right (applyOverride Nothing Nothing Nothing Nothing ignore trusted)
-        Right (ConfigFile (Just (OverrideConfig errors warnings infos styles)) ignore trusted) ->
+            Right (applyOverride Nothing Nothing Nothing Nothing ignore trusted labelschema strictlabels)
+        Right (ConfigFile (Just (OverrideConfig errors warnings infos styles)) ignore trusted labelschema strictlabels) ->
           return $
-            Right (applyOverride errors warnings infos styles ignore trusted)
+            Right (applyOverride errors warnings infos styles ignore trusted labelschema strictlabels)
 
-    applyOverride errors warnings infos styles ignore trusted =
-      applyTrusted trusted
+    applyOverride errors warnings infos styles ignore trusted labelschema strictlabels =
+      applyRulesConfig trusted labelschema strictlabels
         . applyIgnore ignore
         . applyStyles styles
         . applyInfos infos
@@ -123,13 +132,31 @@ applyConfig maybeConfig o
         [] -> opts {Lint.ignoreRules = fromMaybe [] ignore}
         _ -> opts
 
-    applyTrusted trusted opts
-      | null (Hadolint.Process.allowedRegistries (Lint.rulesConfig opts)) =
-        opts {Lint.rulesConfig = toRules trusted <> Lint.rulesConfig opts}
-      | otherwise = opts
+    applyRulesConfig trusted labelschema strictlabels opts =
+      opts { Lint.rulesConfig =
+        ((`applyLabelSchema` labelschema) .
+        (`applyStrictLabels` strictlabels) .
+        (`applyTrustedRegistries` trusted)) (Lint.rulesConfig opts) }
 
-    toRules (Just trusted) = Hadolint.Process.RulesConfig (Set.fromList . coerce $ trusted)
-    toRules _ = mempty
+    applyStrictLabels :: Process.RulesConfig -> Maybe Bool -> Process.RulesConfig
+    applyStrictLabels rc (Just strict) =
+        rc { Process.strictLabels = Process.strictLabels rc || strict }
+    applyStrictLabels rc _ = rc
+
+    applyLabelSchema :: Process.RulesConfig -> Maybe Hadolint.Rule.LabelSchema -> Process.RulesConfig
+    applyLabelSchema rc (Just labelschema)
+        | Map.null (Process.labelSchema rc) =
+            rc { Process.labelSchema = labelschema}
+        | otherwise = rc
+    applyLabelSchema rc _ = rc
+
+    applyTrustedRegistries :: Process.RulesConfig -> Maybe [Lint.TrustedRegistry] -> Process.RulesConfig
+    applyTrustedRegistries rc (Just trusted)
+        | Prelude.null (Process.allowedRegistries rc) =
+            rc { Process.allowedRegistries = Set.fromList . coerce $ trusted }
+        | otherwise = rc
+    applyTrustedRegistries rc _ = rc
+
 
     formatError err config =
       unlines

--- a/src/Hadolint/Config.hs
+++ b/src/Hadolint/Config.hs
@@ -1,7 +1,3 @@
-{-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE OverloadedStrings #-}
-
 module Hadolint.Config
   ( applyConfig,
     ConfigFile (..),
@@ -20,7 +16,7 @@ import qualified Data.YAML as Yaml
 import GHC.Generics (Generic)
 import qualified Hadolint.Lint as Lint
 import qualified Hadolint.Process as Process
-import qualified Hadolint.Rule
+import qualified Hadolint.Rule as Rule
 import qualified Language.Docker as Docker
 import System.Directory
   ( XdgDirectory (..),
@@ -29,6 +25,7 @@ import System.Directory
     getXdgDirectory,
   )
 import System.FilePath ((</>))
+
 
 data OverrideConfig = OverrideConfig
   { overrideErrorRules :: Maybe [Lint.ErrorRule],
@@ -42,7 +39,7 @@ data ConfigFile = ConfigFile
   { overrideRules :: Maybe OverrideConfig,
     ignoredRules :: Maybe [Lint.IgnoreRule],
     trustedRegistries :: Maybe [Lint.TrustedRegistry],
-    labelSchemaConfig :: Maybe Hadolint.Rule.LabelSchema,
+    labelSchemaConfig :: Maybe Rule.LabelSchema,
     strictLabelSchema :: Maybe Bool
   }
   deriving (Show, Eq, Generic)
@@ -143,7 +140,7 @@ applyConfig maybeConfig o
         rc { Process.strictLabels = Process.strictLabels rc || strict }
     applyStrictLabels rc _ = rc
 
-    applyLabelSchema :: Process.RulesConfig -> Maybe Hadolint.Rule.LabelSchema -> Process.RulesConfig
+    applyLabelSchema :: Process.RulesConfig -> Maybe Rule.LabelSchema -> Process.RulesConfig
     applyLabelSchema rc (Just labelschema)
         | Map.null (Process.labelSchema rc) =
             rc { Process.labelSchema = labelschema}
@@ -159,7 +156,7 @@ applyConfig maybeConfig o
 
 
     formatError err config =
-      unlines
+      Prelude.unlines
         [ "Error parsing your config file in  '" ++ config ++ "':",
           "It should contain one of the keys 'override', 'ignored'",
           "or 'trustedRegistries'. For example:\n",

--- a/src/Hadolint/Process.hs
+++ b/src/Hadolint/Process.hs
@@ -56,9 +56,6 @@ import qualified Hadolint.Rule.DL3044
 import qualified Hadolint.Rule.DL3045
 import qualified Hadolint.Rule.DL3046
 import qualified Hadolint.Rule.DL3047
-<<<<<<< HEAD
-import qualified Hadolint.Rule.DL3057
-=======
 import qualified Hadolint.Rule.DL3048
 import qualified Hadolint.Rule.DL3049
 import qualified Hadolint.Rule.DL3050
@@ -68,7 +65,7 @@ import qualified Hadolint.Rule.DL3053
 import qualified Hadolint.Rule.DL3054
 import qualified Hadolint.Rule.DL3055
 import qualified Hadolint.Rule.DL3056
->>>>>>> label-schema: Add configurable rules checking a label schema
+import qualified Hadolint.Rule.DL3057
 import qualified Hadolint.Rule.DL4000
 import qualified Hadolint.Rule.DL4001
 import qualified Hadolint.Rule.DL4003

--- a/src/Hadolint/Rule.hs
+++ b/src/Hadolint/Rule.hs
@@ -2,6 +2,7 @@ module Hadolint.Rule where
 
 import Control.DeepSeq (NFData)
 import qualified Control.Foldl as Foldl
+import qualified Data.Map as Map
 import qualified Data.Sequence as Seq
 import Data.String (IsString (..))
 import qualified Data.Text as Text
@@ -45,6 +46,11 @@ data State a = State
     state :: a
   }
   deriving (Show)
+
+type LabelName = Text.Text
+type LabelType = Text.Text
+type LabelSchema = Map.Map LabelName LabelType
+
 
 withLineNumber ::
   (Linenumber -> t1 -> Instruction args -> t2) ->

--- a/src/Hadolint/Rule/DL3048.hs
+++ b/src/Hadolint/Rule/DL3048.hs
@@ -1,0 +1,39 @@
+module Hadolint.Rule.DL3048 (rule) where
+
+import qualified Data.Text as Text
+import Hadolint.Rule
+import Language.Docker.Syntax
+
+
+rule :: Rule args
+rule = simpleRule code severity message check
+  where
+    code = "DL3048"
+    severity = DLStyleC
+    message = "Invalid label key."
+    check (Label pairs) = hasNoInvalidKey pairs
+    check _ = True
+
+    hasNoInvalidKey prs = null $ [(l, v) | (l, v) <- prs,
+                                          Text.take 1 l `notElem`
+                                              fmap Text.singleton ['a'..'z'] ||
+                                          Text.takeEnd 1 l `notElem`
+                                              fmap Text.singleton (['a'..'z'] ++ ['0'..'9']) ||
+                                          containsIllegalChar l ||
+                                          hasReservedNamespace l ||
+                                          hasConsecutiveSeparators l]
+{-# INLINEABLE rule #-}
+
+containsIllegalChar :: Text.Text -> Bool
+containsIllegalChar = Text.any (`notElem` validChars)
+
+hasReservedNamespace :: Text.Text -> Bool
+hasReservedNamespace l = "com.docker." `Text.isPrefixOf` l
+  || "io.docker." `Text.isPrefixOf` l
+  || "org.dockerproject." `Text.isPrefixOf` l
+
+hasConsecutiveSeparators :: Text.Text -> Bool
+hasConsecutiveSeparators l = ".." `Text.isInfixOf` l || "--" `Text.isInfixOf` l
+
+validChars :: String
+validChars = ['0'..'9'] ++ ['a' .. 'z'] ++ ['.', '-']

--- a/src/Hadolint/Rule/DL3049.hs
+++ b/src/Hadolint/Rule/DL3049.hs
@@ -1,0 +1,60 @@
+ module Hadolint.Rule.DL3049 (rule) where
+
+import qualified Data.Map as Map
+import qualified Data.Set as Set
+import qualified Data.Sequence as Seq
+import qualified Data.Text as Text
+import Hadolint.Rule
+import Language.Docker.Syntax
+
+
+rule :: LabelSchema -> Rule args
+rule labelschema = mconcat $ fmap missingLabelRule (Map.keys labelschema)
+{-# INLINEABLE rule #-}
+
+data StageID = StageID
+  { name :: Text.Text,
+    line :: Linenumber
+  } deriving (Eq, Ord, Show)
+
+data Acc
+  = Acc StageID (Set.Set StageID) (Set.Set StageID)
+  | Empty
+  deriving (Show)
+
+-- missingLabelRule
+--
+-- triggers on a `FROM` instruction when label `label` is not defined within
+-- that stage. Tracks defined labels through multi stage builds
+missingLabelRule :: LabelName -> Rule args
+missingLabelRule label = veryCustomRule check (emptyState Empty) markFailure
+  where
+    code = "DL3049"
+    severity = DLInfoC
+    message = "Label `" <> label <> "` is missing."
+    check line state (From BaseImage {image, alias = Just als}) =
+        state |> modify (currentStage (imageName image) (StageID (unImageAlias als) line))
+    check line state (From BaseImage {image, alias = Nothing}) =
+        state |> modify (currentStage (imageName image) (StageID (imageName image) line))
+    check _ state (Label pairs)
+        | label `elem` fmap fst pairs = state |> modify goodStage
+        | otherwise = state
+    check _ state _ = state
+
+    markFailure :: State Acc -> Failures
+    markFailure (State fails (Acc _ _ b)) = Set.foldl' (Seq.|>) fails (Set.map markFail b)
+    markFailure st = failures st
+
+    markFail (StageID _ line) = CheckFailure {..}
+
+currentStage :: Text.Text -> StageID -> Acc -> Acc
+currentStage src stageid (Acc _ g b)
+    | not $ Set.null (Set.filter (predicate src) g) = Acc stageid (g |> Set.insert stageid) b
+    | otherwise = Acc stageid g (b |> Set.insert stageid)
+  where
+    predicate n0 StageID {name = n1} = n1 == n0
+currentStage _ stageid Empty = Acc stageid Set.empty (Set.singleton stageid)
+
+goodStage :: Acc -> Acc
+goodStage (Acc stageid g b) = Acc stageid (g |> Set.insert stageid) (b |> Set.delete stageid)
+goodStage Empty = Empty

--- a/src/Hadolint/Rule/DL3050.hs
+++ b/src/Hadolint/Rule/DL3050.hs
@@ -1,0 +1,18 @@
+module Hadolint.Rule.DL3050 (rule) where
+
+import qualified Data.Map as Map
+import Hadolint.Rule
+import Language.Docker.Syntax
+
+
+rule :: LabelSchema -> Bool -> Rule args
+rule labelschema strictlabels = simpleRule code severity message check
+  where
+    code = "DL3050"
+    severity = DLInfoC
+    message = "Superfluous label(s) present."
+    check (Label pairs)
+        | strictlabels = all ((`elem` Map.keys labelschema) . fst) pairs
+        | otherwise = True
+    check _ = True
+{-# INLINEABLE rule #-}

--- a/src/Hadolint/Rule/DL3051.hs
+++ b/src/Hadolint/Rule/DL3051.hs
@@ -1,0 +1,23 @@
+module Hadolint.Rule.DL3051 (rule) where
+
+import qualified Data.Map as Map
+import qualified Data.Text as Text
+import Hadolint.Rule
+import Language.Docker.Syntax
+
+
+rule :: LabelSchema -> Rule args
+rule labelschema = mconcat $ fmap labelIsNotEmptyRule (Map.keys labelschema)
+{-# INLINEABLE rule #-}
+
+labelIsNotEmptyRule :: LabelName -> Rule args
+labelIsNotEmptyRule label = simpleRule code severity message check
+  where
+    code = "DL3051"
+    severity = DLWarningC
+    message = "label `" <> label <> "` is empty."
+    check (Label pairs) = null $ getEmptyLabels label pairs
+    check _ = True
+
+getEmptyLabels :: LabelName -> Pairs -> Pairs
+getEmptyLabels lbl prs = [(l, v) | (l, v) <- prs, l == lbl, Text.null v]

--- a/src/Hadolint/Rule/DL3052.hs
+++ b/src/Hadolint/Rule/DL3052.hs
@@ -10,7 +10,7 @@ import Network.URI as Uri
 
 rule :: LabelSchema -> Rule args
 rule labelschema = mconcat $
-  fmap labelIsNotUrlRule (Map.keys (Map.filter (== "url") labelschema))
+  fmap labelIsNotUrlRule (Map.keys (Map.filter (== Url) labelschema))
 {-# INLINEABLE rule #-}
 
 labelIsNotUrlRule :: LabelName -> Rule args

--- a/src/Hadolint/Rule/DL3052.hs
+++ b/src/Hadolint/Rule/DL3052.hs
@@ -1,0 +1,27 @@
+module Hadolint.Rule.DL3052 (rule) where
+
+import qualified Data.Map as Map
+import Data.Maybe
+import qualified Data.Text as Text
+import Hadolint.Rule
+import Language.Docker.Syntax
+import Network.URI as Uri
+
+
+rule :: LabelSchema -> Rule args
+rule labelschema = mconcat $
+  fmap labelIsNotUrlRule (Map.keys (Map.filter (== "url") labelschema))
+{-# INLINEABLE rule #-}
+
+labelIsNotUrlRule :: LabelName -> Rule args
+labelIsNotUrlRule label = simpleRule code severity message check
+  where
+    code = "DL3052"
+    severity = DLWarningC
+    message = "Label `" <> label <> "` is not a valid URL."
+    check (Label ls) = null $ getBadURLLabels label ls
+    check _ = True
+
+getBadURLLabels :: LabelName -> Pairs -> Pairs
+getBadURLLabels lbl prs = [(l, u) | (l, u) <- prs, l == lbl,
+                                    (isNothing . Uri.parseURI) (Text.unpack u)]

--- a/src/Hadolint/Rule/DL3053.hs
+++ b/src/Hadolint/Rule/DL3053.hs
@@ -9,7 +9,7 @@ import Language.Docker.Syntax
 
 rule :: LabelSchema -> Rule args
 rule labelschema = mconcat $
-  fmap labelIsNotRFC3339Rule (Map.keys (Map.filter (== "rfc3339") labelschema))
+  fmap labelIsNotRFC3339Rule (Map.keys (Map.filter (== Rfc3339) labelschema))
 {-# INLINEABLE rule #-}
 
 

--- a/src/Hadolint/Rule/DL3053.hs
+++ b/src/Hadolint/Rule/DL3053.hs
@@ -1,0 +1,28 @@
+module Hadolint.Rule.DL3053 (rule) where
+
+import qualified Data.Map as Map
+import Data.Maybe
+import Data.Time.RFC3339
+import Hadolint.Rule
+import Language.Docker.Syntax
+
+
+rule :: LabelSchema -> Rule args
+rule labelschema = mconcat $
+  fmap labelIsNotRFC3339Rule (Map.keys (Map.filter (== "rfc3339") labelschema))
+{-# INLINEABLE rule #-}
+
+
+labelIsNotRFC3339Rule :: LabelName -> Rule args
+labelIsNotRFC3339Rule label = simpleRule code severity message check
+  where
+    code = "DL3053"
+    severity = DLWarningC
+    message = "Label `" <> label <> "` is not a valid time format - must be conform to RFC3339."
+    check (Label ls) = null $ getBadTimeformatLabels label ls
+    check _ = True
+
+getBadTimeformatLabels :: LabelName -> Pairs -> Pairs
+getBadTimeformatLabels lbl pairs = [(l, v) | (l, v) <- pairs,
+                                             l == lbl,
+                                             isNothing $ parseTimeRFC3339 v]

--- a/src/Hadolint/Rule/DL3054.hs
+++ b/src/Hadolint/Rule/DL3054.hs
@@ -1,0 +1,32 @@
+module Hadolint.Rule.DL3054 (rule) where
+
+import Data.Either
+import qualified Data.Map as Map
+import qualified Data.Text as Text
+import Distribution.Parsec
+import Distribution.SPDX.Extra
+import Hadolint.Rule
+import Language.Docker.Syntax
+
+
+rule :: LabelSchema -> Rule args
+rule labelschema = mconcat $
+  fmap labelIsNotSPDXRule (Map.keys (Map.filter (== "spdx") labelschema))
+{-# INLINEABLE rule #-}
+
+labelIsNotSPDXRule :: LabelName -> Rule args
+labelIsNotSPDXRule label = simpleRule code severity message check
+  where
+    code = "DL3054"
+    severity = DLWarningC
+    message = "Label `" <> label <> "` is not a valid SPDX identifier."
+    check (Label ls) = null $ getBadLicenseLabels label ls
+    check _ = True
+
+
+getBadLicenseLabels :: LabelName -> Pairs -> Pairs
+getBadLicenseLabels lbl pairs =
+    [ (l, v) | (l, v) <- pairs,
+               l == lbl,
+               isLeft (eitherParsec (Text.unpack v) :: Either String LicenseId)
+    ]

--- a/src/Hadolint/Rule/DL3054.hs
+++ b/src/Hadolint/Rule/DL3054.hs
@@ -11,7 +11,7 @@ import Language.Docker.Syntax
 
 rule :: LabelSchema -> Rule args
 rule labelschema = mconcat $
-  fmap labelIsNotSPDXRule (Map.keys (Map.filter (== "spdx") labelschema))
+  fmap labelIsNotSPDXRule (Map.keys (Map.filter (== Spdx) labelschema))
 {-# INLINEABLE rule #-}
 
 labelIsNotSPDXRule :: LabelName -> Rule args

--- a/src/Hadolint/Rule/DL3055.hs
+++ b/src/Hadolint/Rule/DL3055.hs
@@ -8,7 +8,7 @@ import Language.Docker.Syntax
 
 rule :: LabelSchema -> Rule args
 rule labelschema = mconcat $
-  fmap labelIsNotGitHashRule (Map.keys (Map.filter (== "hash") labelschema))
+  fmap labelIsNotGitHashRule (Map.keys (Map.filter (== GitHash) labelschema))
 {-# INLINEABLE rule #-}
 
 labelIsNotGitHashRule :: LabelName -> Rule args

--- a/src/Hadolint/Rule/DL3055.hs
+++ b/src/Hadolint/Rule/DL3055.hs
@@ -1,0 +1,31 @@
+module Hadolint.Rule.DL3055 (rule) where
+
+import qualified Data.Map as Map
+import qualified Data.Text as Text
+import Hadolint.Rule
+import Language.Docker.Syntax
+
+
+rule :: LabelSchema -> Rule args
+rule labelschema = mconcat $
+  fmap labelIsNotGitHashRule (Map.keys (Map.filter (== "hash") labelschema))
+{-# INLINEABLE rule #-}
+
+labelIsNotGitHashRule :: LabelName -> Rule args
+labelIsNotGitHashRule label = simpleRule code severity message check
+  where
+    code = "DL3055"
+    severity = DLWarningC
+    message = "Label `" <> label <> "` is not a valid git hash."
+    check (Label ls) = null $ getBadHashLabels label ls
+    check _ = True
+
+getBadHashLabels :: LabelName -> Pairs -> Pairs
+getBadHashLabels lbl prs = [(l, v) | (l, v) <- prs, l == lbl, isBadHash v]
+
+isBadHash :: Text.Text -> Bool
+isBadHash h = Text.any (`notElem` validHash) h
+            || (Text.length h /= 40 && Text.length h /= 7)
+
+validHash :: String
+validHash = ['0'..'9'] ++ ['a'..'f']

--- a/src/Hadolint/Rule/DL3056.hs
+++ b/src/Hadolint/Rule/DL3056.hs
@@ -10,7 +10,7 @@ import Language.Docker.Syntax
 
 rule :: LabelSchema -> Rule args
 rule labelschema = mconcat $
-  fmap labelIsNotSemVerRule (Map.keys (Map.filter (== "semver") labelschema))
+  fmap labelIsNotSemVerRule (Map.keys (Map.filter (== SemVer) labelschema))
 {-# INLINEABLE rule #-}
 
 labelIsNotSemVerRule :: LabelName -> Rule args

--- a/src/Hadolint/Rule/DL3056.hs
+++ b/src/Hadolint/Rule/DL3056.hs
@@ -1,0 +1,27 @@
+module Hadolint.Rule.DL3056 (rule) where
+
+import Data.Either
+import qualified Data.Map as Map
+import qualified Data.SemVer as SemVer
+import qualified Data.Text as Text
+import Hadolint.Rule
+import Language.Docker.Syntax
+
+
+rule :: LabelSchema -> Rule args
+rule labelschema = mconcat $
+  fmap labelIsNotSemVerRule (Map.keys (Map.filter (== "semver") labelschema))
+{-# INLINEABLE rule #-}
+
+labelIsNotSemVerRule :: LabelName -> Rule args
+labelIsNotSemVerRule label = simpleRule code severity message check
+  where
+    code = "DL3056"
+    severity = DLWarningC
+    message = Text.pack "Label `" <> label <> Text.pack "` does not conform to semantic versioning."
+    check (Label pairs) = hasNoBadVersioning label pairs
+    check _ = True
+
+hasNoBadVersioning :: LabelName -> Pairs -> Bool
+hasNoBadVersioning lbl prs = null [(l, v) | (l, v) <- prs, l == lbl,
+                                            isLeft $ SemVer.fromText v]

--- a/stack.yaml
+++ b/stack.yaml
@@ -8,5 +8,6 @@ extra-deps:
   - colourista-0.1.0.0
   - language-docker-9.1.3
   - megaparsec-9.0.0@sha256:920d1e469056c746b532333a078c2a9a195fab5e860e0c9734ee92a28c2bfb65,3117
+  - spdx-1.0.0.2@sha256:7dfac9b454ff2da0abb7560f0ffbe00ae442dd5cb76e8be469f77e6988a70fed,2008
 ghc-options:
   "$everything": -haddock

--- a/test/ConfigSpec.hs
+++ b/test/ConfigSpec.hs
@@ -7,6 +7,7 @@ import qualified Data.ByteString.Char8 as Bytes
 import Data.Map
 import qualified Data.YAML as Yaml
 import Hadolint.Config
+import Hadolint.Rule as Rule
 import Test.HUnit
 import Test.Hspec
 
@@ -81,7 +82,7 @@ tests =
               "  author: text",
               "  url: url"
             ]
-          expected = ConfigFile Nothing Nothing Nothing (Just (fromList [("author", "text"), ("url", "url")])) Nothing
+          expected = ConfigFile Nothing Nothing Nothing (Just (fromList [("author", Rule.RawText), ("url", Rule.Url)])) Nothing
        in assertConfig expected (Bytes.unlines configFile)
 
     it "Parses config with only label-schema" $
@@ -113,7 +114,7 @@ tests =
               "  url: url"
             ]
           override = Just (OverrideConfig (Just ["DL3001"]) (Just ["DL3003"]) (Just ["DL3002"]) (Just ["DL3004"]))
-          labelschema = Just (fromList [("author", "text"), ("url", "url")])
+          labelschema = Just (fromList [("author", Rule.RawText), ("url", Rule.Url)])
           expected = ConfigFile override (Just ["DL3000"]) (Just ["hub.docker.com"]) labelschema (Just False)
        in assertConfig expected (Bytes.unlines configFile)
 

--- a/test/ConfigSpec.hs
+++ b/test/ConfigSpec.hs
@@ -4,6 +4,7 @@ module ConfigSpec where
 
 import Control.Monad (unless)
 import qualified Data.ByteString.Char8 as Bytes
+import Data.Map
 import qualified Data.YAML as Yaml
 import Hadolint.Config
 import Test.HUnit
@@ -20,7 +21,7 @@ tests =
               "    - SC1010"
             ]
           override = Just (OverrideConfig (Just ["DL3000", "SC1010"]) Nothing Nothing Nothing)
-          expected = ConfigFile override Nothing Nothing
+          expected = ConfigFile override Nothing Nothing Nothing Nothing
        in assertConfig expected (Bytes.unlines configFile)
 
     it "Parses config with only warning severities" $
@@ -31,7 +32,7 @@ tests =
               "    - SC1010"
             ]
           override = Just (OverrideConfig Nothing (Just ["DL3000", "SC1010"]) Nothing Nothing)
-          expected = ConfigFile override Nothing Nothing
+          expected = ConfigFile override Nothing Nothing Nothing Nothing
        in assertConfig expected (Bytes.unlines configFile)
 
     it "Parses config with only info severities" $
@@ -42,7 +43,7 @@ tests =
               "    - SC1010"
             ]
           override = Just (OverrideConfig Nothing Nothing (Just ["DL3000", "SC1010"]) Nothing)
-          expected = ConfigFile override Nothing Nothing
+          expected = ConfigFile override Nothing Nothing Nothing Nothing
        in assertConfig expected (Bytes.unlines configFile)
 
     it "Parses config with only style severities" $
@@ -53,7 +54,7 @@ tests =
               "    - SC1010"
             ]
           override = Just (OverrideConfig Nothing Nothing Nothing (Just ["DL3000", "SC1010"]))
-          expected = ConfigFile override Nothing Nothing
+          expected = ConfigFile override Nothing Nothing Nothing Nothing
        in assertConfig expected (Bytes.unlines configFile)
 
     it "Parses config with only ignores" $
@@ -62,7 +63,7 @@ tests =
               "- DL3000",
               "- SC1010"
             ]
-          expected = ConfigFile Nothing (Just ["DL3000", "SC1010"]) Nothing
+          expected = ConfigFile Nothing (Just ["DL3000", "SC1010"]) Nothing Nothing Nothing
        in assertConfig expected (Bytes.unlines configFile)
 
     it "Parses config with only trustedRegistries" $
@@ -71,7 +72,21 @@ tests =
               "- hub.docker.com",
               "- my.shady.xyz"
             ]
-          expected = ConfigFile Nothing Nothing (Just ["hub.docker.com", "my.shady.xyz"])
+          expected = ConfigFile Nothing Nothing (Just ["hub.docker.com", "my.shady.xyz"]) Nothing Nothing
+       in assertConfig expected (Bytes.unlines configFile)
+
+    it "Parses config with only label-schema" $
+      let configFile =
+            [ "label-schema:",
+              "  author: text",
+              "  url: url"
+            ]
+          expected = ConfigFile Nothing Nothing Nothing (Just (fromList [("author", "text"), ("url", "url")])) Nothing
+       in assertConfig expected (Bytes.unlines configFile)
+
+    it "Parses config with only label-schema" $
+      let configFile = [ "strict-labels: true" ]
+          expected = ConfigFile Nothing Nothing Nothing Nothing (Just True)
        in assertConfig expected (Bytes.unlines configFile)
 
     it "Parses full file" $
@@ -90,10 +105,16 @@ tests =
               "- hub.docker.com",
               "",
               "ignored:",
-              "- DL3000"
+              "- DL3000",
+              "",
+              "strict-labels: false",
+              "label-schema:",
+              "  author: text",
+              "  url: url"
             ]
           override = Just (OverrideConfig (Just ["DL3001"]) (Just ["DL3003"]) (Just ["DL3002"]) (Just ["DL3004"]))
-          expected = ConfigFile override (Just ["DL3000"]) (Just ["hub.docker.com"])
+          labelschema = Just (fromList [("author", "text"), ("url", "url")])
+          expected = ConfigFile override (Just ["DL3000"]) (Just ["hub.docker.com"]) labelschema (Just False)
        in assertConfig expected (Bytes.unlines configFile)
 
 assertConfig :: HasCallStack => ConfigFile -> Bytes.ByteString -> Assertion

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -11,6 +11,7 @@ import qualified Data.Text as Text
 import Hadolint.Formatter.TTY (formatCheck, formatError)
 import qualified Hadolint.Process
 import Hadolint.Rule (CheckFailure (..), Failures, RuleCode (..))
+import Hadolint.Rule as Rule
 import Language.Docker.Parser
 import Language.Docker.Syntax
 import qualified ShellSpec
@@ -1665,7 +1666,7 @@ main =
       it "warn when `useradd` and long uid without flag `-l`" $ ruleCatches "DL3046" "RUN useradd -u 123456 luser"
     --
     describe "Missing label rule tests" $
-      let ?rulesConfig = Hadolint.Process.RulesConfig [] (Map.fromList [("foo", "text")]) False
+      let ?rulesConfig = Hadolint.Process.RulesConfig [] (Map.fromList [("foo", Rule.RawText)]) False
        in do
     -- single stage tests
       it "not ok: single stage, no label" $ do
@@ -1734,7 +1735,7 @@ main =
               (Text.unlines dockerFile)
               (failsWith 0 "DL3049")
     describe "Strict Labels" $
-      let ?rulesConfig = Hadolint.Process.RulesConfig [] (Map.fromList [("required", "text")]) True
+      let ?rulesConfig = Hadolint.Process.RulesConfig [] (Map.fromList [("required", Rule.RawText)]) True
        in do
       it "ok with no label" $ do
         ruleCatchesNot "DL3050" ""
@@ -1749,7 +1750,7 @@ main =
         ruleCatches "DL3050" "LABEL required=\"foo\" other=\"bar\""
         onBuildRuleCatches "DL3050" "LABEL required=\"foo\" other=\"bar\""
     describe "Label is not empty rule" $
-      let ?rulesConfig = Hadolint.Process.RulesConfig [] (Map.fromList [("emptylabel", "text")]) False
+      let ?rulesConfig = Hadolint.Process.RulesConfig [] (Map.fromList [("emptylabel", Rule.RawText)]) False
        in do
       it "not ok with label empty" $ do
         ruleCatches "DL3051" "LABEL emptylabel=\"\""
@@ -1761,7 +1762,7 @@ main =
         ruleCatchesNot "DL3051" "LABEL other=\"\""
         onBuildRuleCatchesNot "DL3051" "LABEL other=\"\""
     describe "Label is not URL rule" $
-      let ?rulesConfig = Hadolint.Process.RulesConfig [] (Map.fromList [("urllabel", "url")]) False
+      let ?rulesConfig = Hadolint.Process.RulesConfig [] (Map.fromList [("urllabel", Rule.Url)]) False
        in do
       it "not ok with label not containing URL" $ do
         ruleCatches "DL3052" "LABEL urllabel=\"not-url\""
@@ -1773,7 +1774,7 @@ main =
         ruleCatchesNot "DL3052" "LABEL other=\"foo\""
         onBuildRuleCatchesNot "DL3052" "LABEL other=\"bar\""
     describe "Label is not RFC3339 date rule" $
-      let ?rulesConfig = Hadolint.Process.RulesConfig [] (Map.fromList [("datelabel", "rfc3339")]) False
+      let ?rulesConfig = Hadolint.Process.RulesConfig [] (Map.fromList [("datelabel", Rule.Rfc3339)]) False
        in do
       it "not ok with label not containing RFC3339 date" $ do
         ruleCatches "DL3053" "LABEL datelabel=\"not-date\""
@@ -1785,7 +1786,7 @@ main =
         ruleCatchesNot "DL3053" "LABEL other=\"doo\""
         onBuildRuleCatchesNot "DL3053" "LABEL other=\"bar\""
     describe "Label is not SPDX license identifier rule" $
-      let ?rulesConfig = Hadolint.Process.RulesConfig [] (Map.fromList [("spdxlabel", "spdx")]) False
+      let ?rulesConfig = Hadolint.Process.RulesConfig [] (Map.fromList [("spdxlabel", Rule.Spdx)]) False
        in do
       it "not ok with label not containing SPDX identifier" $ do
         ruleCatches "DL3054" "LABEL spdxlabel=\"not-spdx\""
@@ -1797,7 +1798,7 @@ main =
         ruleCatchesNot "DL3054" "LABEL other=\"fooo\""
         onBuildRuleCatchesNot "DL3054" "LABEL other=\"bar\""
     describe "Label is not git hash rule" $
-      let ?rulesConfig = Hadolint.Process.RulesConfig [] (Map.fromList [("githash", "hash")]) False
+      let ?rulesConfig = Hadolint.Process.RulesConfig [] (Map.fromList [("githash", Rule.GitHash)]) False
        in do
       it "not ok with label not containing git hash" $ do
         ruleCatches "DL3055" "LABEL githash=\"not-git-hash\""
@@ -1812,7 +1813,7 @@ main =
         ruleCatchesNot "DL3055" "LABEL other=\"foo\""
         onBuildRuleCatchesNot "DL3055" "LABEL other=\"bar\""
     describe "Label is not semantic version rule" $
-      let ?rulesConfig = Hadolint.Process.RulesConfig [] (Map.fromList [("semver", "semver")]) False
+      let ?rulesConfig = Hadolint.Process.RulesConfig [] (Map.fromList [("semver", Rule.SemVer)]) False
        in do
       it "not ok with label not containing semantic version" $ do
         ruleCatches "DL3056" "LABEL semver=\"not-sem-ver\""

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -6,6 +6,7 @@ import qualified ConfigSpec
 import qualified Control.Foldl as Foldl
 import Control.Monad (unless, when)
 import qualified Data.Sequence as Seq
+import qualified Data.Map as Map
 import qualified Data.Text as Text
 import Hadolint.Formatter.TTY (formatCheck, formatError)
 import qualified Hadolint.Process
@@ -879,7 +880,6 @@ main =
               -- This is debatable, as it should actaully pass, but detecting it correctly
               -- is quite difficult
               assertOnBuildChecks dockerFile failsShellcheck
-
       it "Resets the SHELL to sh after a FROM" $
         let dockerFile =
               Text.unlines
@@ -1413,21 +1413,21 @@ main =
         let dockerFile =
               [ "FROM random.com/debian"
               ]
-        let ?rulesConfig = Hadolint.Process.RulesConfig ["docker.io"]
+        let ?rulesConfig = Hadolint.Process.RulesConfig ["docker.io"] Map.empty False
         ruleCatches "DL3026" $ Text.unlines dockerFile
 
       it "does not warn on allowed registries" $ do
         let dockerFile =
               [ "FROM random.com/debian"
               ]
-        let ?rulesConfig = Hadolint.Process.RulesConfig ["x.com", "random.com"]
+        let ?rulesConfig = Hadolint.Process.RulesConfig ["x.com", "random.com"] Map.empty False
         ruleCatchesNot "DL3026" $ Text.unlines dockerFile
 
       it "doesn't warn on scratch image" $ do
         let dockerFile =
               [ "FROM scratch"
               ]
-        let ?rulesConfig = Hadolint.Process.RulesConfig ["x.com", "random.com"]
+        let ?rulesConfig = Hadolint.Process.RulesConfig ["x.com", "random.com"] Map.empty False
         ruleCatchesNot "DL3026" $ Text.unlines dockerFile
 
       it "allows boths all forms of docker.io" $ do
@@ -1436,7 +1436,7 @@ main =
                 "FROM zemanlx/ubuntu:18.04 AS builder2",
                 "FROM docker.io/zemanlx/ubuntu:18.04 AS builder3"
               ]
-        let ?rulesConfig = Hadolint.Process.RulesConfig ["docker.io"]
+        let ?rulesConfig = Hadolint.Process.RulesConfig ["docker.io"] Map.empty False
         ruleCatchesNot "DL3026" $ Text.unlines dockerFile
 
       it "allows using previous stages" $ do
@@ -1444,7 +1444,7 @@ main =
               [ "FROM random.com/foo AS builder1",
                 "FROM builder1 AS builder2"
               ]
-        let ?rulesConfig = Hadolint.Process.RulesConfig ["random.com"]
+        let ?rulesConfig = Hadolint.Process.RulesConfig ["random.com"] Map.empty False
         ruleCatchesNot "DL3026" $ Text.unlines dockerFile
     --
     describe "Wget or Curl" $ do
@@ -1663,6 +1663,195 @@ main =
       it "ok with `useradd` long uid and flag `-l`" $ ruleCatchesNot "DL3046" "RUN useradd -l -u 123456 luser"
       it "ok with `useradd` and just flag `-l`" $ ruleCatchesNot "DL3046" "RUN useradd -l luser"
       it "warn when `useradd` and long uid without flag `-l`" $ ruleCatches "DL3046" "RUN useradd -u 123456 luser"
+    --
+    describe "Missing label rule tests" $
+      let ?rulesConfig = Hadolint.Process.RulesConfig [] (Map.fromList [("foo", "text")]) False
+       in do
+    -- single stage tests
+      it "not ok: single stage, no label" $ do
+        ruleCatches "DL3049" "FROM baseimage"
+        onBuildRuleCatches "DL3049" "FROM baseimage"
+      it "not ok: single stage, wrong label" $ do
+        ruleCatches "DL3049" "FROM baseimage\nLABEL bar=\"baz\""
+        onBuildRuleCatches "DL3049" "FROM baseimage\nLABEL bar=\"baz\""
+      it "ok: single stage, label present" $ do
+        ruleCatchesNot "DL3049" "FROM baseimage\nLABEL foo=\"bar\""
+        onBuildRuleCatchesNot "DL3049" "FROM baseimage\nLABEL foo=\"bar\""
+    -- multi stage tests
+      it "warn twice: two stages, no labels" $
+        let dockerFile =
+              [ "FROM stage1",
+                "FROM stage2"
+              ]
+         in assertChecks
+              (Text.unlines dockerFile)
+              (failsWith 2 "DL3049")
+      it "warn twice: two stages, wrong labels only" $
+        let dockerFile =
+              [ "FROM stage1",
+                "LABEL bar=\"baz\"",
+                "FROM stage2",
+                "LABEL buzz=\"fuzz\""
+              ]
+         in assertChecks
+              (Text.unlines dockerFile)
+              (failsWith 2 "DL3049")
+      it "warn once: two stages, label present in second only" $
+        let dockerFile =
+              [ "FROM baseimage",
+                "FROM newimage",
+                "LABEL foo=\"bar\""
+              ]
+         in assertChecks
+              (Text.unlines dockerFile)
+              (failsWith 1 "DL3049")
+      it "warn once: two stages, no inheritance, wrong label in one" $
+        let dockerFile =
+              [ "FROM baseimage",
+                "LABEL baz=\"bar\"",
+                "FROM newimage",
+                "LABEL foo=\"bar\""
+              ]
+         in assertChecks
+              (Text.unlines dockerFile)
+              (failsWith 1 "DL3049")
+      it "warn once: two stages, inheritance, label only defined in second stage" $
+        let dockerFile =
+              [ "FROM baseimage as base",
+                "FROM base",
+                "LABEL foo=\"bar\""
+              ]
+         in assertChecks
+              (Text.unlines dockerFile)
+              (failsWith 1 "DL3049")
+      it "don't warn: two stages, inheritance" $
+        let dockerFile =
+              [ "FROM baseimage as base",
+                "LABEL foo=\"bar\"",
+                "FROM base"
+              ]
+         in assertChecks
+              (Text.unlines dockerFile)
+              (failsWith 0 "DL3049")
+    describe "Strict Labels" $
+      let ?rulesConfig = Hadolint.Process.RulesConfig [] (Map.fromList [("required", "text")]) True
+       in do
+      it "ok with no label" $ do
+        ruleCatchesNot "DL3050" ""
+        onBuildRuleCatchesNot "DL3050" ""
+      it "ok with required label" $ do
+        ruleCatchesNot "DL3050" "LABEL required=\"foo\""
+        onBuildRuleCatchesNot "DL3050" "LABEL required=\"bar\""
+      it "not ok with just other label" $ do
+        ruleCatches "DL3050" "LABEL other=\"bar\""
+        onBuildRuleCatches "DL3050" "LABEL other=\"bar\""
+      it "not ok with other label and required label" $ do
+        ruleCatches "DL3050" "LABEL required=\"foo\" other=\"bar\""
+        onBuildRuleCatches "DL3050" "LABEL required=\"foo\" other=\"bar\""
+    describe "Label is not empty rule" $
+      let ?rulesConfig = Hadolint.Process.RulesConfig [] (Map.fromList [("emptylabel", "text")]) False
+       in do
+      it "not ok with label empty" $ do
+        ruleCatches "DL3051" "LABEL emptylabel=\"\""
+        onBuildRuleCatches "DL3051" "LABEL emptylabel=\"\""
+      it "ok with label not empty" $ do
+        ruleCatchesNot "DL3051" "LABEL emptylabel=\"foo\""
+        onBuildRuleCatchesNot "DL3051" "LABEL emptylabel=\"bar\""
+      it "ok with other label empty" $ do
+        ruleCatchesNot "DL3051" "LABEL other=\"\""
+        onBuildRuleCatchesNot "DL3051" "LABEL other=\"\""
+    describe "Label is not URL rule" $
+      let ?rulesConfig = Hadolint.Process.RulesConfig [] (Map.fromList [("urllabel", "url")]) False
+       in do
+      it "not ok with label not containing URL" $ do
+        ruleCatches "DL3052" "LABEL urllabel=\"not-url\""
+        onBuildRuleCatches "DL3052" "LABEL urllabel=\"not-url\""
+      it "ok with label containing URL" $ do
+        ruleCatchesNot "DL3052" "LABEL urllabel=\"http://example.com\""
+        onBuildRuleCatchesNot "DL3052" "LABEL urllabel=\"http://example.com\""
+      it "ok with other label not containing URL" $ do
+        ruleCatchesNot "DL3052" "LABEL other=\"foo\""
+        onBuildRuleCatchesNot "DL3052" "LABEL other=\"bar\""
+    describe "Label is not RFC3339 date rule" $
+      let ?rulesConfig = Hadolint.Process.RulesConfig [] (Map.fromList [("datelabel", "rfc3339")]) False
+       in do
+      it "not ok with label not containing RFC3339 date" $ do
+        ruleCatches "DL3053" "LABEL datelabel=\"not-date\""
+        onBuildRuleCatches "DL3053" "LABEL datelabel=\"not-date\""
+      it "ok with label containing RFC3339 date" $ do
+        ruleCatchesNot "DL3053" "LABEL datelabel=\"2021-03-10T10:26:33.564595127+01:00\""
+        onBuildRuleCatchesNot "DL3053" "LABEL datelabel=\"2021-03-10T10:26:33.564595127+01:00\""
+      it "ok with other label not containing RFC3339 date" $ do
+        ruleCatchesNot "DL3053" "LABEL other=\"doo\""
+        onBuildRuleCatchesNot "DL3053" "LABEL other=\"bar\""
+    describe "Label is not SPDX license identifier rule" $
+      let ?rulesConfig = Hadolint.Process.RulesConfig [] (Map.fromList [("spdxlabel", "spdx")]) False
+       in do
+      it "not ok with label not containing SPDX identifier" $ do
+        ruleCatches "DL3054" "LABEL spdxlabel=\"not-spdx\""
+        onBuildRuleCatches "DL3054" "LABEL spdxlabel=\"not-spdx\""
+      it "ok with label containing SPDX identifier" $ do
+        ruleCatchesNot "DL3054" "LABEL spdxlabel=\"BSD-3-Clause\""
+        onBuildRuleCatchesNot "DL3054" "LABEL spdxlabel=\"MIT\""
+      it "ok with other label not containing SPDX identifier" $ do
+        ruleCatchesNot "DL3054" "LABEL other=\"fooo\""
+        onBuildRuleCatchesNot "DL3054" "LABEL other=\"bar\""
+    describe "Label is not git hash rule" $
+      let ?rulesConfig = Hadolint.Process.RulesConfig [] (Map.fromList [("githash", "hash")]) False
+       in do
+      it "not ok with label not containing git hash" $ do
+        ruleCatches "DL3055" "LABEL githash=\"not-git-hash\""
+        onBuildRuleCatches "DL3055" "LABEL githash=\"not-git-hash\""
+      it "ok with label containing short git hash" $ do
+        ruleCatchesNot "DL3055" "LABEL githash=\"2dbfae9\""
+        onBuildRuleCatchesNot "DL3055" "LABEL githash=\"2dbfae9\""
+      it "ok with label containing long git hash" $ do
+        ruleCatchesNot "DL3055" "LABEL githash=\"43c572f1272b6b3171dd1db9e41b7027128ce080\""
+        onBuildRuleCatchesNot "DL3055" "LABEL githash=\"43c572f1272b6b3171dd1db9e41b7027128ce080\""
+      it "ok with other label not containing git hash" $ do
+        ruleCatchesNot "DL3055" "LABEL other=\"foo\""
+        onBuildRuleCatchesNot "DL3055" "LABEL other=\"bar\""
+    describe "Label is not semantic version rule" $
+      let ?rulesConfig = Hadolint.Process.RulesConfig [] (Map.fromList [("semver", "semver")]) False
+       in do
+      it "not ok with label not containing semantic version" $ do
+        ruleCatches "DL3056" "LABEL semver=\"not-sem-ver\""
+        onBuildRuleCatches "DL3056" "LABEL semver=\"not-sem-ver\""
+      it "ok with label containing semantic version" $ do
+        ruleCatchesNot "DL3056" "LABEL semver=\"1.0.0\""
+        onBuildRuleCatchesNot "DL3056" "LABEL semver=\"2.0.1-rc1\""
+      it "ok with other label not containing semantic version" $ do
+        ruleCatchesNot "DL3056" "LABEL other=\"foo\""
+        onBuildRuleCatchesNot "DL3056" "LABEL other=\"bar\""
+    --
+    describe "Invalid Label Key Rule" $ do
+      it "not ok with reserved namespace" $ do
+        ruleCatches "DL3048" "LABEL com.docker.label=\"foo\""
+        ruleCatches "DL3048" "LABEL io.docker.label=\"foo\""
+        ruleCatches "DL3048" "LABEL org.dockerproject.label=\"foo\""
+        onBuildRuleCatches "DL3048" "LABEL com.docker.label=\"foo\""
+        onBuildRuleCatches "DL3048" "LABEL io.docker.label=\"foo\""
+        onBuildRuleCatches "DL3048" "LABEL org.dockerproject.label=\"foo\""
+      it "not ok with invalid character" $ do
+        ruleCatches "DL3048" "LABEL invalid$character=\"foo\""
+        onBuildRuleCatches "DL3048" "LABEL invalid$character=\"foo\""
+      it "not ok with invalid start and end characters" $ do
+        ruleCatches "DL3048" "LABEL .invalid =\"foo\""
+        ruleCatches "DL3048" "LABEL -invalid =\"foo\""
+        ruleCatches "DL3048" "LABEL 1invalid =\"foo\""
+        onBuildRuleCatches "DL3048" "LABEL .invalid=\"foo\""
+        onBuildRuleCatches "DL3048" "LABEL -invalid=\"foo\""
+        onBuildRuleCatches "DL3048" "LABEL 1invalid=\"foo\""
+      it "not ok with consecutive dividers" $ do
+        ruleCatches "DL3048" "LABEL invalid..character=\"foo\""
+        ruleCatches "DL3048" "LABEL invalid--character=\"foo\""
+        onBuildRuleCatches "DL3048" "LABEL invalid..character=\"foo\""
+        onBuildRuleCatches "DL3048" "LABEL invalid--character=\"foo\""
+      it "ok with valid labels" $ do
+        ruleCatchesNot "DL3048" "LABEL org.valid-key.label3=\"foo\""
+        ruleCatchesNot "DL3048" "LABEL validlabel=\"foo\""
+        onBuildRuleCatchesNot "DL3048" "LABEL org.valid-key.label3=\"foo\""
+        onBuildRuleCatchesNot "DL3048" "LABEL validlabel=\"foo\""
     --
     describe "Regression Tests" $ do
       it "Comments with backslashes at the end are just comments" $


### PR DESCRIPTION
- Add configuration options to describe a label schema to Hadolint.
- Add commandline option --require-label, which can also describe a
  label schema to Hadolint
- Add a rule that alerts on any label that is not specified to be
  present
- Add a rule generator, which generates rules that check the existence
  of labels described in the label schema.
- Add a rule generator for generating rules that check that labels have
  a valid URL as value
- Add a rule generator for generating rules that check that labels have
  a valid time stamp according to RFC3339 as value
- Add a rule generator for generating rules that check that labels have
  a valid SPDX license identifier as value
- Add a rule generator for generating rules that check that labels have
  a valid git hash as value

fixes #480 
fixes #199 
conflicts with: #530 

This is a draft PR and not quite ready yet but please feel invited to play around with this and give me feedback.

Configure your label schema via config file like so:
```yaml
label-schema:
  my-label: text
  my-url-label: url
  my-license-label: spdx
  my-git-hash-label: hash
  my-rfc3339-compliant-date-label: rfc3339
```
or via commandline options:
```
$ hadolint --require-label my-label --requrie-label my-url-label:url --require-label my-license-label:spdx [...] Dockerfile
```
![hadolint-labels](https://user-images.githubusercontent.com/17141774/110210367-9f208b80-7e91-11eb-936e-536d7b623025.png)

### Todo:
- [x] Make the superfluous label rule generator optional behind a --strict-labels flag, or similar
- [x] figure out tests
- [x] More informative messages
- [x] write documentation
- [x] Make the rule for label existence work better with multi stage builds
- [x] complete the value validation options, such that OCI labels can be fully validated
- [x] replace rule identifiers
- [x] Add rules for checking label names (see docker label inspector for example)
