### PR TITLE
DL3060: stage aware logic

### DIFF
--- a/src/Hadolint/Rule/DL3060.hs
+++ b/src/Hadolint/Rule/DL3060.hs
@@ -1,27 +1,74 @@
 module Hadolint.Rule.DL3060 (rule) where
 
+import qualified Data.Map.Strict as Map
+import qualified Data.Text as Text
 import Hadolint.Rule
 import qualified Hadolint.Shell as Shell
 import Language.Docker.Syntax
 
 
+data Acc
+  = Acc
+      { current :: BaseImage,
+        active :: Map.Map Text.Text Linenumber,
+        inactive :: Map.Map Linenumber BaseImage
+      }
+  | Empty
+  deriving (Show)
+
 rule :: Rule Shell.ParsedShell
-rule = simpleRule code severity message check
+rule = veryCustomRule check (emptyState Empty) markFailures
   where
     code = "DL3060"
     severity = DLInfoC
     message = "`yarn cache clean` missing after `yarn install` was run."
 
-    check (Run (RunArgs args _)) =
-      foldArguments (Shell.noCommands yarnInstall) args
-        || ( foldArguments (Shell.anyCommands yarnInstall) args
-              && foldArguments (Shell.anyCommands yarnCacheClean) args
-           )
-    check _ = True
+    check line st (From from) =
+      st |> modify (rememberStage line from)
+    check line st (Run (RunArgs args _))
+      | foldArguments (Shell.anyCommands yarnInstall) args
+          && foldArguments (Shell.noCommands yarnCacheClean) args =
+        st |> modify (rememberLine line)
+      | otherwise = st
+    check _ st _ = st
+
+    -- Produce failures from the final state Acc
+    markFailures :: State Acc -> Failures
+    markFailures (State fails Empty) = fails
+    markFailures (State _ Acc {..}) = inactive |> Map.foldMapWithKey mapFail
+      where
+        mapFail line from
+          | from == current = pure CheckFailure {..}
+          | BaseImage {alias = Just (ImageAlias als)} <- from,
+            Just _ <- Map.lookup als active = pure CheckFailure {..}
+          | otherwise = mempty
 {-# INLINEABLE rule #-}
+
+rememberStage :: Linenumber -> BaseImage -> Acc -> Acc
+rememberStage line stage@BaseImage {image = Image _ als} Empty =
+  Acc stage (Map.singleton als line) Map.empty
+rememberStage line stage@BaseImage {image = Image _ als} (Acc _ stages o) =
+  Acc stage (Map.insert als line stages) o
+
+rememberLine :: Linenumber -> Acc -> Acc
+rememberLine line Empty = Acc scratch mempty (Map.singleton line scratch)
+rememberLine line (Acc from stages o) = Acc from stages (Map.insert line from o)
 
 yarnInstall :: Shell.Command -> Bool
 yarnInstall = Shell.cmdHasArgs "yarn" ["install"]
 
 yarnCacheClean :: Shell.Command -> Bool
 yarnCacheClean = Shell.cmdHasArgs "yarn" ["cache", "clean"]
+
+-- | This is needed as placeholder when no FROM statement has yet been
+-- envountered.
+scratch :: BaseImage
+scratch =
+  ( BaseImage
+      { image = "scratch",
+        tag = Nothing,
+        digest = Nothing,
+        alias = Nothing,
+        platform = Nothing
+      }
+  )

--- a/test/DL3060.hs
+++ b/test/DL3060.hs
@@ -1,5 +1,6 @@
 module DL3060 (tests) where
 
+import qualified Data.Text as Text
 import Helpers
 import Test.Hspec
 
@@ -17,3 +18,51 @@ tests = do
     it "ok with cache clean" $ do
       ruleCatchesNot "DL3060" "RUN yarn install bar && yarn cache clean"
       onBuildRuleCatchesNot "DL3060" "RUN yarn install bar && yarn cache clean"
+
+    it "not ok when yarn install is in last stage w/o yarn clean" $
+      let dockerFile =
+            Text.unlines
+              [ "FROM node:lts-alpine as foo",
+                "RUN hey!",
+                "FROM scratch",
+                "RUN yarn install"
+              ]
+       in do
+            ruleCatches "DL3060" dockerFile
+            onBuildRuleCatches "DL3060" dockerFile
+
+    it "not ok when inheriting from stage with yarn install w/o yarn clean" $
+      let dockerFile =
+            Text.unlines
+              [ "FROM node:lts-alpine as foo",
+                "RUN yarn install",
+                "FROM foo",
+                "RUN hey!"
+              ]
+       in do
+            ruleCatches "DL3060" dockerFile
+            onBuildRuleCatches "DL3060" dockerFile
+
+    it "ok when inheriting from stage with yarn cache clear" $
+      let dockerFile =
+            Text.unlines
+              [ "FROM node:lts-alpine as foo",
+                "RUN yarn install && yarn cache clean",
+                "FROM foo",
+                "RUN hey!"
+              ]
+       in do
+            ruleCatchesNot "DL3060" dockerFile
+            onBuildRuleCatchesNot "DL3060" dockerFile
+
+    it "ok when omitting yarn cache clean in stage that is not reused later" $
+      let dockerFile =
+            Text.unlines
+              [ "FROM node:lts-alpine as foo",
+                "RUN yarn install foo",
+                "FROM scratch",
+                "RUN hey!"
+              ]
+       in do
+            ruleCatchesNot "DL3060" dockerFile
+            onBuildRuleCatches "DL3060" dockerFile

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -60,6 +60,7 @@ import qualified DL3056
 import qualified DL3057
 import qualified DL3058
 import qualified DL3059
+import qualified DL3060
 import qualified DL4001
 import qualified DL4003
 import qualified DL4004
@@ -230,6 +231,7 @@ main =
     DL3057.tests
     DL3058.tests
     DL3059.tests
+    DL3060.tests
     DL4001.tests
     DL4003.tests
     DL4004.tests


### PR DESCRIPTION
- Enable tests for DL3060
- Make failure logic stage aware, meaning that a `yarn install` without
  a `yarn cache clean` will not trigger DL3060 anymore in build stages,
  but will still trigger in the final image.

fixes: #619

### How to verify it
```Dockerfile
FROM node:lts-alpine
RUN yarn install
FROM node:lts-alpint
RUN foo
```
should no longer trigger DL3060, while
```Dockerfile
FROM node:lts-alpine as stage1
RUN yarn install
FROM stage1
RUN foo
```
still should trigger DL3060.