### PR TITLE
Fix hadolint docker image in .pre-commit-hooks.yaml

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -4,7 +4,7 @@
   description: Runs hadolint Docker image to lint Dockerfiles
   language: docker_image
   types: ["dockerfile"]
-  entry: hadolint/hadolint hadolint
+  entry: hadolint/hadolint:v2.3.0 hadolint
 - id: hadolint
   name: Lint Dockerfiles
   description: Runs hadolint to lint Dockerfiles


### PR DESCRIPTION
fixes https://github.com/hadolint/hadolint/issues/628

### What I did

The version of docker image is fixed in .pre-commit-hooks.yaml

### How I did it

Just added tag

### How to verify it

```
---
repos:
  - repo: https://github.com/mathbunnyru/hadolint.git
    rev: asalikhov/pre_commit_docker_version
    hooks:
      - id: hadolint-docker
```

If I prune docker images, on the first run it's easy to see, that exact version is pulled from docker:
`docker image rm hadolint/hadolint:v2.3.0`
`pre-commit run --all-files --verbose`

```
Unable to find image 'hadolint/hadolint:v2.3.0' locally
v2.3.0: Pulling from hadolint/hadolint
4fc54f9b225a: Pull complete
Digest: sha256:5bd624ce29f153036a3b03083af66f9ac040d2cb0673b2b4785394425e66f10b
Status: Image is up to date for hadolint/hadolint:v2.3.0
Unable to find image 'hadolint/hadolint:v2.3.0' locally
v2.3.0: Pulling from hadolint/hadolint
4fc54f9b225a: Pull complete
Digest: sha256:5bd624ce29f153036a3b03083af66f9ac040d2cb0673b2b4785394425e66f10b
Status: Image is up to date for hadolint/hadolint:v2.3.0
Unable to find image 'hadolint/hadolint:v2.3.0' locally
v2.3.0: Pulling from hadolint/hadolint
4fc54f9b225a: Pull complete
Digest: sha256:5bd624ce29f153036a3b03083af66f9ac040d2cb0673b2b4785394425e66f10b
Status: Downloaded newer image for hadolint/hadolint:v2.3.0
```