### PR TITLE
DL3045: Fix workdir detection in `ONBUILD` context

### DIFF
--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -1027,6 +1027,16 @@ main =
          in do
               ruleCatchesNot "DL3045" dockerFile
               onBuildRuleCatchesNot "DL3045" dockerFile
+      it "ok: `COPY` to relative destination if `WORKDIR` has been set, both within an `ONBUILD` context" $
+        let dockerFile =
+              Text.unlines
+                [ "FROM debian:buster",
+                  "ONBUILD WORKDIR /usr/local/lib",
+                  "ONBUILD COPY foo bar"
+                ]
+         in do
+              ruleCatchesNot "DL3045" dockerFile
+              onBuildRuleCatchesNot "DL3045" dockerFile
     --
     describe "other rules" $ do
       it "apt-get auto yes" $ do


### PR DESCRIPTION
- Fix workdir detection on `ONBUILD` context by allowing the current
  stage to take the special value `None`, since an `ONBUILD` context has
  no current build stage.
- Add test cast specifically testing this case

fixes: #573


### What I did
With the larger restructuring, the way `ONBUILD` instructions are linted has changed. Now the rules are executed on a filtered version of the dockerfile, only containing the lines with `ONBUILD` instructions. This strips the `FROM` instructions out of the input to the rules, breaking rules that rely on finding at least one `FROM` instruction to initialize.
This fix concerns only rule DL3045 by modifying its state to allow for the possibility that the current context has no `FROM` instruction.

### How to verify it
The following dockerfile should no longer trigger DL3045
```Dockerfile
FROM python:3.9

ONBUILD WORKDIR /usr/src/app
ONBUILD COPY requirements.txt .
```