### PR TITLE
json-formatter: fix error message

### DIFF
--- a/src/Hadolint/Formatter/Format.hs
+++ b/src/Hadolint/Formatter/Format.hs
@@ -1,6 +1,7 @@
 module Hadolint.Formatter.Format
   ( severityText,
     stripNewlines,
+    errorMessage,
     errorMessageLine,
     errorPosition,
     errorPositionPretty,
@@ -53,6 +54,10 @@ stripNewlines =
 errorMessageLine :: (VisualStream s, TraversableStream s, ShowErrorComponent e) => ParseErrorBundle s e -> String
 errorMessageLine err@(ParseErrorBundle e _) =
   errorPositionPretty err ++ " " ++ parseErrorTextPretty (NE.head e)
+
+errorMessage :: (VisualStream s, ShowErrorComponent e) => ParseErrorBundle s e -> String
+errorMessage (ParseErrorBundle e _) =
+  reverse . dropWhile (== '\n') . reverse $ parseErrorTextPretty (NE.head e)
 
 errorPositionPretty :: TraversableStream s => ParseErrorBundle s e -> String
 errorPositionPretty err = sourcePosPretty (errorPosition err)

--- a/src/Hadolint/Formatter/Json.hs
+++ b/src/Hadolint/Formatter/Json.hs
@@ -9,7 +9,12 @@ import Data.Aeson hiding (Result)
 import qualified Data.ByteString.Lazy.Char8 as B
 import Data.Sequence (Seq)
 import qualified Data.Text as Text
-import Hadolint.Formatter.Format (Result (..), errorPosition, severityText)
+import Hadolint.Formatter.Format
+  ( Result (..),
+    errorPosition,
+    severityText,
+    errorMessage
+  )
 import Hadolint.Rule (CheckFailure (..), DLSeverity (..), unRuleCode)
 import Text.Megaparsec (TraversableStream)
 import Text.Megaparsec.Error
@@ -37,7 +42,7 @@ instance (VisualStream s, TraversableStream s, ShowErrorComponent e) => ToJSON (
         "column" .= unPos (sourceColumn pos),
         "level" .= severityText DLErrorC,
         "code" .= ("DL1000" :: Text.Text),
-        "message" .= errorBundlePretty err
+        "message" .= errorMessage err
       ]
     where
       pos = errorPosition err

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -64,6 +64,7 @@ import qualified DL4003
 import qualified DL4004
 import qualified DL4005
 import qualified DL4006
+import Hadolint.Formatter.Format (errorMessage)
 import Hadolint.Formatter.TTY (formatError)
 import Helpers
 import Language.Docker.Parser
@@ -85,6 +86,13 @@ main =
                 <> "USER, VOLUME, WORKDIR, or end of input "
         case ast of
           Left err -> assertEqual "Unexpected error msg" expectedMsg (formatError err)
+          Right _ -> assertFailure "AST should fail parsing"
+    describe "errorMessage" $
+      it "display just the error message" $ do
+        let ast = parseText "RUNNN"
+            expectedMsg = "missing whitespace"
+        case ast of
+          Left err -> assertEqual "Unexpected error msg" expectedMsg (errorMessage err)
           Right _ -> assertFailure "AST should fail parsing"
     --
     describe "Rules can be ignored with inline comments" $ do


### PR DESCRIPTION
Fix `message` field in output by json formatter in case of errors
preventing rule application (e.g. parsing errors).

Previously, a pretty printing method from `Text.Megaparsec.Error` was
used, but this decorated the message with junk characters. The new
`errorMessage` function converts a `ParseErrorBundle` into a printable
`String` without additional junk, stripping newlines from the end as
well.

fixes: #593

### How to verify it
Executing `hadolint -f json Dockerfile` for the following Dockerfile should yield `[{"line":1,"code":"DL1000","message":"missing whitespace","column":4,"file":"/home/moritz/tmp/Dockerfile","level":"error"}]`:
```Dockerfile
RUNNN
```