### PR TITLE
DL3018: Don't trigger when installing from .apk file  #662

### DIFF
--- a/src/Hadolint/Rule/DL3018.hs
+++ b/src/Hadolint/Rule/DL3018.hs
@@ -12,10 +12,20 @@ rule = simpleRule code severity message check
     code = "DL3018"
     severity = DLWarningC
     message =
-      "Pin versions in apk add. Instead of `apk add <package>` use `apk add <package>=<version>`"
-    check (Run (RunArgs args _)) = foldArguments (\as -> and [versionFixed p | p <- apkAddPackages as]) args
+      "Pin versions in apk add. Instead of `apk add <package>` \
+      \use `apk add <package>=<version>`"
+    check (Run (RunArgs args _)) =
+      foldArguments
+        ( \as ->
+            and
+              [ versionFixed p || packageFile p
+                | p <- apkAddPackages as
+              ]
+        )
+        args
     check _ = True
     versionFixed package = "=" `Text.isInfixOf` package
+    packageFile package = ".apk" `Text.isSuffixOf` package
 {-# INLINEABLE rule #-}
 
 apkAddPackages :: ParsedShell -> [Text.Text]

--- a/test/DL3018.hs
+++ b/test/DL3018.hs
@@ -84,3 +84,7 @@ tests = do
        in do
             ruleCatchesNot "DL3018" $ Text.unlines dockerFile
             onBuildRuleCatchesNot "DL3018" $ Text.unlines dockerFile
+
+    it "don't trigger when installing from .apk file" $ do
+      ruleCatchesNot "DL3018" "RUN apk add mypackage-1.1.1.apk"
+      onBuildRuleCatchesNot "DL3018" "RUN apk add mypackage-1.1.1.apk"


### PR DESCRIPTION
DL3018 ensures version pinning. When installing from an .apk file, this
is pointless and should not trigger the rule, since it is equivalent to
version pinning.

fixes: #662

### How to verify it
This should no longer trigger DL3018:

```Dockerfile
RUN apk add mypackagefile-1.1.1.apk
```
Test case included.