### PR TITLE
Update config path in a Docker container

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,9 +151,9 @@ To pass a custom configuration file (using relative or absolute path) to a conta
 use the following command:
 
 ```bash
-$ docker run --rm -i -v ./your/path/to/hadolint.yaml:/root/.config/hadolint.yaml hadolint/hadolint < Dockerfile
+$ docker run --rm -i -v /your/path/to/hadolint.yaml:/.config/hadolint.yaml hadolint/hadolint < Dockerfile
 # or
-$ docker run --rm -i -v ./your/path/to/hadolint.yaml:/root/.config/hadolint.yaml ghcr.io/hadolint/hadolint < Dockerfile
+$ docker run --rm -i -v /your/path/to/hadolint.yaml:/.config/hadolint.yaml ghcr.io/hadolint/hadolint < Dockerfile
 ```
 
 ## Inline ignores


### PR DESCRIPTION
### What I did

I've updated README.md to use correct config path used in Docker containers, and removed relative path example, as Docker requires an absolute one. 

### How I did it

Edited the README.md.

### How to verify it

Verify wrong path, as rules from the `/some/project/hadolint.yaml` file will be ignored:

```bash
$ docker run --rm -i -v /some/project/hadolint.yaml:/root/.config/hadolint.yaml hadolint/hadolint < Dockerfile
-:7 DL4006 warning: Set the SHELL option -o pipefail before RUN with a pipe in it. If you are using /bin/sh in an alpine image or if your shell is symlinked to busybox then consider explicitly setting your SHELL to /bin/ash, or disable this check
-:13 DL3041 warning: Specify version with `dnf install -y <package>-<version>`.
```

Verify relative paths are not possible:

```bash
$ docker run --rm -i -v ./hadolint.yaml:/root/.config/hadolint.yaml hadolint/hadolint < Dockerfile
docker: Error response from daemon: create ./hadolint.yaml: "./hadolint.yaml" includes invalid characters for a local volume name, only "[a-zA-Z0-9][a-zA-Z0-9_.-]" are allowed. If you intended to pass a host directory, use absolute path.
See 'docker run --help'.
```

Verify correct config path:

```bash
$ docker run --rm -i -v /some/project/hadolint.yaml:/.config/hadolint.yaml hadolint/hadolint < Dockerfile # All rules from the config are successfully ignored
```

`hadolint.yaml` example:

```yaml
ignored:
  - DL3041
  - DL4006
```