### PR TITLE
dl3044: fix bug with variable detection

### DIFF
--- a/src/Hadolint/Rule/DL3044.hs
+++ b/src/Hadolint/Rule/DL3044.hs
@@ -52,17 +52,17 @@ isSubstringOfAny t l =
 bareVariableInText :: Text.Text -> Text.Text -> Bool
 bareVariableInText v t =
   let var = "$" <> v
-      rest = Text.splitOn var t
+      rest = drop 1 $ Text.splitOn var t
    in var `Text.isInfixOf` t && any terminatesVarName rest
   where
     -- x would terminate a variable name if it was appended directly to
     -- that name
     terminatesVarName :: Text.Text -> Bool
-    terminatesVarName x = not $ beginsWithAnyOf x varChar
+    terminatesVarName x = Text.null x || not (beginsWithAnyOf x varChar)
 
     -- txt begins with any character of String
     beginsWithAnyOf :: Text.Text -> Set.Set Char -> Bool
-    beginsWithAnyOf txt str = Text.null txt || (Text.head txt `elem` str)
+    beginsWithAnyOf txt str = any (`Text.isPrefixOf` txt) (Set.map Text.singleton str)
 
     -- all characters valid in the inner of a shell variable name
     varChar :: Set.Set Char

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -1636,6 +1636,8 @@ main =
         ruleCatchesNot "DL3044" "ENV BLA=\"blubb\" BLUBB=\"$BLAFOO/blubb\""
       it "fail with partial match 5" $
         ruleCatches "DL3044" "ENV BLA=\"blubb\" BLUBB=\"$BLA/$BLAFOO/blubb\""
+      it "ok with parial match 6" $
+        ruleCatchesNot "DL3044" "ENV BLA=\"blubb\" BLUBB=\"BLA/$BLAFOO/BLA\""
       it "ok when previously defined in `ARG`" $
         ruleCatchesNot "DL3044" "ARG BLA\nENV BLA=${BLA}"
       it "ok when previously defined in `ENV`" $
@@ -1650,6 +1652,10 @@ main =
         ruleCatches "DL3044" "ENV BLA=\"blubb\" BLUBB=\"${BLA}/blubb\""
       it "fail with selfreferencing without curly braces ENV" $
         ruleCatches "DL3044" "ENV BLA=\"blubb\" BLUBB=\"$BLA/blubb\""
+      it "fail with full match 1" $
+        ruleCatches "DL3044" "ENV BLA=\"blubb\" BLUBB=\"$BLA\""
+      it "fail with full match 2" $
+        ruleCatches "DL3044" "ENV BLA=\"blubb\" BLUBB=\"${BLA}\""
     --
     describe "warn when using `useradd` with long UID and without `-l`" $ do
       it "ok with `useradd` alone" $ ruleCatchesNot "DL3046" "RUN useradd luser"


### PR DESCRIPTION
When a variable is defined in terms of another variable and that other
variable is not referred to with curly-baces notation, the definition of
the first variable is split on the variable name. This results in a list
of remaining strings. The beginnings of the remaining strings is used to
determine, if the variable name that was found was just a substring of
another variable name, or is the actual variable. This is done by scanning
the beginnings of these strings for characters that terminate a variable name.
If one such character is found, the variable name looked for is actually found
and not just a substring of another variable name.
Since the `Text.splitOn` also returns the first part before the
variable, it is wrongfully determined, that the variable was found in
cases where its name was just a substring in another variable name.
Dropping this substring that never could begin with a terminator for a
variable name therefore fixes this problem.

fixes #568

This fixes #568 because the erroneous match is removed:
```Dockerfile
ENV SAMTOOLS="$SOFT/samtools-$SAMTOOLS_VERSION/bin/samtools" \
    BGZIP="$SOFT/htslib-$SAMTOOLS_VERSION/bin/bgzip"
           ^^^^^^^^^^^^^
           This part matches erroneously, therefore the rule thinks that the variable name is terminated after $SAMTOOLS and needs to be flagged.
```