### PR TITLE
sonarqube-formatter: fix start column  #658

### DIFF
--- a/src/Hadolint/Formatter/SonarQube.hs
+++ b/src/Hadolint/Formatter/SonarQube.hs
@@ -49,7 +49,7 @@ instance (VisualStream s,
             "textRange" .= object
               [ "startLine" .= line,
                 "endLine" .= line,
-                "startColumn" .= (1 :: Int),
+                "startColumn" .= (0 :: Int),
                 "endColumn" .= (1 :: Int)
               ]
           ]


### PR DESCRIPTION
The Sonarqube output format forbids having equal start- and endcolumns
in the report for an issue. This commit changes the start column to 0
and leaves the end-column at 1, thus always marking an issue at the
first character of the corresponding line.

fixes: #658