### PR TITLE
Feature: Silence DL3020 even for doube quoted URLs #693

### DIFF
--- a/src/Hadolint/Rule/DL3020.hs
+++ b/src/Hadolint/Rule/DL3020.hs
@@ -26,4 +26,4 @@ isArchive path =
     )
 
 isUrl :: Text.Text -> Bool
-isUrl path = or ([proto `Text.isPrefixOf` path | proto <- ["https://", "http://"]])
+isUrl path = or ([proto `Text.isPrefixOf` path | proto <- ["https://", "http://", "\"https://", "\"http://"]])


### PR DESCRIPTION
### What I did

Added ignore case to DL3020

fixes #693

### How I did it

Added two more string to test against

### How to verify it

```
ADD "https://dl.k8s.io/release/v1.21.0/bin/linux/amd64/kubectl" /tmp
```

should not trigger DL3020 anymore