### PR TITLE
Feature: Silence DL3009,DL3019 for cache mounts

### DIFF
--- a/src/Hadolint/Rule/DL3019.hs
+++ b/src/Hadolint/Rule/DL3019.hs
@@ -1,5 +1,6 @@
 module Hadolint.Rule.DL3019 (rule) where
 
+import qualified Data.Text as Text
 import Hadolint.Rule
 import Hadolint.Shell (ParsedShell)
 import qualified Hadolint.Shell as Shell
@@ -11,9 +12,20 @@ rule = simpleRule code severity message check
     code = "DL3019"
     severity = DLInfoC
     message =
-      "Use the `--no-cache` switch to avoid the need to use `--update` and remove \
-      \`/var/cache/apk/*` when done installing packages"
-    check (Run (RunArgs args _)) = foldArguments (Shell.noCommands forgotCacheOption) args
+      "Use the `--no-cache` switch to avoid the need to use `--update` and \
+      \remove `/var/cache/apk/*` when done installing packages"
+    check (Run (RunArgs args flags)) = hasCacheMount flags
+      || foldArguments (Shell.noCommands forgotCacheOption) args
     check _ = True
-    forgotCacheOption cmd = Shell.cmdHasArgs "apk" ["add"] cmd && not (Shell.hasFlag "no-cache" cmd)
 {-# INLINEABLE rule #-}
+
+hasCacheMount :: RunFlags -> Bool
+hasCacheMount RunFlags
+  { mount =
+      Just (CacheMount CacheOpts {cTarget = TargetPath {unTargetPath = p}})
+  } = Text.dropWhileEnd (=='/') p == "/var/cache/apk"
+hasCacheMount RunFlags {} = False
+
+forgotCacheOption :: Shell.Command -> Bool
+forgotCacheOption cmd = Shell.cmdHasArgs "apk" ["add"] cmd
+  && not (Shell.hasFlag "no-cache" cmd)

--- a/test/DL3009.hs
+++ b/test/DL3009.hs
@@ -75,3 +75,7 @@ tests = do
        in do
             ruleCatchesNot "DL3009" $ Text.unlines dockerFile
             onBuildRuleCatchesNot "DL3009" $ Text.unlines dockerFile
+
+    it "don't warn: BuildKit cache mount to apt lists directory" $ do
+      ruleCatchesNot "DL3009" "RUN --mount=type=cache,target=/var/lib/apt/lists apt-get update && apt-get install python"
+      onBuildRuleCatchesNot "DL3009" "RUN --mount=type=cache,target=/var/lib/apt/lists apt-get update && apt-get install python"

--- a/test/DL3019.hs
+++ b/test/DL3019.hs
@@ -14,3 +14,12 @@ tests = do
     it "apk add without --no-cache" $ do
       ruleCatchesNot "DL3019" "RUN apk add --no-cache flex=2.6.4-r1"
       onBuildRuleCatchesNot "DL3019" "RUN apk add --no-cache flex=2.6.4-r1"
+    it "don't warn: apk add with BuildKit cache mount" $ do
+      ruleCatchesNot "DL3019" "RUN --mount=type=cache,target=/var/cache/apk apk add -U curl=7.77.0"
+      onBuildRuleCatchesNot "DL3019" "RUN --mount=type=cache,target=/var/cache/apk apk add -U curl=7.77.0"
+    it "don't warn: apk add with BuildKit cache mount in wrong dir and --no-cache" $ do
+      ruleCatchesNot "DL3019" "RUN --mount=type=cache,target=/var/cache/foo apk add --no-cache -U curl=7.77.0"
+      onBuildRuleCatchesNot "DL3019" "RUN --mount=type=cache,target=/var/cache/foo apk add --no-cache -U curl=7.77.0"
+    it "warn: apk add with BuildKit cache mount to wrong dir" $ do
+      ruleCatches "DL3019" "RUN --mount=type=cache,target=/var/cache/foo apk add -U curl=7.77.0"
+      onBuildRuleCatches "DL3019" "RUN --mount=type=cache,target=/var/cache/foo apk add -U curl=7.77.0"


### PR DESCRIPTION
In case the cache directories DL3009 and DL3019 respectively are
provided via BuildKit cache mount, the two rules need not warn a user to
remove the directories.

fixes: #671

### How to verify it
The following Dockerfiles should no longer emit warnings DL3009 or DL3019 respectively:
```Dockerfile
FROM alpine:3.14.0
RUN --mount=type=cache,target=/var/cache/apk apk add -U curl=7.77.0-r1
```

```Dockerfile
FROM debian:10
RUN --mount=type=cache,target=/var/lib/apt/lists/ apt-get update && apt-get install foo
```