### PR TITLE
parser: heredoc support

### DIFF
--- a/hadolint.cabal
+++ b/hadolint.cabal
@@ -141,7 +141,7 @@ library
     , filepath
     , foldl
     , ilist
-    , language-docker >=10.0.0 && <11
+    , language-docker >=10.1.0 && <11
     , megaparsec >=9.0.0
     , mtl
     , network-uri
@@ -178,7 +178,7 @@ executable hadolint
     , containers
     , gitrev >=1.3.1
     , hadolint
-    , language-docker >=10.0.0 && <11
+    , language-docker >=10.1.0 && <11
     , megaparsec >=9.0.0
     , optparse-applicative >=0.14.0
     , text
@@ -284,7 +284,7 @@ test-suite hadolint-unit-tests
     , foldl
     , hadolint
     , hspec
-    , language-docker >=10.0.0 && <11
+    , language-docker >=10.1.0 && <11
     , megaparsec >=9.0.0
     , split >=0.2
     , text

--- a/package.yaml
+++ b/package.yaml
@@ -26,7 +26,7 @@ ghc-options:
 dependencies:
   - base >=4.8 && <5
   - megaparsec >= 9.0.0
-  - language-docker >=10.0.0 && <11
+  - language-docker >=10.1.0 && <11
 default-extensions:
   - OverloadedStrings
   - NamedFieldPuns

--- a/src/Hadolint/Shell.hs
+++ b/src/Hadolint/Shell.hs
@@ -61,7 +61,7 @@ setShell s (ShellOpts _ v) = ShellOpts s v
 
 shellcheck :: ShellOpts -> ParsedShell -> [PositionedComment]
 shellcheck (ShellOpts sh env) (ParsedShell txt _ _) =
-  if any (`Text.isPrefixOf` sh) nonPosixShells
+  if any (`Text.isPrefixOf` sh) nonPosixShells || hasUnsupportedShebang txt
     then [] -- Do no run for non-posix shells i.e. powershell, cmd.exe
     else runShellCheck
   where
@@ -87,6 +87,19 @@ shellcheck (ShellOpts sh env) (ParsedShell txt _ _) =
 
 nonPosixShells :: [Text.Text]
 nonPosixShells = ["pwsh", "powershell", "cmd"]
+
+hasUnsupportedShebang :: Text.Text -> Bool
+hasUnsupportedShebang script =
+  "#!" `Text.isPrefixOf` script &&
+  not ( any (`Text.isPrefixOf` script)
+          [ "#!/bin/sh",
+            "#!/bin/bash",
+            "#!/bin/ksh",
+            "#!/usr/bin/env sh",
+            "#!/usr/bin/env bash",
+            "#!/usr/bin/env ksh"
+          ]
+      )
 
 parseShell :: Text.Text -> ParsedShell
 parseShell txt = ParsedShell {original = txt, parsed = parsedResult, presentCommands = commands}

--- a/stack.yaml
+++ b/stack.yaml
@@ -6,7 +6,7 @@ resolver: lts-17.5
 extra-deps:
   - ShellCheck-0.7.1@sha256:94a6ee5a38e2668204bc95fdc7539a9a4ca7230984157694409444530c23b5a4,3170
   - colourista-0.1.0.0
-  - language-docker-10.0.0
+  - language-docker-10.1.0
   - megaparsec-9.0.0@sha256:920d1e469056c746b532333a078c2a9a195fab5e860e0c9734ee92a28c2bfb65,3117
   - spdx-1.0.0.2@sha256:7dfac9b454ff2da0abb7560f0ffbe00ae442dd5cb76e8be469f77e6988a70fed,2008
 ghc-options:


### PR DESCRIPTION
- version bump of language-docker for support for heredoc parsing
- Ignore shellchecking for heredocs using interpreters that are not
  supported by ShellCheck

fixes: #682
