### PR TITLE
bugfix: avoid index overrun in DL3045

### DIFF
--- a/src/Hadolint/Rule/DL3045.hs
+++ b/src/Hadolint/Rule/DL3045.hs
@@ -85,5 +85,7 @@ quotePredicate c
 
 isWindowsAbsolute :: Text.Text -> Bool
 isWindowsAbsolute path
-  | Char.isLetter (Text.index path 0) && (':' == Text.index path 1) = True
+  | Just (d, r1) <- Text.uncons path,
+    Just (c, _) <- Text.uncons r1,
+    Char.isLetter d && ':' == c = True
   | otherwise = False

--- a/test/DL3045.hs
+++ b/test/DL3045.hs
@@ -150,3 +150,7 @@ tests = do
        in do
             ruleCatchesNot "DL3045" dockerFile
             onBuildRuleCatchesNot "DL3045" dockerFile
+
+    it "regression: don't crash with single character paths" $ do
+      ruleCatches "DL3045" "COPY a b"
+      onBuildRuleCatches "DL3045" "COPY a b"


### PR DESCRIPTION
- fix index overrun in DL3045 with single character paths when checking
  for windows type paths.

fixes: #638