### PR TITLE
healthcheck: Rules for checking HEALTHCHECK instructions

### DIFF
--- a/hadolint.cabal
+++ b/hadolint.cabal
@@ -4,7 +4,7 @@ cabal-version: 2.0
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: c7489925f7c60f72f7b137aaa8665b6eaa1e6ca5c4d8785d1f31bc5a55573914
+-- hash: 9005197a6ffe91fc38b440f234b96e25dbb18c603db1ceb521f1026e4f24e4a7
 
 name:           hadolint
 version:        2.0.0
@@ -56,6 +56,7 @@ library
       Hadolint.Rule.DL3009
       Hadolint.Rule.DL3010
       Hadolint.Rule.DL3011
+      Hadolint.Rule.DL3012
       Hadolint.Rule.DL3013
       Hadolint.Rule.DL3014
       Hadolint.Rule.DL3015
@@ -91,6 +92,7 @@ library
       Hadolint.Rule.DL3045
       Hadolint.Rule.DL3046
       Hadolint.Rule.DL3047
+      Hadolint.Rule.DL3057
       Hadolint.Rule.DL4000
       Hadolint.Rule.DL4001
       Hadolint.Rule.DL4003

--- a/src/Hadolint/Process.hs
+++ b/src/Hadolint/Process.hs
@@ -19,6 +19,7 @@ import qualified Hadolint.Rule.DL3008
 import qualified Hadolint.Rule.DL3009
 import qualified Hadolint.Rule.DL3010
 import qualified Hadolint.Rule.DL3011
+import qualified Hadolint.Rule.DL3012
 import qualified Hadolint.Rule.DL3013
 import qualified Hadolint.Rule.DL3014
 import qualified Hadolint.Rule.DL3015
@@ -54,6 +55,7 @@ import qualified Hadolint.Rule.DL3044
 import qualified Hadolint.Rule.DL3045
 import qualified Hadolint.Rule.DL3046
 import qualified Hadolint.Rule.DL3047
+import qualified Hadolint.Rule.DL3057
 import qualified Hadolint.Rule.DL4000
 import qualified Hadolint.Rule.DL4001
 import qualified Hadolint.Rule.DL4003
@@ -129,6 +131,7 @@ failures RulesConfig {allowedRegistries} =
     <> Hadolint.Rule.DL3009.rule
     <> Hadolint.Rule.DL3010.rule
     <> Hadolint.Rule.DL3011.rule
+    <> Hadolint.Rule.DL3012.rule
     <> Hadolint.Rule.DL3013.rule
     <> Hadolint.Rule.DL3014.rule
     <> Hadolint.Rule.DL3015.rule
@@ -164,6 +167,7 @@ failures RulesConfig {allowedRegistries} =
     <> Hadolint.Rule.DL3045.rule
     <> Hadolint.Rule.DL3046.rule
     <> Hadolint.Rule.DL3047.rule
+    <> Hadolint.Rule.DL3057.rule
     <> Hadolint.Rule.DL4000.rule
     <> Hadolint.Rule.DL4001.rule
     <> Hadolint.Rule.DL4003.rule

--- a/src/Hadolint/Rule/DL3012.hs
+++ b/src/Hadolint/Rule/DL3012.hs
@@ -1,0 +1,18 @@
+module Hadolint.Rule.DL3012 (rule) where
+
+import Hadolint.Rule
+import Language.Docker.Syntax
+
+
+rule :: Rule args
+rule = customRule check (emptyState False)
+  where
+    code = "DL3012"
+    severity = DLErrorC
+    message = "Multiple `HEALTHCHECK` instructions"
+    check _ st From {} = st |> replaceWith False
+    check line st Healthcheck {}
+        | not (state st) = st |> replaceWith True
+        | otherwise = st |> addFail CheckFailure {..}
+    check _ st _ = st
+{-# INLINEABLE rule #-}

--- a/src/Hadolint/Rule/DL3057.hs
+++ b/src/Hadolint/Rule/DL3057.hs
@@ -1,0 +1,50 @@
+module Hadolint.Rule.DL3057 (rule) where
+
+import qualified Data.Sequence as Seq
+import qualified Data.Set as Set
+import qualified Data.Text as Text
+import Hadolint.Rule
+import Language.Docker.Syntax
+
+
+data StageID = StageID
+  { name :: Text.Text,
+    line :: Linenumber
+  } deriving (Show, Eq, Ord)
+
+data Acc
+  = Acc StageID (Set.Set StageID) (Set.Set StageID)
+  | Empty
+  deriving (Show)
+
+rule :: Rule args
+rule = veryCustomRule check (emptyState Empty) markFailures
+  where
+    code = "DL3057"
+    severity = DLIgnoreC
+    message = "`HEALTHCHECK` instruction missing."
+
+    check line state (From BaseImage {image, alias = Just als}) =
+      state |> modify (currentStage (imageName image) (StageID (unImageAlias als) line))
+    check line state (From BaseImage {image, alias = Nothing}) =
+      state |> modify (currentStage (imageName image) (StageID (imageName image) line))
+    check _ state (Healthcheck _) = state |> modify goodStage
+    check _ state _ = state
+
+    markFailures :: State Acc -> Failures
+    markFailures (State fails (Acc _ _ b)) = Set.foldl' (Seq.|>) fails (Set.map makeFail b)
+    markFailures st = failures st
+    makeFail (StageID _ line) = CheckFailure {..}
+{-# INLINEABLE rule #-}
+
+currentStage :: Text.Text -> StageID -> Acc -> Acc
+currentStage src stageid (Acc _ g b)
+    | not $ Set.null (Set.filter (predicate src) g) = Acc stageid (g |> Set.insert stageid) b
+    | otherwise = Acc stageid g (b |> Set.insert stageid)
+  where
+    predicate n0 StageID {name = n1} = n1 == n0
+currentStage _ stageid Empty = Acc stageid Set.empty (Set.singleton stageid)
+
+goodStage :: Acc -> Acc
+goodStage (Acc stageid g b) = Acc stageid (g |> Set.insert stageid) (b |> Set.delete stageid)
+goodStage Empty = Empty

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -1569,6 +1569,26 @@ main =
               ]
          in ruleCatchesNot "DL3047" $ Text.unlines dockerFile
     --
+    describe "DL3012 - Multiple `HEALTHCHECK` instructions" $ do
+      it "ok with no HEALTHCHECK instruction" $
+        ruleCatchesNot "DL3012" "FROM scratch"
+      it "ok with one HEALTHCHECK instruction" $
+        ruleCatchesNot "DL3012" "FROM scratch\nHEALTHCHECK CMD /bin/bla"
+      it "ok with two HEALTHCHECK instructions in two stages" $
+        ruleCatchesNot "DL3012" "FROM scratch\nHEALTHCHECK CMD /bin/bla1\nFROM scratch\nHEALTHCHECK CMD /bin/bla2"
+      it "warn with two HEALTHCHECK instructions" $
+        ruleCatches "DL3012" "FROM scratch\nHEALTHCHECK CMD /bin/bla1\nHEALTHCHECK CMD /bin/bla2"
+    --
+    describe "DL3057 - `HEALTHCHECK instruction missing" $ do
+      it "warn with no HEALTHCHECK instructions" $
+        ruleCatches "DL3057" "FROM scratch"
+      it "ok with one HEALTHCHECK instruction" $
+        ruleCatchesNot "DL3057" "FROM scratch\nHEALTHCHECK CMD /bin/bla"
+      it "ok with inheriting HEALTHCHECK instruction" $
+        ruleCatchesNot "DL3057" "FROM scratch AS base\nHEALTHCHECK CMD /bin/bla\nFROM base"
+      it "warn when not inheriting with no HEALTHCHECK instruction" $
+        ruleCatches "DL3057" "FROM scratch AS base\nHEALTHCHECK CMD /bin/bla\nFROM scratch"
+    --
     describe "ONBUILD" $ do
       it "error when using `ONBUILD` within `ONBUILD`" $
         let dockerFile =


### PR DESCRIPTION
- Add rule DL3012 that makes sure no stage has two `HEALTHCHECK`
  instructions
- Add rule DL3057 that makes sure every stage has one `HEALTHCHECK`
  instruction.
  This rule disabled by default and can be enabled by overriding its
  severity.

fixes #360

### What I did

Third time's the charm, right? As promised here https://github.com/hadolint/hadolint/pull/555#issuecomment-801004824, this is the PR with the two rules wrt. `HEALTHCHECK` instructions.
