### PR TITLE
Fix version of Docker image in pre-commit hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -4,7 +4,7 @@
   description: Runs hadolint Docker image to lint Dockerfiles
   language: docker_image
   types: ["dockerfile"]
-  entry: hadolint/hadolint:v2.6.1 hadolint
+  entry: hadolint/hadolint:v2.7.0 hadolint
 - id: hadolint
   name: Lint Dockerfiles
   description: Runs hadolint to lint Dockerfiles


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

This fixes issue #697.

### What I did
Updated the Docker version used in the pre-commit hook configuration file.

### How I did it

### How to verify it
