### PR TITLE
threshold: tune behaviour to match help message

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -249,7 +249,7 @@ labelParser l =
 noFailure :: Hadolint.Result s e -> Rule.DLSeverity -> Bool
 noFailure (Hadolint.Result _ Seq.Empty Seq.Empty) _ = True
 noFailure (Hadolint.Result _ Seq.Empty fails) cutoff =
-  Seq.null (Seq.filter (\f -> Rule.severity f < cutoff) fails)
+  Seq.null (Seq.filter (\f -> Rule.severity f <= cutoff) fails)
 noFailure _ _ = False
 
 exitProgram ::


### PR DESCRIPTION
The help message suggests that the failure threshold makes Hadolint exit
with failure when a rule above **or equal to** the threshold is
violated. This was introduced to the help message with
https://github.com/hadolint/hadolint/pull/639/commits/3121fe9d79e609979f7c5bfe5704ba22c5af7bc6
But never updated the behaviour to match the help message.

fixes: #651