### PR TITLE
config: fix parsing problems

### DIFF
--- a/src/Hadolint/Lint.hs
+++ b/src/Hadolint/Lint.hs
@@ -24,13 +24,13 @@ import qualified Language.Docker as Docker
 import Language.Docker.Parser (DockerfileError, Error)
 import Language.Docker.Syntax (Dockerfile)
 
-type ErrorRule = Text
+type ErrorRule = Hadolint.Rule.RuleCode
 
-type WarningRule = Text
+type WarningRule = Hadolint.Rule.RuleCode
 
-type InfoRule = Text
+type InfoRule = Hadolint.Rule.RuleCode
 
-type StyleRule = Text
+type StyleRule = Hadolint.Rule.RuleCode
 
 type IgnoreRule = Hadolint.Rule.RuleCode
 
@@ -56,10 +56,10 @@ instance Semigroup LintOptions where
       (a4 <> b4)
       (a5 <> b5)
       (a6 <> b6)
-      (min a7 b7)
+      (a7 <> b7)
 
 instance Monoid LintOptions where
-  mempty = LintOptions mempty mempty mempty mempty mempty mempty Hadolint.Rule.DLIgnoreC
+  mempty = LintOptions mempty mempty mempty mempty mempty mempty mempty
 
 -- | Performs the process of parsing the dockerfile and analyzing it with all the applicable
 -- rules, depending on the list of ignored rules.
@@ -101,10 +101,10 @@ fixSeverity :: LintOptions -> Seq.Seq Hadolint.Rule.CheckFailure -> Seq.Seq Hado
 fixSeverity LintOptions {..} = Seq.filter ignoredRules . Seq.mapWithIndex (const correctSeverity)
   where
     correctSeverity =
-      makeSeverity Hadolint.Rule.DLErrorC (fmap Hadolint.Rule.RuleCode errorRules)
-        . makeSeverity Hadolint.Rule.DLWarningC (fmap Hadolint.Rule.RuleCode warningRules)
-        . makeSeverity Hadolint.Rule.DLInfoC (fmap Hadolint.Rule.RuleCode infoRules)
-        . makeSeverity Hadolint.Rule.DLStyleC (fmap Hadolint.Rule.RuleCode styleRules)
+      makeSeverity Hadolint.Rule.DLErrorC errorRules
+        . makeSeverity Hadolint.Rule.DLWarningC warningRules
+        . makeSeverity Hadolint.Rule.DLInfoC infoRules
+        . makeSeverity Hadolint.Rule.DLStyleC styleRules
 
     ignoredRules = ignoreFilter ignoreRules
 

--- a/test/ConfigSpec.hs
+++ b/test/ConfigSpec.hs
@@ -93,11 +93,6 @@ tests =
           expected = ConfigFile Nothing Nothing Nothing Nothing Nothing (Just Rule.DLErrorC)
        in assertConfig expected (Bytes.unlines configFile)
 
-    it "Parses config with invalid failure-threshold" $
-      let configFile = [ "failure-threshold: foo" ]
-          expected = ConfigFile Nothing Nothing Nothing Nothing Nothing Nothing
-       in assertConfig expected (Bytes.unlines configFile)
-
     it "Parses full file" $
       let configFile =
             [ "override:",


### PR DESCRIPTION
Parsing the contents of the `failure-threshold` property was done
improperly and resulted in all results being discarded in case the
property was absent. The observed behaviour was seemingly the same as if
the config file had not been found, but in fact it was a problem of the
parser.

- Make all severity overrides more solid as types by implementing the
  to-be-overridden rules as rule codes instead of `Text.Text`s
- Make `DLSeverity` an instance of `Yaml.FromYAML`, `Semigroup` and
  `Monoid` to properly handle parsing from yaml files and combining
  multiple severities.

With `DLSeverity` being a more sophisticated type and implementing its
own yaml parser, parsing the config and combining it with the
configuration obtained from commandline options has much more consistent
behaviours with respect to the existing configuration properties.

fixes: #624

### How to verify it
Using the following config file and Dockerfile should ignore the error within the Dockerfile:
```yaml
ignored:
  - DL3059
```
```Dockerfile
FROM debian:buster
RUN foo
RUN bar
```