### PR TITLE
DL3059: Multiple consecutive `RUN` instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,6 +293,7 @@ Please [create an issue][] if you have an idea for a good rule.
 | [DL3056](https://github.com/hadolint/hadolint/wiki/DL3056)   | Label `<label>` does not conform to semantic versioning.                                                                                            |
 | [DL3057](https://github.com/hadolint/hadolint/wiki/DL3057)   | `HEALTHCHECK` instruction missing.                                                                                                                  |
 | [DL3058](https://github.com/hadolint/hadolint/wiki/DL3058)   | Label `<label>` is not a valid email format - must be conform to RFC5322.                                                                           |
+| [DL3059](https://github.com/hadolint/hadolint/wiki/DL3059)   | Multiple consecutive `RUN` instructions. Consider consolidation.                                                                                    |
 | [DL3060](https://github.com/hadolint/hadolint/wiki/DL3060)   | `yarn cache clean` missing after `yarn install` was run.                                                                                            |
 | [DL4000](https://github.com/hadolint/hadolint/wiki/DL4000)   | MAINTAINER is deprecated.                                                                                                                           |
 | [DL4001](https://github.com/hadolint/hadolint/wiki/DL4001)   | Either use Wget or Curl but not both.                                                                                                               |

--- a/hadolint.cabal
+++ b/hadolint.cabal
@@ -4,7 +4,7 @@ cabal-version: 2.0
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: eed75724a8db42341a72e20e43d8b2e55eb80aff0e6bdefa525f3d886190db39
+-- hash: a3dcae5731e589aef133f0480f631dbd365f68690d730bcc58e422a3e7db16d0
 
 name:           hadolint
 version:        2.1.0
@@ -103,6 +103,7 @@ library
       Hadolint.Rule.DL3056
       Hadolint.Rule.DL3057
       Hadolint.Rule.DL3058
+      Hadolint.Rule.DL3059
       Hadolint.Rule.DL3060
       Hadolint.Rule.DL4000
       Hadolint.Rule.DL4001
@@ -236,6 +237,7 @@ test-suite hadolint-unit-tests
       DL3056
       DL3057
       DL3058
+      DL3059
       DL3060
       DL4000
       DL4001

--- a/src/Hadolint/Process.hs
+++ b/src/Hadolint/Process.hs
@@ -67,6 +67,7 @@ import qualified Hadolint.Rule.DL3055
 import qualified Hadolint.Rule.DL3056
 import qualified Hadolint.Rule.DL3057
 import qualified Hadolint.Rule.DL3058
+import qualified Hadolint.Rule.DL3059
 import qualified Hadolint.Rule.DL3060
 import qualified Hadolint.Rule.DL4000
 import qualified Hadolint.Rule.DL4001
@@ -197,6 +198,7 @@ failures RulesConfig {allowedRegistries, labelSchema, strictLabels} =
     <> Hadolint.Rule.DL3056.rule labelSchema
     <> Hadolint.Rule.DL3057.rule
     <> Hadolint.Rule.DL3058.rule labelSchema
+    <> Hadolint.Rule.DL3059.rule
     <> Hadolint.Rule.DL3060.rule
     <> Hadolint.Rule.DL4000.rule
     <> Hadolint.Rule.DL4001.rule

--- a/src/Hadolint/Rule/DL3059.hs
+++ b/src/Hadolint/Rule/DL3059.hs
@@ -1,0 +1,26 @@
+module Hadolint.Rule.DL3059 (rule) where
+
+import Hadolint.Rule
+import Language.Docker.Syntax
+
+
+type Acc = Int
+
+rule :: Rule args
+rule = customRule check (emptyState 0)
+  where
+    code = "DL3059"
+    severity = DLInfoC
+    message = "Multiple consecutive `RUN` instructions. Consider consolidation."
+
+    check line st (Run _)
+      | state st < 1 = st |> modify remember
+      | otherwise = st |> addFail CheckFailure {..}
+    check _ st _ = st |> modify reset
+{-# INLINEABLE rule #-}
+
+remember :: Acc -> Acc
+remember a = a + 1
+
+reset :: Acc -> Acc
+reset _ = 0

--- a/test/DL3059.hs
+++ b/test/DL3059.hs
@@ -1,0 +1,18 @@
+module DL3059 (tests) where
+
+import Helpers
+import Test.Hspec
+
+
+tests :: SpecWith ()
+tests = do
+  let ?rulesConfig = mempty
+  describe "DL3059 - Multiple consecutive `RUN` instructions" $ do
+    it "ok with no `RUN` at all" $ do
+      ruleCatchesNot "DL3059" "FROM debian:10"
+    it "ok with one `RUN`" $ do
+      ruleCatchesNot "DL3059" "RUN /foo.sh"
+    it "ok with two not consecutive `RUN`" $ do
+      ruleCatchesNot "DL3059" "RUN /foo.sh\nWORKDIR /\nRUN /bar.sh"
+    it "not ok with two consecutive `RUN`s" $ do
+      ruleCatches "DL3059" "RUN /foo.sh\nRUN /bar.sh"

--- a/test/ShellSpec.hs
+++ b/test/ShellSpec.hs
@@ -1,6 +1,5 @@
 module ShellSpec where
 
-import Data.Text as Text
 import Hadolint.Shell
 import Test.Hspec
 

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -59,6 +59,7 @@ import qualified DL3055
 import qualified DL3056
 import qualified DL3057
 import qualified DL3058
+import qualified DL3059
 import qualified DL4001
 import qualified DL4003
 import qualified DL4004
@@ -220,6 +221,7 @@ main =
     DL3056.tests
     DL3057.tests
     DL3058.tests
+    DL3059.tests
     DL4001.tests
     DL4003.tests
     DL4004.tests


### PR DESCRIPTION
- Add new rule linting for multiple consecutive run instructions that
  could be consolidated.
- Add tests for that rule.

On of the first bullet points in the Docker best practices is that one
should merge multiple `RUN` instructions into one, where possible to
reduce the layer count:
https://docs.docker.com/develop/dev-best-practices/
This rule informs with a severity of `DLInfoC`, where this is possible.

### How to verify it
The following should trigger rule DL3059:
```Dockerfile
RUN /foo.sh
RUN /bar.sh
```
None of these should trigger rule DL3059:
```Dockerfile
RUN /foo.sh
WORKDIR /
RUN /bar.sh
```
```Dockerfile
RUN /foo.sh \
 && /bar.sh
```

### Notes
I have omitted `onBuildRuleCatches[Not]` unit tests, because they don't behave properly. In particular, this one:
```Haskell
onBuildRuleCatchesNot "DL3059" "RUN /foo.sh\nWORKDIR /\nRUN /bar.sh
```
This is because the `onBuildRuleCatchesNot` only wraps `RUN` instructions and no other instructions in an `ONBUILD` context. This is probably wrong as other instructions (e.g. `LABEL`, `COPY`, `ADD`...) are allowed as well in an `ONBUILD` context.

As usual, I'll add a wiki page once this rule makes it into `master`.