### PR TITLE
Add file-path-in-report option for checkstyle format

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -59,7 +59,8 @@ data CommandOptions = CommandOptions
     isVerbose :: Bool,
     format :: Hadolint.OutputFormat,
     dockerfiles :: [String],
-    lintingOptions :: Hadolint.LintOptions
+    lintingOptions :: Hadolint.LintOptions,
+    filePathInReportOption :: Maybe FilePath
   }
 
 toOutputFormat :: String -> Maybe Hadolint.OutputFormat
@@ -99,6 +100,7 @@ parseOptions =
     <*> outputFormat
     <*> files
     <*> lintOptions
+    <*> filePathInReportOption
   where
     version = switch (long "version" <> short 'v' <> help "Show version")
 
@@ -206,6 +208,14 @@ parseOptions =
         <*> parseRulesConfig
         <*> noFailCutoff
 
+    filePathInReportOption =
+      optional
+        ( strOption
+            ( long "file-path-in-report" <> metavar "FILEPATHINREPORT"
+                <> help "The file path referenced in the generated report. This only applies for the 'checkstyle' format and is useful when running Hadolint with Docker to set the correct file path."
+            )
+        )
+
     labels =
       Map.fromList
         <$> many
@@ -267,7 +277,8 @@ runLint cmd conf files = do
   res <- Hadolint.lintIO conf files
   noColorEnv <- lookupEnv "NO_COLOR"
   let noColor = nocolor cmd || isJust noColorEnv
-  Hadolint.printResults (format cmd) noColor res
+  let filePathInReport = filePathInReportOption cmd
+  Hadolint.printResults (format cmd) noColor filePathInReport res
   exitProgram cmd conf res
 
 main :: IO ()

--- a/src/Hadolint.hs
+++ b/src/Hadolint.hs
@@ -33,12 +33,12 @@ data OutputFormat
 shallSkipErrorStatus :: OutputFormat -> Bool
 shallSkipErrorStatus format = format `elem` [CodeclimateJson, Codacy]
 
-printResults :: Foldable f => OutputFormat -> Bool -> f (Result Text DockerfileError) -> IO ()
-printResults format nocolor allResults =
+printResults :: Foldable f => OutputFormat -> Bool -> Maybe FilePath -> f (Result Text DockerfileError) -> IO ()
+printResults format nocolor filePathInReport allResults =
   case format of
     TTY -> Hadolint.Formatter.TTY.printResults allResults nocolor
     Json -> Hadolint.Formatter.Json.printResults allResults
-    Checkstyle -> Hadolint.Formatter.Checkstyle.printResults allResults
+    Checkstyle -> Hadolint.Formatter.Checkstyle.printResults allResults filePathInReport
     CodeclimateJson -> Hadolint.Formatter.Codeclimate.printResults allResults
     GitlabCodeclimateJson -> Hadolint.Formatter.Codeclimate.printGitlabResults allResults
     Codacy -> Hadolint.Formatter.Codacy.printResults allResults


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

Enhancement https://github.com/hadolint/hadolint/issues/529

### What I did

I added a new command option `'file-path-in-report'`.
If the `'checkstyle'` format is selected and this new option is selected it will allow the user to define the file path referenced in the generated report and will override the input source file path which is taken by default.

This solves the problem that occurs when you run Hadolint with Docker and `checkstyle` format and the input source file path may not be the correct path i.e., it may default to '-' or '/dev/stdin' or the local container file path.
The correct file path is needed if you need your pipeline to integrate with something like [Jenkins Warnings Ng Plugin](https://www.jenkins.io/doc/pipeline/steps/warnings-ng/) which cross references the line numbers in the original file path with the report.

**NOTE**: I'm not sure if this fix is needed for other formats like `'json'` which also has a file path reference but this current solution is only for `'checkstyle'`.
Also it won't work for a situation where multiple Docker source files are input to Hadolint.
Also I would like to add a unit test to check the new command option. I am not too familiar with Haskell and couldn't find an example test to work off. Any help with that would be appreciated.

### How I did it

I updated the command options with the new option, passed the option to the `printResults` function and updated  the specific `'checkstyle' printResults` function to override the input source file path if the new option was present.

### How to verify it

Example Input Dockerfile
```
FROM ubuntu:latest
```

Docker run Hadolint without new option

```
donalhurley@donals-MacBook-Pro hadolint-work % docker run --rm -i hadolint:local hadolint -f checkstyle - < Dockerfile 
<?xml version='1.0' encoding='UTF-8'?><checkstyle version='4.3'><file name='&#45;' ><error line='1' column='1' severity='warning' message='Using latest is prone to errors if the image will ever update. Pin the version explicitly to a release tag' source='DL3007' /></file></checkstyle>  
```                                                                                                                                                                                                      

Docker run Hadolint with the new option

```
donalhurley@donals-MacBook-Pro hadolint-work % docker run --rm -i hadolint:local hadolint -f checkstyle --file-path-in-report /mypath/Dockerfile - < Dockerfile
<?xml version='1.0' encoding='UTF-8'?><checkstyle version='4.3'><file name='/mypath/Dockerfile' ><error line='1' column='1' severity='warning' message='Using latest is prone to errors if the image will ever update. Pin the version explicitly to a release tag' source='DL3007' /></file></checkstyle> 
```

Docker run Hadolint and show Help information

```
donalhurley@donals-MacBook-Pro hadolint-work % docker run --rm -i hadolint:local hadolint -h                          
hadolint - Dockerfile Linter written in Haskell

Usage: hadolint [-v|--version] [--no-fail] [--no-color] [-c|--config FILENAME] 
                [-V|--verbose] [-f|--format ARG] [DOCKERFILE...] 
                [--error RULECODE] [--warning RULECODE] [--info RULECODE] 
                [--style RULECODE] [--ignore RULECODE] 
                [--trusted-registry REGISTRY (e.g. docker.io)] 
                [--require-label LABELSCHEMA (e.g. maintainer:text)] 
                [--strict-labels] [-t|--failure-threshold THRESHOLD] 
                [--file-path-in-report FILEPATHINREPORT]
  Lint Dockerfile for errors and best practices

Available options:
  -h,--help                Show this help text
  -v,--version             Show version
  --no-fail                Don't exit with a failure status code when any rule
                           is violated
  --no-color               Don't colorize output
  -c,--config FILENAME     Path to the configuration file
  -V,--verbose             Enables verbose logging of hadolint's output to
                           stderr
  -f,--format ARG          The output format for the results [tty | json |
                           checkstyle | codeclimate | gitlab_codeclimate |
                           codacy] (default: tty)
  --error RULECODE         Make the rule `RULECODE` have the level `error`
  --warning RULECODE       Make the rule `RULECODE` have the level `warning`
  --info RULECODE          Make the rule `RULECODE` have the level `info`
  --style RULECODE         Make the rule `RULECODE` have the level `style`
  --ignore RULECODE        A rule to ignore. If present, the ignore list in the
                           config file is ignored
  --trusted-registry REGISTRY (e.g. docker.io)
                           A docker registry to allow to appear in FROM
                           instructions
  --require-label LABELSCHEMA (e.g. maintainer:text)
                           The option --require-label=label:format makes
                           Hadolint check that the label `label` conforms to
                           format requirement `format`
  --strict-labels          Do not permit labels other than specified in
                           `label-schema`
  -t,--failure-threshold THRESHOLD
                           Exit with failure code only when rules with a
                           severity equal to or above THRESHOLD are violated.
                           Accepted values: [error | warning | info | style |
                           ignore | none] (default: info)
  --file-path-in-report FILEPATHINREPORT
                           The file path referenced in the generated report.
                           This only applies for the 'checkstyle' format and is
                           useful when running Hadolint with Docker to set the
                           correct file path.
```
