### PR TITLE
DL3016: fix mistakenly interpret argument to flag as package

### DIFF
--- a/src/Hadolint/Rule/DL3016.hs
+++ b/src/Hadolint/Rule/DL3016.hs
@@ -26,36 +26,63 @@ rule = simpleRule code severity message check
 
     check (Run (RunArgs args _)) = foldArguments (Shell.noCommands forgotToPinVersion) args
     check _ = True
-
-    forgotToPinVersion cmd =
-      isNpmInstall cmd && installIsFirst cmd && not (all versionFixed (packages cmd))
-
-    isNpmInstall = Shell.cmdHasArgs "npm" ["install"]
-    installIsFirst cmd = ["install"] `isPrefixOf` Shell.getArgsNoFlags cmd
-    packages cmd = stripInstallPrefix (Shell.getArgsNoFlags cmd)
-
-    versionFixed package
-      | hasGitPrefix package = isVersionedGit package
-      | hasTarballSuffix package = True
-      | isFolder package = True
-      | otherwise = hasVersionSymbol package
-
-    gitPrefixes = ["git://", "git+ssh://", "git+http://", "git+https://"]
-    pathPrefixes = ["/", "./", "../", "~/"]
-    tarballSuffixes = [".tar", ".tar.gz", ".tgz"]
-
-    hasGitPrefix package = or [p `Text.isPrefixOf` package | p <- gitPrefixes]
-    hasTarballSuffix package = or [p `Text.isSuffixOf` package | p <- tarballSuffixes]
-    isFolder package = or [p `Text.isPrefixOf` package | p <- pathPrefixes]
-    isVersionedGit package = "#" `Text.isInfixOf` package
-
-    hasVersionSymbol package = "@" `Text.isInfixOf` dropScope package
-      where
-        dropScope pkg =
-          if "@" `Text.isPrefixOf` pkg
-            then Text.dropWhile ('/' <) pkg
-            else pkg
 {-# INLINEABLE rule #-}
+
+
+forgotToPinVersion :: Shell.Command -> Bool
+forgotToPinVersion cmd =
+  isNpmInstall cmd && installIsFirst cmd && not (all versionFixed (packages cmd))
+
+isNpmInstall :: Shell.Command -> Bool
+isNpmInstall = Shell.cmdHasArgs "npm" ["install"]
+
+installIsFirst :: Shell.Command -> Bool
+installIsFirst cmd = ["install"] `isPrefixOf` Shell.getArgsNoFlags
+  (Shell.dropFlagArg ignoreFlags cmd)
+
+packages :: Shell.Command -> [Text.Text]
+packages cmd = stripInstallPrefix
+  (Shell.getArgsNoFlags (Shell.dropFlagArg ignoreFlags cmd))
+
+versionFixed :: Text.Text -> Bool
+versionFixed package
+  | hasGitPrefix package = isVersionedGit package
+  | hasTarballSuffix package = True
+  | isFolder package = True
+  | otherwise = hasVersionSymbol package
+
+hasGitPrefix :: Text.Text -> Bool
+hasGitPrefix package = or [p `Text.isPrefixOf` package | p <- gitPrefixes]
+
+hasTarballSuffix :: Text.Text -> Bool
+hasTarballSuffix package = or [p `Text.isSuffixOf` package | p <- tarballSuffixes]
+
+isFolder :: Text.Text -> Bool
+isFolder package = or [p `Text.isPrefixOf` package | p <- pathPrefixes]
+
+isVersionedGit :: Text.Text -> Bool
+isVersionedGit package = "#" `Text.isInfixOf` package
+
+hasVersionSymbol :: Text.Text -> Bool
+hasVersionSymbol package = "@" `Text.isInfixOf` dropScope package
+  where
+    dropScope pkg =
+      if "@" `Text.isPrefixOf` pkg
+        then Text.dropWhile ('/' <) pkg
+        else pkg
 
 stripInstallPrefix :: [Text.Text] -> [Text.Text]
 stripInstallPrefix cmd = dropWhile (== "install") (dropWhile (/= "install") cmd)
+
+
+ignoreFlags :: [Text.Text]
+ignoreFlags = ["loglevel"]
+
+gitPrefixes :: [Text.Text]
+gitPrefixes = ["git://", "git+ssh://", "git+http://", "git+https://"]
+
+pathPrefixes :: [Text.Text]
+pathPrefixes = ["/", "./", "../", "~/"]
+
+tarballSuffixes :: [Text.Text]
+tarballSuffixes = [".tar", ".tar.gz", ".tgz"]

--- a/src/Hadolint/Shell.hs
+++ b/src/Hadolint/Shell.hs
@@ -18,14 +18,14 @@ data CmdPart = CmdPart
   { arg :: Text,
     partId :: Int
   }
-  deriving (Show)
+  deriving (Eq, Show)
 
 data Command = Command
   { name :: Text.Text,
     arguments :: [CmdPart],
     flags :: [CmdPart]
   }
-  deriving (Show)
+  deriving (Eq, Show)
 
 data ParsedShell = ParsedShell
   { original :: Text.Text,
@@ -202,8 +202,8 @@ dropFlagArg flagsToDrop Command {name, arguments, flags} = Command name filterdA
 getFlagArg :: Text.Text -> Command -> [Text.Text]
 getFlagArg flag Command {arguments, flags} = extractArgs
   where
-    idsToGet = [getValueId fId arguments | CmdPart f fId <- flags, f == flag]
-    extractArgs = [arg | (CmdPart arg aId) <- arguments, aId `elem` idsToGet]
+    idsToGet = Set.fromList [getValueId fId arguments | CmdPart f fId <- flags, f == flag]
+    extractArgs = [arg | (CmdPart arg aId) <- arguments, aId `Set.member` idsToGet]
 
 getValueId :: Int -> [CmdPart] -> Int
 getValueId fId flags = foldl min (maxBound :: Int) $ filter (> fId) $ map partId flags

--- a/test/DL3016.hs
+++ b/test/DL3016.hs
@@ -118,3 +118,6 @@ tests = do
     it "commit not pinned for git" $ do
       ruleCatches "DL3016" "RUN npm install git://github.com/npm/npm.git"
       onBuildRuleCatches "DL3016" "RUN npm install git://github.com/npm/npm.git"
+    it "don't fire on loglevel flag" $ do
+      ruleCatchesNot "DL3016" "RUN npm install --loglevel verbose sax@0.1.1"
+      onBuildRuleCatchesNot "DL3016" "RUN npm install --loglevel verbose sax@0.1.1"

--- a/test/ShellSpec.hs
+++ b/test/ShellSpec.hs
@@ -9,32 +9,45 @@ tests =
   describe "Shell unit tests" $ do
   --
     it "getFlagArgs" $ do
-      let cmd = Command (Text.pack "useradd")
-                        [ CmdPart (Text.pack "12345") 2,
-                          CmdPart (Text.pack "67890") 4,
-                          CmdPart (Text.pack "luser") 5 ]
-                        [ CmdPart (Text.pack "u") 1,
-                          CmdPart (Text.pack "u") 3 ]
-       in getFlagArg (Text.pack "u") cmd `shouldBe` [ Text.pack "12345",
-                                                      Text.pack "67890" ]
-      let cmd = Command (Text.pack "useradd")
-                        [ CmdPart (Text.pack "12345") 2,
-                          CmdPart (Text.pack "luser") 3 ]
-                        [ CmdPart (Text.pack "u") 1 ]
-       in getFlagArg (Text.pack "u") cmd `shouldBe` [ Text.pack "12345" ]
+      let cmd = Command "useradd"
+                        [ CmdPart "12345" 2,
+                          CmdPart "67890" 4,
+                          CmdPart "luser" 5 ]
+                        [ CmdPart "u" 1,
+                          CmdPart "u" 3 ]
+       in getFlagArg "u" cmd `shouldBe` [ "12345",
+                                          "67890" ]
+      let cmd = Command "useradd"
+                        [ CmdPart "12345" 2,
+                          CmdPart "luser" 3 ]
+                        [ CmdPart "u" 1 ]
+       in getFlagArg "u" cmd `shouldBe` [ "12345" ]
 
-      let cmd = Command (Text.pack "useradd")
-                        [ CmdPart (Text.pack "12345") 2,
-                          CmdPart (Text.pack "luser") 3 ]
-                        [ CmdPart (Text.pack "u") 1 ]
-       in getFlagArg (Text.pack "f") cmd `shouldBe` []
+      let cmd = Command "useradd"
+                        [ CmdPart "12345" 2,
+                          CmdPart "luser" 3 ]
+                        [ CmdPart "u" 1 ]
+       in getFlagArg "f" cmd `shouldBe` []
   --
     it "hasFlag" $ do
-      let cmd = Command (Text.pack "useradd")
-                        [ CmdPart (Text.pack "luser") 1 ]
-                        [ CmdPart (Text.pack "l") 0 ]
-       in hasFlag (Text.pack "l") cmd `shouldBe` True
-      let cmd = Command (Text.pack "useradd")
-                        [ CmdPart (Text.pack "luser") 1 ]
-                        [ CmdPart (Text.pack "l") 0 ]
-       in hasFlag (Text.pack "f") cmd `shouldBe` False
+      let cmd = Command "useradd"
+                        [ CmdPart "luser" 1 ]
+                        [ CmdPart "l" 0 ]
+       in hasFlag "l" cmd `shouldBe` True
+      let cmd = Command "useradd"
+                        [ CmdPart "luser" 1 ]
+                        [ CmdPart "l" 0 ]
+       in hasFlag "f" cmd `shouldBe` False
+  --
+    it "dropFlagArg" $ do
+      let cmd = Command "npm"
+                        [ CmdPart "verbose" 2,
+                          CmdPart "install" 3,
+                          CmdPart "bla@1.0.0" 4]
+                        [ CmdPart "loglevel" 1]
+      let res = Command "npm"
+                        [ CmdPart "install" 3,
+                          CmdPart "bla@1.0.0" 4]
+                        [ CmdPart "loglevel" 1]
+       in do
+        dropFlagArg ["loglevel"] cmd `shouldBe` res


### PR DESCRIPTION
- Add unit test case for `Shell.dropFlagArg`
- Add unit test case for DL3016 with `--loglevel verbose`
- make DL3016 ignore the arguments to named flags and not mistage them
  as packages
- move helper functions for DL3016 to top level and name their type
  signatures
- fixup `Shell.getFlagArg` to use a `Set` instead of a raw list
- remove superfluous use of `Text.pack` from `test/Shellspec.hs`

fixes #515

As I don't have very much experience with `npm`, there may very well be other flags that should have their arguments ignored as well, but from a quick glance over the documentation, I could not make out any.

### How to verify it

The following Dockerfile should no longer emit `DL3016`:
```Dockerfile
RUN npm --loglevel verbose install foo@1.0.0
```