### PR TITLE
Update docker version in pre-commit-hooks

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -4,7 +4,7 @@
   description: Runs hadolint Docker image to lint Dockerfiles
   language: docker_image
   types: ["dockerfile"]
-  entry: hadolint/hadolint:v2.3.0 hadolint
+  entry: hadolint/hadolint:v2.4.1 hadolint
 - id: hadolint
   name: Lint Dockerfiles
   description: Runs hadolint to lint Dockerfiles


### PR DESCRIPTION
Related: https://github.com/hadolint/hadolint/issues/628

Please, next time update this before creating a release.
This way the release (basically, zip file), will get the same docker version as the release and it will be consistent.