### PR TITLE
refactor(config.hs): adds additional accepted config file

### DIFF
--- a/src/Hadolint/Config.hs
+++ b/src/Hadolint/Config.hs
@@ -85,10 +85,12 @@ applyConfig maybeConfig o
       Nothing -> return (Right o)
       Just config -> parseAndApply config
   where
+    acceptedConfigs = [".hadolint.yaml", ".hadolint.yml"]
+
     findConfig = do
-      localConfigFile <- (</> ".hadolint.yaml") <$> getCurrentDirectory
-      configFile <- getXdgDirectory XdgConfig "hadolint.yaml"
-      listToMaybe <$> filterM doesFileExist [localConfigFile, configFile]
+      localConfigFiles <- traverse (\filePath -> (</> filePath) <$> getCurrentDirectory) acceptedConfigs
+      configFiles <- traverse (getXdgDirectory XdgConfig) acceptedConfigs
+      listToMaybe <$> filterM doesFileExist (localConfigFiles ++ configFiles)
 
     parseAndApply :: FilePath -> IO (Either String Lint.LintOptions)
     parseAndApply configFile = do


### PR DESCRIPTION
### Problem
`.yaml` is [functionally identical](https://stackoverflow.com/questions/21059124/is-it-yaml-or-yml) to `.yml` and hence, users should be able to specify the config file in either format for `hadolint`.

This closes #614 

### Solution
This PR adds support for an additional config file `.hadolint.yml` for `hadolint` to use. Existing functionality was kept intact and `hadolint` should prefer the extension `.yaml` still over `.yml`. 

### Implementation Details
Changes `findConfig` from taking `FilePath` to a list of `FilePath`. Adds a constant called `acceptedConfigs` 

### Manual Tests 
- [ ] Create a file called `.hadolint.yml` in your current working directory. Invoke `hadolint` in the current working directory. This should call `hadolint` with the rules specified 
- [ ] Create a file called `.hadolint.yml` in `$XDG_CONFIG_HOME` (can `echo` to find out where this is on linux). Invoke `hadolint` in the current working directory. This should call `hadolint` with the rules specified.
