### PR TITLE
shellcheck: ignore non-posix shells

### DIFF
--- a/src/Hadolint/Shell.hs
+++ b/src/Hadolint/Shell.hs
@@ -61,8 +61,8 @@ setShell s (ShellOpts _ v) = ShellOpts s v
 
 shellcheck :: ShellOpts -> ParsedShell -> [PositionedComment]
 shellcheck (ShellOpts sh env) (ParsedShell txt _ _) =
-  if "pwsh" `Text.isPrefixOf` sh
-    then [] -- Do no run for powershell
+  if any (`Text.isPrefixOf` sh) nonPosixShells
+    then [] -- Do no run for non-posix shells i.e. powershell, cmd.exe
     else runShellCheck
   where
     runShellCheck = crComments $ runIdentity $ checkScript si spec
@@ -84,6 +84,9 @@ shellcheck (ShellOpts sh env) (ParsedShell txt _ _) =
 
     extractShell s = fromMaybe "" (listToMaybe . Text.words $ s)
     printVars = Text.unlines . Set.toList $ Set.map (\v -> "export " <> v <> "=1") env
+
+nonPosixShells :: [Text.Text]
+nonPosixShells = ["pwsh", "powershell", "cmd"]
 
 parseShell :: Text.Text -> ParsedShell
 parseShell txt = ParsedShell {original = txt, parsed = parsedResult, presentCommands = commands}

--- a/test/DL4006.hs
+++ b/test/DL4006.hs
@@ -81,3 +81,24 @@ tests = do
               "RUN wget -O - https://some.site | wc -l file > /number"
             ]
        in ruleCatches "DL4006" $ Text.unlines dockerFile
+    it "ignore non posix shells: pwsh" $
+      let dockerFile =
+            [ "FROM mcr.microsoft.com/powershell:ubuntu-16.04",
+              "SHELL [ \"pwsh\", \"-c\" ]",
+              "RUN Get-Variable PSVersionTable | Select-Object -ExpandProperty Value"
+            ]
+       in ruleCatchesNot "DL4006" $ Text.unlines dockerFile
+    it "ignore non posix shells: powershell" $
+      let dockerFile =
+            [ "FROM mcr.microsoft.com/powershell:ubuntu-16.04",
+              "SHELL [ \"powershell.exe\" ]",
+              "RUN Get-Variable PSVersionTable | Select-Object -ExpandProperty Value"
+            ]
+       in ruleCatchesNot "DL4006" $ Text.unlines dockerFile
+    it "ignore non posix shells: cmd.exe" $
+      let dockerFile =
+            [ "FROM mcr.microsoft.com/powershell:ubuntu-16.04",
+              "SHELL [ \"cmd.exe\", \"/c\" ]",
+              "RUN Get-Variable PSVersionTable | Select-Object -ExpandProperty Value"
+            ]
+       in ruleCatchesNot "DL4006" $ Text.unlines dockerFile

--- a/test/Shellcheck.hs
+++ b/test/Shellcheck.hs
@@ -110,10 +110,19 @@ tests = do
             assertChecks dockerFile passesShellcheck
             assertOnBuildChecks dockerFile passesShellcheck
 
-    it "Does not complain on powershell" $
+    it "Does not complain on non-posix shells: pwsh" $
       let dockerFile =
             Text.unlines
               [ "SHELL [\"pwsh\", \"-c\"]",
+                "RUN Get-Variable PSVersionTable | Select-Object -ExpandProperty Value"
+              ]
+       in do
+            assertChecks dockerFile passesShellcheck
+            assertOnBuildChecks dockerFile passesShellcheck
+    it "Does not complain on non-posix shells: cmd.exe" $
+      let dockerFile =
+            Text.unlines
+              [ "SHELL [\"cmd.exe\", \"/c\"]",
                 "RUN Get-Variable PSVersionTable | Select-Object -ExpandProperty Value"
               ]
        in do


### PR DESCRIPTION
- Ignore execution of shellcheck rules and DL4006 for non-posix shells
  other than pwsh as well, where said rules are not applicable.

fixes: #644 #431

### What I did

Expand the list of shells known to break with shellcheck and avoid execution of shellcheck when they are set as `SHELL`.

### How to verify it
There are tests for the relevant rules (Shellcheck and DL4006), but also this Dockerfile for example should no longer be complained about:
```Dockerfile
FROM mcr.microsoft.com/powershell:ubuntu-16.04
SHELL [ "cmd", "-c" ]
RUN Get-Variable PSVersionTable | Select-Object -ExpandProperty Value
```