### PR TITLE
DL3060: Lint for `yarn cache clean` #395

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,6 +293,7 @@ Please [create an issue][] if you have an idea for a good rule.
 | [DL3056](https://github.com/hadolint/hadolint/wiki/DL3056)   | Label `<label>` does not conform to semantic versioning.                                                                                            |
 | [DL3057](https://github.com/hadolint/hadolint/wiki/DL3057)   | `HEALTHCHECK` instruction missing.                                                                                                                  |
 | [DL3058](https://github.com/hadolint/hadolint/wiki/DL3058)   | Label `<label>` is not a valid email format - must be conform to RFC5322.                                                                           |
+| [DL3060](https://github.com/hadolint/hadolint/wiki/DL3060)   | `yarn cache clean` missing after `yarn install` was run.                                                                                            |
 | [DL4000](https://github.com/hadolint/hadolint/wiki/DL4000)   | MAINTAINER is deprecated.                                                                                                                           |
 | [DL4001](https://github.com/hadolint/hadolint/wiki/DL4001)   | Either use Wget or Curl but not both.                                                                                                               |
 | [DL4003](https://github.com/hadolint/hadolint/wiki/DL4003)   | Multiple `CMD` instructions found.                                                                                                                  |

--- a/hadolint.cabal
+++ b/hadolint.cabal
@@ -4,7 +4,7 @@ cabal-version: 2.0
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 3a6af1aecfc32d960fd1df8de865bb60b8682f8877a9b3bb848a3f59c50c063d
+-- hash: eed75724a8db42341a72e20e43d8b2e55eb80aff0e6bdefa525f3d886190db39
 
 name:           hadolint
 version:        2.1.0
@@ -103,6 +103,7 @@ library
       Hadolint.Rule.DL3056
       Hadolint.Rule.DL3057
       Hadolint.Rule.DL3058
+      Hadolint.Rule.DL3060
       Hadolint.Rule.DL4000
       Hadolint.Rule.DL4001
       Hadolint.Rule.DL4003
@@ -235,6 +236,7 @@ test-suite hadolint-unit-tests
       DL3056
       DL3057
       DL3058
+      DL3060
       DL4000
       DL4001
       DL4003

--- a/src/Hadolint/Process.hs
+++ b/src/Hadolint/Process.hs
@@ -67,6 +67,7 @@ import qualified Hadolint.Rule.DL3055
 import qualified Hadolint.Rule.DL3056
 import qualified Hadolint.Rule.DL3057
 import qualified Hadolint.Rule.DL3058
+import qualified Hadolint.Rule.DL3060
 import qualified Hadolint.Rule.DL4000
 import qualified Hadolint.Rule.DL4001
 import qualified Hadolint.Rule.DL4003
@@ -194,8 +195,9 @@ failures RulesConfig {allowedRegistries, labelSchema, strictLabels} =
     <> Hadolint.Rule.DL3054.rule labelSchema
     <> Hadolint.Rule.DL3055.rule labelSchema
     <> Hadolint.Rule.DL3056.rule labelSchema
-    <> Hadolint.Rule.DL3058.rule labelSchema
     <> Hadolint.Rule.DL3057.rule
+    <> Hadolint.Rule.DL3058.rule labelSchema
+    <> Hadolint.Rule.DL3060.rule
     <> Hadolint.Rule.DL4000.rule
     <> Hadolint.Rule.DL4001.rule
     <> Hadolint.Rule.DL4003.rule

--- a/src/Hadolint/Rule/DL3060.hs
+++ b/src/Hadolint/Rule/DL3060.hs
@@ -1,0 +1,27 @@
+module Hadolint.Rule.DL3060 (rule) where
+
+import Hadolint.Rule
+import qualified Hadolint.Shell as Shell
+import Language.Docker.Syntax
+
+
+rule :: Rule Shell.ParsedShell
+rule = simpleRule code severity message check
+  where
+    code = "DL3060"
+    severity = DLInfoC
+    message = "`yarn cache clean` missing after `yarn install` was run."
+
+    check (Run (RunArgs args _)) =
+      foldArguments (Shell.noCommands yarnInstall) args
+        || ( foldArguments (Shell.anyCommands yarnInstall) args
+              && foldArguments (Shell.anyCommands yarnCacheClean) args
+           )
+    check _ = True
+{-# INLINEABLE rule #-}
+
+yarnInstall :: Shell.Command -> Bool
+yarnInstall = Shell.cmdHasArgs "yarn" ["install"]
+
+yarnCacheClean :: Shell.Command -> Bool
+yarnCacheClean = Shell.cmdHasArgs "yarn" ["cache", "clean"]

--- a/test/DL3060.hs
+++ b/test/DL3060.hs
@@ -1,0 +1,19 @@
+module DL3060 (tests) where
+
+import Helpers
+import Test.Hspec
+
+
+tests :: SpecWith ()
+tests = do
+  let ?rulesConfig = mempty
+  describe "DL3060 - `yarn cache clean` missing after `yarn install`" $ do
+    it "ok with non-yarn commands" $ do
+      ruleCatchesNot "DL3060" "RUN foo"
+      onBuildRuleCatchesNot "DL3060" "RUN foo"
+    it "not ok with no cache clean" $ do
+      ruleCatches "DL3060" "RUN yarn install foo"
+      onBuildRuleCatches "DL3060" "RUN yarn install foo"
+    it "ok with cache clean" $ do
+      ruleCatchesNot "DL3060" "RUN yarn install bar && yarn cache clean"
+      onBuildRuleCatchesNot "DL3060" "RUN yarn install bar && yarn cache clean"


### PR DESCRIPTION
- Add new rule DL3060 linting for `yarn cache clean` after `yarn
  install` with severity `DLInfoC`
- Add tests

This rule reminds the odd programmer about cleaning `yarn`s caches after
installing, just like with the other package managers.

fixes: #395
### How to verify it
This should trigger `DL3060`:
```Dockerfile
RUN yarn install foo
```
This should be fine:
```Dockerfile
RUN yarn install foo \
 && yarn cache clean
```