### PR TITLE
Update repository name in GitHub Actions integration docs

### DIFF
--- a/docs/INTEGRATION.md
+++ b/docs/INTEGRATION.md
@@ -78,7 +78,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Lint Dockerfile
-        uses: brpaz/hadolint-action@master
+        uses: hadolint/hadolint-action@master
         with:
           dockerfile: "Dockerfile"
 


### PR DESCRIPTION
The integration docs for GitHub Actions use `brpaz/hadolint-action`. However, it looks like the repository for the GitHub Action has moved to the hadolint organization. The [GitHub Marketplace page for the Hadolint Action](https://github.com/marketplace/actions/hadolint-action) refers to `hadolint/hadolint-action`.