### PR TITLE
language-docker: version bump

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,11 +127,12 @@ override:
 ```
 
 Configuration files can be used globally or per project. By default, `hadolint` will look for
-a configuration file in the current directory with the name `.hadolint.yaml`
+a configuration file in the current directory with the name `.hadolint.yaml` or
+`.hadolint.yml`
 
 The global configuration file should be placed in the folder specified by `XDG_CONFIG_HOME`,
-with the name `hadolint.yaml`. In summary, the following locations are valid for the configuration
-file, in order or preference:
+with the name `hadolint.yaml` or `hadolint.yml`. In summary, the following locations are valid
+for the configuration file, in order or preference:
 
 - `$PWD/.hadolint.yaml`
 - `$XDG_CONFIG_HOME/hadolint.yaml`

--- a/hadolint.cabal
+++ b/hadolint.cabal
@@ -4,7 +4,7 @@ cabal-version: 2.0
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: c0b9bba31a6bbfb674f269ac9d6ed1046c5df58b5702a6b457b7f906781084c8
+-- hash: bfb172dcc87132d276f04f523bb6b3151ee018a0aa3db082771ce3cecf4c1e38
 
 name:           hadolint
 version:        2.3.0
@@ -137,7 +137,7 @@ library
     , filepath
     , foldl
     , ilist
-    , language-docker >=9.3.0 && <10
+    , language-docker >=10.0.0 && <11
     , megaparsec >=9.0.0
     , mtl
     , network-uri
@@ -165,7 +165,7 @@ executable hadolint
     , containers
     , gitrev >=1.3.1
     , hadolint
-    , language-docker >=9.3.0 && <10
+    , language-docker >=10.0.0 && <11
     , megaparsec >=9.0.0
     , optparse-applicative >=0.14.0
     , text
@@ -264,7 +264,7 @@ test-suite hadolint-unit-tests
     , foldl
     , hadolint
     , hspec
-    , language-docker >=9.3.0 && <10
+    , language-docker >=10.0.0 && <11
     , megaparsec >=9.0.0
     , split >=0.2
     , text

--- a/package.yaml
+++ b/package.yaml
@@ -26,7 +26,7 @@ ghc-options:
 dependencies:
   - base >=4.8 && <5
   - megaparsec >= 9.0.0
-  - language-docker >=9.3.0 && < 10
+  - language-docker >=10.0.0 && <11
 default-extensions:
   - OverloadedStrings
   - NamedFieldPuns

--- a/src/Hadolint/Config.hs
+++ b/src/Hadolint/Config.hs
@@ -168,8 +168,10 @@ getConfig maybeConfig =
   where
     findConfig :: IO (Maybe FilePath)
     findConfig = do
-      localConfigFiles <- traverse (\filePath -> (</> filePath) <$> getCurrentDirectory) acceptedConfigs
+      localConfigFiles <- traverse
+                            (\filePath -> (</> filePath) <$> getCurrentDirectory)
+                            (fmap ("."++) acceptedConfigs)
       configFiles <- traverse (getXdgDirectory XdgConfig) acceptedConfigs
       listToMaybe <$> filterM doesFileExist (localConfigFiles ++ configFiles)
       where
-        acceptedConfigs = [".hadolint.yaml", ".hadolint.yml"]
+        acceptedConfigs = ["hadolint.yaml", "hadolint.yml"]

--- a/stack.yaml
+++ b/stack.yaml
@@ -6,7 +6,7 @@ resolver: lts-17.5
 extra-deps:
   - ShellCheck-0.7.1@sha256:94a6ee5a38e2668204bc95fdc7539a9a4ca7230984157694409444530c23b5a4,3170
   - colourista-0.1.0.0
-  - language-docker-9.3.0
+  - language-docker-10.0.0
   - megaparsec-9.0.0@sha256:920d1e469056c746b532333a078c2a9a195fab5e860e0c9734ee92a28c2bfb65,3117
   - spdx-1.0.0.2@sha256:7dfac9b454ff2da0abb7560f0ffbe00ae442dd5cb76e8be469f77e6988a70fed,2008
 ghc-options:

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -85,7 +85,7 @@ main =
             expectedMsg =
               "<string>:1:1 unexpected 'F' expecting '#', ADD, ARG, CMD, COPY, ENTRYPOINT, "
                 <> "ENV, EXPOSE, FROM, HEALTHCHECK, LABEL, MAINTAINER, ONBUILD, RUN, SHELL, STOPSIGNAL, "
-                <> "USER, VOLUME, WORKDIR, or end of input "
+                <> "USER, VOLUME, WORKDIR, a pragma, end of input, or whitespaces "
         case ast of
           Left err -> assertEqual "Unexpected error msg" expectedMsg (formatError err)
           Right _ -> assertFailure "AST should fail parsing"


### PR DESCRIPTION
- Bump version of language-docker to 10.0.0
- Fix documentation for config file paths
- Fix search behaviour for config files to be backwards compatible
  and match documentation.