### PR TITLE
Publish ARM64 docker images

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
         with:
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
@@ -54,7 +54,7 @@ jobs:
         with:
           context: .
           file: docker/Dockerfile
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64/v8
           push: true
           target: ${{ steps.build-opts.outputs.target }}
           tags: |

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -24,8 +24,17 @@ RUN scripts/fetch_version.sh \
   && stack install --ghc-options="-fPIC" --flag hadolint:static
 
 # COMPRESS WITH UPX
-RUN curl -sSL https://github.com/upx/upx/releases/download/v3.96/upx-3.96-amd64_linux.tar.xz \
-  | tar -x --xz --strip-components 1 upx-3.96-amd64_linux/upx \
+RUN case "$(uname -m)" in \
+  x86_64|amd64) \
+  LONG_ARCH="x86_64" \
+  SHORT_ARCH="amd64" \
+  ;; \
+  aarch64|arm64) \
+  LONG_ARCH="aarch64" \
+  SHORT_ARCH="arm64" \
+  ;; \
+  curl -sSL https://github.com/upx/upx/releases/download/v3.96/upx-3.96-${SHORT_ARCH}_linux.tar.xz \
+  | tar -x --xz --strip-components 1 upx-3.96-${SHORT_ARCH}_linux/upx \
   && ./upx --best --ultra-brute /root/.local/bin/hadolint
 
 FROM debian:stretch-slim AS debian-distro


### PR DESCRIPTION
### What I did

By leveraging QEMU we can build ARM64 docker images.

This feature is requested in #411.

### How I did it

I enabled ARM64 as a platform for QEMU and instructed the build-push action to build also for ARM64.

### How to verify it

Create a tag based on this branch to see if the Docker build is working for ARM64.

Tested in an artificial tag inside my fork: https://github.com/icereed/hadolint/actions/runs/697423133