### PR TITLE
formatters: add SonarQube formatter

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -64,6 +64,7 @@ data CommandOptions = CommandOptions
 
 toOutputFormat :: String -> Maybe Hadolint.OutputFormat
 toOutputFormat "json" = Just Hadolint.Json
+toOutputFormat "sonarqube" = Just Hadolint.SonarQube
 toOutputFormat "tty" = Just Hadolint.TTY
 toOutputFormat "codeclimate" = Just Hadolint.CodeclimateJson
 toOutputFormat "gitlab_codeclimate" = Just Hadolint.GitlabCodeclimateJson
@@ -73,6 +74,7 @@ toOutputFormat _ = Nothing
 
 showFormat :: Hadolint.OutputFormat -> String
 showFormat Hadolint.Json = "json"
+showFormat Hadolint.SonarQube = "sonarqube"
 showFormat Hadolint.TTY = "tty"
 showFormat Hadolint.CodeclimateJson = "codeclimate"
 showFormat Hadolint.GitlabCodeclimateJson = "gitlab_codeclimate"

--- a/hadolint.cabal
+++ b/hadolint.cabal
@@ -39,6 +39,7 @@ library
       Hadolint.Formatter.Codeclimate
       Hadolint.Formatter.Format
       Hadolint.Formatter.Json
+      Hadolint.Formatter.SonarQube
       Hadolint.Formatter.TTY
       Hadolint.Ignore
       Hadolint.Lint

--- a/src/Hadolint.hs
+++ b/src/Hadolint.hs
@@ -16,6 +16,7 @@ import qualified Hadolint.Formatter.Codacy
 import qualified Hadolint.Formatter.Codeclimate
 import Hadolint.Formatter.Format (Result (..))
 import qualified Hadolint.Formatter.Json
+import qualified Hadolint.Formatter.SonarQube
 import qualified Hadolint.Formatter.TTY
 import Hadolint.Lint
 import Hadolint.Process
@@ -23,6 +24,7 @@ import Language.Docker.Parser (DockerfileError)
 
 data OutputFormat
   = Json
+  | SonarQube
   | TTY
   | CodeclimateJson
   | GitlabCodeclimateJson
@@ -37,6 +39,7 @@ printResults :: Foldable f => OutputFormat -> Bool -> f (Result Text DockerfileE
 printResults format nocolor allResults =
   case format of
     TTY -> Hadolint.Formatter.TTY.printResults allResults nocolor
+    SonarQube -> Hadolint.Formatter.SonarQube.printResults allResults
     Json -> Hadolint.Formatter.Json.printResults allResults
     Checkstyle -> Hadolint.Formatter.Checkstyle.printResults allResults
     CodeclimateJson -> Hadolint.Formatter.Codeclimate.printResults allResults

--- a/src/Hadolint/Formatter/SonarQube.hs
+++ b/src/Hadolint/Formatter/SonarQube.hs
@@ -1,0 +1,103 @@
+module Hadolint.Formatter.SonarQube
+  ( formatResult,
+    printResults
+  )
+  where
+
+import qualified Control.Foldl as Foldl
+import Data.Aeson hiding (Result)
+import qualified Data.ByteString.Lazy.Char8 as B
+import Data.Sequence (Seq)
+import qualified Data.Text as Text
+import Hadolint.Formatter.Format
+  ( Result (..),
+    errorPosition,
+    errorMessage
+  )
+import Hadolint.Rule
+  ( CheckFailure (..),
+    DLSeverity (..),
+    unRuleCode
+  )
+import Text.Megaparsec (TraversableStream)
+import Text.Megaparsec.Error
+import Text.Megaparsec.Pos
+  ( sourceColumn,
+    sourceLine,
+    sourceName,
+    unPos
+  )
+import Text.Megaparsec.Stream (VisualStream)
+
+
+data SonarQubeFormat s e
+  = SonarQubeCheck Text.Text CheckFailure
+  | SonarQubeError (ParseErrorBundle s e)
+
+instance (VisualStream s,
+  TraversableStream s,
+  ShowErrorComponent e) => ToJSON (SonarQubeFormat s e) where
+  toJSON (SonarQubeCheck filename CheckFailure {..}) =
+    object
+      [ "engineId" .= Text.pack "Hadolint",
+        "ruleId" .= unRuleCode code,
+        "severity" .= toSeverity severity,
+        "type" .= toType severity,
+        "primaryLocation" .= object
+          [ "message" .= message,
+            "filePath" .= filename,
+            "textRange" .= object
+              [ "startLine" .= line,
+                "endLine" .= line,
+                "startColumn" .= (1 :: Int),
+                "endColumn" .= (1 :: Int)
+              ]
+          ]
+      ]
+  toJSON (SonarQubeError err) =
+    object
+      [ "engineId" .= Text.pack "Hadolint",
+        "ruleId" .= Text.pack "DL1000",
+        "severity" .= Text.pack "BLOCKER",
+        "type" .= Text.pack "BUG",
+        "primaryLocation" .= object
+          [ "message" .= errorMessage err,
+            "filePath" .= Text.pack (sourceName pos),
+            "textRange" .= object
+              [ "startLine" .= linenumber,
+                "endLine" .= linenumber,
+                "startColumn" .= column,
+                "endColumn" .= column
+              ]
+          ]
+      ]
+    where
+      pos = errorPosition err
+      linenumber = unPos $ sourceLine pos
+      column = unPos $ sourceColumn pos
+
+
+formatResult :: Result s e -> Seq (SonarQubeFormat s e)
+formatResult (Result filename errors checks) = allMessages
+  where
+    allMessages = errorMessages <> checkMessages
+    errorMessages = fmap SonarQubeError errors
+    checkMessages = fmap (SonarQubeCheck filename) checks
+
+printResults :: (VisualStream s,
+  TraversableStream s,
+  ShowErrorComponent e,
+  Foldable f) => f (Result s e) -> IO ()
+printResults results = B.putStr . encode $ object [ "issues" .= flattened ]
+  where
+    flattened = Foldl.fold (Foldl.premap formatResult Foldl.mconcat) results
+
+toType :: DLSeverity -> Text.Text
+toType DLErrorC = "BUG"
+toType _ = "CODE_SMELL"
+
+toSeverity :: DLSeverity -> Text.Text
+toSeverity DLErrorC = "CRITICAL"
+toSeverity DLWarningC = "MAJOR"
+toSeverity DLInfoC = "MINOR"
+toSeverity _ = "INFO"


### PR DESCRIPTION
- Add formatter for outputting json objects compatible with SonarQube's
  generic [import format](https://docs.sonarqube.org/latest/analysis/generic-issue/)

All parse errors appear as code "DL1000" with severity BLOCKER and type
BUG. All rule violations with severity DLErrorC have type BUG and
severity CRITICAL, all other rule violations have type CODE_SMELL and
the appropriate severity MAJOR, MINOR, INFO respectively.

fixes: #626

### How to verify it
![hadolint-sonarqube](https://user-images.githubusercontent.com/17141774/118359196-aabfbb00-b582-11eb-9926-26e0d2c27c26.png)