### PR TITLE
app/main: add sonarqube to cli output

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -147,10 +147,10 @@ parseOptions =
         ( long "format"
             <> short 'f' -- options for the output format
             <> help
-              "The output format for the results [tty | json | checkstyle | codeclimate | gitlab_codeclimate | codacy]"
+              "The output format for the results [tty | json | checkstyle | codeclimate | gitlab_codeclimate | codacy | sonarqube]"
             <> value Hadolint.TTY
             <> showDefaultWith showFormat -- The default value
-            <> completeWith ["tty", "json", "checkstyle", "codeclimate", "gitlab_codeclimate", "codacy"]
+            <> completeWith ["tty", "json", "checkstyle", "codeclimate", "gitlab_codeclimate", "codacy", "sonarqube"]
         )
 
     errorList =


### PR DESCRIPTION
The sonarqube formatted was added in the `2.5.0` release. This commit adds the option to the cli (which already accepts it).