### PR TITLE
heredocs: fix line continuation bug

### DIFF
--- a/hadolint.cabal
+++ b/hadolint.cabal
@@ -5,7 +5,7 @@ cabal-version: 2.0
 -- see: https://github.com/sol/hpack
 
 name:           hadolint
-version:        2.7.0
+version:        2.7.1
 synopsis:       Dockerfile Linter JavaScript API
 description:    A smarter Dockerfile linter that helps you build best practice Docker images.
 category:       Development
@@ -141,7 +141,7 @@ library
     , filepath
     , foldl
     , ilist
-    , language-docker >=10.1.0 && <11
+    , language-docker >=10.1.1 && <11
     , megaparsec >=9.0.0
     , mtl
     , network-uri
@@ -178,7 +178,7 @@ executable hadolint
     , containers
     , gitrev >=1.3.1
     , hadolint
-    , language-docker >=10.1.0 && <11
+    , language-docker >=10.1.1 && <11
     , megaparsec >=9.0.0
     , optparse-applicative >=0.14.0
     , text
@@ -284,7 +284,7 @@ test-suite hadolint-unit-tests
     , foldl
     , hadolint
     , hspec
-    , language-docker >=10.1.0 && <11
+    , language-docker >=10.1.1 && <11
     , megaparsec >=9.0.0
     , split >=0.2
     , text

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: hadolint
-version: "2.7.0"
+version: "2.7.1"
 synopsis: Dockerfile Linter JavaScript API
 description: A smarter Dockerfile linter that helps you build best practice Docker images.
 category: Development
@@ -26,7 +26,7 @@ ghc-options:
 dependencies:
   - base >=4.8 && <5
   - megaparsec >= 9.0.0
-  - language-docker >=10.1.0 && <11
+  - language-docker >=10.1.1 && <11
 default-extensions:
   - OverloadedStrings
   - NamedFieldPuns

--- a/stack.yaml
+++ b/stack.yaml
@@ -6,7 +6,7 @@ resolver: lts-17.5
 extra-deps:
   - ShellCheck-0.7.1@sha256:94a6ee5a38e2668204bc95fdc7539a9a4ca7230984157694409444530c23b5a4,3170
   - colourista-0.1.0.0
-  - language-docker-10.1.0
+  - language-docker-10.1.1
   - megaparsec-9.0.0@sha256:920d1e469056c746b532333a078c2a9a195fab5e860e0c9734ee92a28c2bfb65,3117
   - spdx-1.0.0.2@sha256:7dfac9b454ff2da0abb7560f0ffbe00ae442dd5cb76e8be469f77e6988a70fed,2008
 ghc-options:


### PR DESCRIPTION
- Bump version of language-docker to 10.1.1
- Bump version to 2.7.1

Pull in fixes from upstream language-docker, so the line continuation
bug in heredoc parsing gets fixed.

fixes: https://github.com/hadolint/hadolint/issues/699