### PR TITLE
Update .pre-commit-hooks.yaml

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -4,7 +4,7 @@
   description: Runs hadolint Docker image to lint Dockerfiles
   language: docker_image
   types: ["dockerfile"]
-  entry: hadolint/hadolint:v2.4.1 hadolint
+  entry: hadolint/hadolint:v2.5.0 hadolint
 - id: hadolint
   name: Lint Dockerfiles
   description: Runs hadolint to lint Dockerfiles


### PR DESCRIPTION
Just a minor change updating the docker image tag to the latest version as mentioned in #631 and #647.

@asottile, in pre-commit is there a better way to indicate the version of the docker image to be pulled such that issues like #628 (not respecting rev, always pulling latest) are avoided but do not require manually updating the version in the `.pre-commit-hooks.yaml` file for each release?  If not currently, I would be happy to open an issue for that feature to be considered for pre-commit.

Thanks to all for the great tools!  Y'all are making people's lives better.
