### PR TITLE
Update Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -21,7 +21,7 @@ RUN stack --no-terminal --install-ghc test --only-dependencies
 
 COPY . /opt/hadolint
 RUN scripts/fetch_version.sh \
-  && stack install --ghc-options="-fPIC" --flag hadolint:static
+  && stack install --flag hadolint:static
 
 FROM debian:stretch-slim AS debian-distro
 COPY --from=builder /root/.local/bin/hadolint /bin/


### PR DESCRIPTION
Remove fPIC flag which results in binaries which are not entirely statically linked

### What I did

Tried running the Docker container on the [latest x64 version of Flatcar Linux](https://kinvolk.io/flatcar-container-linux/releases/#release-2905.2.1)
docker - 19.03.15
kernel - 5.10.55

This resulted in the following output:
```
# docker run -it --rm hadolint/hadolint:latest-alpine sh
# hadolint --version
Segmentation fault (core dumped)
```

I compiled without fPIC and was able to fix this
```
# docker run -it --rm bdwyertech/hadolint:latest-alpine sh
# hadolint --version
Haskell Dockerfile Linter v2.6.1-bdwyertech-0-g3ab38af
```

Test images available on my fork:
https://github.com/bdwyertech/hadolint/pkgs/container/hadolint
