### PR TITLE
Add linux/aarch64 to Docker build workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -11,14 +11,20 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        distro: ["scratch", "alpine", "debian"]
+        distro:
+          - scratch
+          - alpine
+          - debian
+        os:
+          - linux/amd64
+          - linux/aarch64
     steps:
       - uses: actions/checkout@v2
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
         with:
-          platforms: linux/amd64
+          platforms: ${{ matrix.os }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
@@ -54,7 +60,7 @@ jobs:
         with:
           context: .
           file: docker/Dockerfile
-          platforms: linux/amd64
+          platforms: ${{ matrix.os }}
           push: true
           target: ${{ steps.build-opts.outputs.target }}
           tags: |

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,27 +1,64 @@
-FROM debian:stretch-slim AS builder
+FROM ubuntu:20.04 AS builder
 
-SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+SHELL ["/bin/bash", "-Eeuxo", "pipefail", "-c"]
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV LANG=C.UTF-8
 
 RUN apt-get update \
- && apt-get install --no-install-recommends -y \
-    build-essential=12.3 \
-    libffi-dev=3.2.* \
-    libgmp-dev=2:6.1.* \
-    zlib1g-dev=1:1.2.* \
-    curl=7.52.* \
+  && apt-get install -y --no-install-recommends \
+    build-essential=* \
     ca-certificates=* \
-    git=1:2.11.* \
-    netbase=5.4 \
- && curl -sSL https://get.haskellstack.org/ | sh \
- && rm -rf /var/lib/apt/lists/*
+    curl=7.* \
+    g++=* \
+    gcc=* \
+    git=1:2.* \
+    gnupg=* \
+    libc6-dev=* \
+    libffi-dev=* \
+    libffi7=* \
+    libgmp-dev=* \
+    libgmp-dev=* \
+    libgmp10=* \
+    libncurses-dev=* \
+    libncurses5=* \
+    libnuma-dev=* \
+    libtinfo5=* \
+    make=* \
+    netbase=* \
+    xz-utils=* \
+    zlib1g-dev=* \
+  && rm -fr /var/lib/apt/lists/*
+
+WORKDIR /tmp
+
+ENV \
+  GHC_VERSION=8.10.4 \
+  LLVM_VERSION=9.0.1 \
+  STACK_VERSION=2.7.1
+
+RUN \
+  if [ "$(uname -m)" = aarch64 ]; then \
+    curl -fsSL https://github.com/llvm/llvm-project/releases/download/llvmorg-${LLVM_VERSION}/clang+llvm-${LLVM_VERSION}-aarch64-linux-gnu.tar.xz \
+      | tar -xJvf - --strip-components=1 -C /usr \
+    && curl -fL https://github.com/commercialhaskell/stack/releases/download/v${STACK_VERSION}/stack-${STACK_VERSION}-linux-aarch64.bin \
+      -o /usr/local/bin/stack \
+    && chmod +x /usr/local/bin/stack; \
+  else \
+    apt-get update \
+    && curl -sSL https://get.haskellstack.org/ | sh \
+    && rm -fr /var/lib/apt/lists/*; \
+  fi \
+  && stack setup ghc-$GHC_VERSION
 
 WORKDIR /opt/hadolint/
 COPY stack.yaml package.yaml /opt/hadolint/
-RUN stack --no-terminal --install-ghc test --only-dependencies
+RUN stack -j"$(nproc)" --no-terminal test --only-dependencies
 
 COPY . /opt/hadolint
 RUN scripts/fetch_version.sh \
-  && stack install --ghc-options="-fPIC" --flag hadolint:static
+  && stack -j"$(nproc)" --no-terminal install --ghc-options="-fPIC" \
+    --flag hadolint:static
 
 FROM debian:stretch-slim AS debian-distro
 COPY --from=builder /root/.local/bin/hadolint /bin/


### PR DESCRIPTION
﻿<!--
If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

### What I did

This pull request builds on the work done in #665 to add support for shipping linux/aarch64 images (tested on my 13" Apple M1 MacBook Air). Apologies, I don't have much time to respond to feedback but I wanted to get a PR up to share with others.

### How I did it

- Extended the Docker workflow to build for x86_64 and aarch64 as separate jobs (to avoid timeouts) rather than the previous strategy of building within a single job.
- Extended the Dockerfile to manually install binary releases of Clang and Stack for aarch64.

The prior work from #665 used `ubuntu:20.04` as the base image. It should still be possible to continue with the current `debian:stretch-slim` image though that would likely require some adjustments to the Apt dependencies.

### How to verify it

I've tested using a linux/x86_64 build host (all green :+1:) and on darwin/aarch64 (native works 👍 / GHC under QEMU crashes :sob:).

```sh
docker build --platforms linux/aarch64 -f docker/Dockerfile .
docker build --platforms linux/amd64 -f docker/Dockerfile .
```

I didn't have time to test the changes to the workflow.
