### PR TITLE
DL3010, DL3020: fix edge-cases for archives

### DIFF
--- a/src/Hadolint/Rule.hs
+++ b/src/Hadolint/Rule.hs
@@ -195,3 +195,22 @@ aliasMustBe predicate fromInstr =
   case fromInstr of
     From BaseImage {alias = Just (ImageAlias as)} -> predicate as
     _ -> True
+
+archiveFileFormatExtensions :: [Text.Text]
+archiveFileFormatExtensions =
+  [ ".tar",
+    ".Z",
+    ".bz2",
+    ".gz",
+    ".lz",
+    ".lzma",
+    ".tZ",
+    ".tb2",
+    ".tbz",
+    ".tbz2",
+    ".tgz",
+    ".tlz",
+    ".tpz",
+    ".txz",
+    ".xz"
+  ]

--- a/src/Hadolint/Rule/DL3010.hs
+++ b/src/Hadolint/Rule/DL3010.hs
@@ -11,28 +11,11 @@ rule = simpleRule code severity message check
     code = "DL3010"
     severity = DLInfoC
     message = "Use ADD for extracting archives into an image"
-    check (Copy (CopyArgs srcs _ _ _ _)) =
+    check (Copy (CopyArgs srcs _ _ _ NoSource)) =
       and
         [ not (format `Text.isSuffixOf` src)
           | SourcePath src <- toList srcs,
-            format <- archiveFormats
+            format <- archiveFileFormatExtensions
         ]
     check _ = True
-    archiveFormats =
-      [ ".tar",
-        ".tar.bz2",
-        ".tb2",
-        ".tbz",
-        ".tbz2",
-        ".tar.gz",
-        ".tgz",
-        ".tpz",
-        ".tar.lz",
-        ".tar.lzma",
-        ".tlz",
-        ".tar.xz",
-        ".txz",
-        ".tar.Z",
-        ".tZ"
-      ]
 {-# INLINEABLE rule #-}

--- a/src/Hadolint/Rule/DL3020.hs
+++ b/src/Hadolint/Rule/DL3020.hs
@@ -21,23 +21,7 @@ isArchive :: Text.Text -> Bool
 isArchive path =
   or
     ( [ ftype `Text.isSuffixOf` path
-        | ftype <-
-            [ ".tar",
-              ".gz",
-              ".bz2",
-              ".xz",
-              ".zip",
-              ".tgz",
-              ".tb2",
-              ".tbz",
-              ".tbz2",
-              ".lz",
-              ".lzma",
-              ".tlz",
-              ".txz",
-              ".Z",
-              ".tZ"
-            ]
+        | ftype <- archiveFileFormatExtensions
       ]
     )
 

--- a/test/DL3010.hs
+++ b/test/DL3010.hs
@@ -10,3 +10,4 @@ tests = do
   describe "COPY rules" $ do
     it "use add" $ ruleCatches "DL3010" "COPY packaged-app.tar /usr/src/app"
     it "use not add" $ ruleCatchesNot "DL3010" "COPY package.json /usr/src/app"
+    it "ignore: copy from previous stage" $ ruleCatchesNot "DL3010" "COPY --from=builder /usr/local/share/some.tar /opt/some.tar"

--- a/test/DL3020.hs
+++ b/test/DL3020.hs
@@ -9,10 +9,10 @@ tests = do
   let ?rulesConfig = mempty
   describe "DL3020 - Use `COPY` instead of `ADD` for files and folders." $ do
     it "add for tar" $ ruleCatchesNot "DL3020" "ADD file.tar /usr/src/app/"
-    it "add for zip" $ ruleCatchesNot "DL3020" "ADD file.zip /usr/src/app/"
     it "add for gzip" $ ruleCatchesNot "DL3020" "ADD file.gz /usr/src/app/"
     it "add for bz2" $ ruleCatchesNot "DL3020" "ADD file.bz2 /usr/src/app/"
     it "add for xz" $ ruleCatchesNot "DL3020" "ADD file.xz /usr/src/app/"
     it "add for tgz" $ ruleCatchesNot "DL3020" "ADD file.tgz /usr/src/app/"
     it "add for url" $ ruleCatchesNot "DL3020" "ADD http://file.com /usr/src/app/"
     it "using add" $ ruleCatches "DL3020" "ADD file /usr/src/app/"
+    it "warn for zip" $ ruleCatches "DL3020" "ADD file.zip /usr/src/app/"


### PR DESCRIPTION
DL3020:
  - Don't warn that the user should use `ADD` instead of `COPY`, as this
    has the same result since zip files are not extracted.

DL3010:
  - Don't suggest using `ADD` when copying from a previous build stage,
    as `ADD` does not support copying from previous build stages.

General:
  - Unify the list of archive extensions to reduce data duplication.

fixes: #679
fixes: #676

