### PR TITLE
Add GitHub action to update/create ThirdPartyNotices.txt

### DIFF
--- a/.github/workflows/thirdparty.yaml
+++ b/.github/workflows/thirdparty.yaml
@@ -1,0 +1,25 @@
+name: Third Party Notices Update
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  third_party_notices_update:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out
+        uses: actions/checkout@v2
+      - name: Setup Haskell
+        id: setup-haskell-cabal
+        uses: haskell/actions/setup@v1
+        with:
+          ghc-version: "8.10"
+      - name: Update ThirdPartyNotices.txt
+        run: cabal update && cabal install licensor --constraint 'licensor >= 0.4 && <0.5' && /home/runner/.cabal/bin/licensor --silent > ThirdPartyNotices.txt
+      - name: Commit ThirdPartyNotices.txt
+        uses: EndBug/add-and-commit@v7
+        with:
+          add: "ThirdPartyNotices.txt"
+          message: "Update ThirdPartyNotices.txt"

--- a/.github/workflows/thirdparty.yaml
+++ b/.github/workflows/thirdparty.yaml
@@ -4,6 +4,15 @@ on:
   push:
     branches:
       - master
+  pull_request:
+    branches: [master]
+    paths:
+      - ".github/workflows/haskell.yml"
+      - "stack*.yaml"
+      - "hadolint.cabal"
+      - "app/**"
+      - "src/**"
+      - "test/**"
 
 jobs:
   third_party_notices_update:

--- a/.github/workflows/thirdparty.yaml
+++ b/.github/workflows/thirdparty.yaml
@@ -4,15 +4,6 @@ on:
   push:
     branches:
       - master
-  pull_request:
-    branches: [master]
-    paths:
-      - ".github/workflows/haskell.yml"
-      - "stack*.yaml"
-      - "hadolint.cabal"
-      - "app/**"
-      - "src/**"
-      - "test/**"
 
 jobs:
   third_party_notices_update:

--- a/src/Hadolint/Config.hs
+++ b/src/Hadolint/Config.hs
@@ -98,10 +98,12 @@ applyConfig maybeConfig o
       Nothing -> return (Right o)
       Just config -> parseAndApply config
   where
+    acceptedConfigs = [".hadolint.yaml", ".hadolint.yml"]
+
     findConfig = do
-      localConfigFile <- (</> ".hadolint.yaml") <$> getCurrentDirectory
-      configFile <- getXdgDirectory XdgConfig "hadolint.yaml"
-      listToMaybe <$> filterM doesFileExist [localConfigFile, configFile]
+      localConfigFiles <- traverse (\filePath -> (</> filePath) <$> getCurrentDirectory) acceptedConfigs
+      configFiles <- traverse (getXdgDirectory XdgConfig) acceptedConfigs
+      listToMaybe <$> filterM doesFileExist (localConfigFiles ++ configFiles)
 
     parseAndApply :: FilePath -> IO (Either String Lint.LintOptions)
     parseAndApply configFile = do


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

Closes #622 .

### What I did

I added a new GitHub action that creates/updates a `ThirdPartyNotices.txt` file, which contains the license types for all its (transitive) dependencies.

### How I did it

The action is built around [licensor v0.4](https://hackage.haskell.org/package/licensor).

### How to verify it

- A successful action run looks like [this](https://github.com/janjagusch/hadolint/actions/runs/807661288).
- You can see that the action does not commit anything if the `ThirdPartyNotices.txt` hasn't changed [here](https://github.com/janjagusch/hadolint/runs/2494433558?check_suite_focus=true).
