### PR TITLE
Fix docs on failure-threshold option

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -111,7 +111,7 @@ parseOptions =
             <> long "failure-threshold"
             <> help
               "Exit with failure code only when rules with a severity \
-              \above THRESHOLD are violated. Accepted values: \
+              \equal to or above THRESHOLD are violated. Accepted values: \
               \[error | warning | info | style | ignore | none]"
             <> value Rule.DLInfoC
             <> metavar "THRESHOLD"


### PR DESCRIPTION
This is a follow-up on hadolint#607. The given threshold is inclusive. I.e. setting threshold to `info` will cause exit code 1 when rules with a severity above **or equal** to `info`  are violated. The docs should reflect that.

Update; My test that lead to this conclusion seems broken. See discussion in https://github.com/hadolint/hadolint/pull/613#pullrequestreview-656369769.