### PR TITLE
DL3059: improve behaviour when considering flags

### DIFF
--- a/test/DL3059.hs
+++ b/test/DL3059.hs
@@ -1,5 +1,6 @@
 module DL3059 (tests) where
 
+import Data.Text as Text
 import Helpers
 import Test.Hspec
 
@@ -16,3 +17,15 @@ tests = do
       ruleCatchesNot "DL3059" "RUN /foo.sh\nWORKDIR /\nRUN /bar.sh"
     it "not ok with two consecutive `RUN`s" $ do
       ruleCatches "DL3059" "RUN /foo.sh\nRUN /bar.sh"
+    it "ok with two consecutive `RUN`s when flags are different 1" $ do
+      ruleCatchesNot "DL3059" "RUN --mount=type=secret,id=foo /foo.sh\nRUN /bar.sh"
+    it "ok with two consecutive `RUN`s when flags are different 2" $ do
+      let dfile = [ "RUN --mount=type=secret,id=foo /foo.sh",
+                    "RUN --mount=type=secret,id=bar /bar.sh"
+                  ]
+       in ruleCatchesNot "DL3059" $ Text.unlines dfile
+    it "not ok with two consecutive `RUN`s when flags are equal" $ do
+      let dfile = [ "RUN --mount=type=secret,id=foo /foo.sh",
+                    "RUN --mount=type=secret,id=foo /bar.sh"
+                  ]
+       in ruleCatches "DL3059" $ Text.unlines dfile


### PR DESCRIPTION
Refine behaviour of DL3059 when dealing with `RUN` flags. These flags
are Docker buildkit specific, but may significantly alter behaviour of
`RUN` commands.

- Do warn when two consecutive `RUN` instructions are found with the
  same flags
- Do not warn when two consecutive `RUN` instructions have differen
  flags

As explained in [this discussion](https://github.com/hadolint/hadolint/pull/591#issuecomment-814595691) consolidation of consecutive `RUN` instructions may be undesired, if there are different flags for each of the instructions. In addition to that, consolidation may not be possible, if both `RUN` instructions have flags, but the flags are different.

### How to verify it
These Dockerfile should no longer trigger DL3059:
```Dockerfile
RUN --mount=type=secret,id=foo /foo.sh
RUN /bar.sh
```
```Dockerfile
RUN --mount=type=secret,id=foo /foo.sh
RUN --mount=type=secret,id=bar /bar.sh
```

The following Dockerfiles should still trigger DL3059:
```Dockerfile
RUN --mount=type=secret,id=foo /foo.sh
RUN --mount=type=secret,id=foo /bar.sh
```
```Dockerfile
RUN /foo.sh
RUN /bar.sh
```