### PR TITLE
Lower severity level of DL3047 to info

### DIFF
--- a/src/Hadolint/Rule/DL3047.hs
+++ b/src/Hadolint/Rule/DL3047.hs
@@ -9,7 +9,7 @@ rule :: Rule ParsedShell
 rule = simpleRule code severity message check
   where
     code = "DL3047"
-    severity = DLWarningC
+    severity = DLInfoC
     message =
       "Avoid use of wget without progress bar. Use `wget --progress=dot:giga <url>`.\
       \Or consider using `-q` or `-nv` (shorthands for `--quiet` or `--no-verbose`)."


### PR DESCRIPTION
As @lorenzo mentioned in #546, it's okay to lower it down.

### What I did

Lower severity level of DL3047 to info, instead of warn

### How I did it

Simply change its severity from `DLWarningC` to `DLInfoC`

### How to verify it

Simply write a Dockerfile and add a `RUN` instruction with `wget` command, use Hadolint to lint it. 

The result should be like:

```
Dockerfile:10 DL3047 info: Avoid use of wget without progress bar. Use `wget --progress=dot:giga <url>`.Or consider using `-q` or `-nv` (shorthands for `--quiet` or `--no-verbose`).
```

cc #546 #566
