### PR TITLE
Drop quotes

### DIFF
--- a/ThirdPartyNotices.txt
+++ b/ThirdPartyNotices.txt
@@ -1,4 +1,4 @@
-Package: hadolint-2.7.1 (License: GPL-3.0-only)
+Package: hadolint-2.7.2 (License: GPL-3.0-only)
 -----
 1 package licensed under BSD-2: text-1.2.4.1
 -----
@@ -10,7 +10,7 @@ Package: hadolint-2.7.1 (License: GPL-3.0-only)
 -----
 1 package licensed under GPL-2: HsYAML-0.2.1.0
 -----
-2 packages licensed under GPL-3: ShellCheck-0.7.1, language-docker-10.1.1
+2 packages licensed under GPL-3: ShellCheck-0.7.1, language-docker-10.1.2
 -----
 1 package licensed under ISC: th-abstraction-0.4.2.0
 -----

--- a/hadolint.cabal
+++ b/hadolint.cabal
@@ -5,7 +5,7 @@ cabal-version: 2.0
 -- see: https://github.com/sol/hpack
 
 name:           hadolint
-version:        2.7.1
+version:        2.7.2
 synopsis:       Dockerfile Linter JavaScript API
 description:    A smarter Dockerfile linter that helps you build best practice Docker images.
 category:       Development
@@ -141,7 +141,7 @@ library
     , filepath
     , foldl
     , ilist
-    , language-docker >=10.1.1 && <11
+    , language-docker >=10.1.2 && <11
     , megaparsec >=9.0.0
     , mtl
     , network-uri
@@ -178,7 +178,7 @@ executable hadolint
     , containers
     , gitrev >=1.3.1
     , hadolint
-    , language-docker >=10.1.1 && <11
+    , language-docker >=10.1.2 && <11
     , megaparsec >=9.0.0
     , optparse-applicative >=0.14.0
     , text
@@ -284,7 +284,7 @@ test-suite hadolint-unit-tests
     , foldl
     , hadolint
     , hspec
-    , language-docker >=10.1.1 && <11
+    , language-docker >=10.1.2 && <11
     , megaparsec >=9.0.0
     , split >=0.2
     , text

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: hadolint
-version: "2.7.1"
+version: "2.7.2"
 synopsis: Dockerfile Linter JavaScript API
 description: A smarter Dockerfile linter that helps you build best practice Docker images.
 category: Development
@@ -26,7 +26,7 @@ ghc-options:
 dependencies:
   - base >=4.8 && <5
   - megaparsec >= 9.0.0
-  - language-docker >=10.1.1 && <11
+  - language-docker >=10.1.2 && <11
 default-extensions:
   - OverloadedStrings
   - NamedFieldPuns

--- a/src/Hadolint/Rule.hs
+++ b/src/Hadolint/Rule.hs
@@ -214,3 +214,10 @@ archiveFileFormatExtensions =
     ".txz",
     ".xz"
   ]
+
+dropQuotes :: Text.Text -> Text.Text
+dropQuotes = Text.dropAround quotes
+  where
+    quotes '\"' = True
+    quotes '\'' = True
+    quotes _ = False

--- a/src/Hadolint/Rule/DL3000.hs
+++ b/src/Hadolint/Rule/DL3000.hs
@@ -12,18 +12,12 @@ rule = simpleRule code severity message check
     severity = DLErrorC
     message = "Use absolute WORKDIR"
     check (Workdir loc)
-      | "$" `Text.isPrefixOf` Text.dropAround dropQuotes loc = True
-      | "/" `Text.isPrefixOf` Text.dropAround dropQuotes loc = True
-      | isWindowsAbsolute (Text.dropAround dropQuotes loc) = True
+      | "$" `Text.isPrefixOf` dropQuotes loc = True
+      | "/" `Text.isPrefixOf` dropQuotes loc = True
+      | isWindowsAbsolute (dropQuotes loc) = True
       | otherwise = False
     check _ = True
 {-# INLINEABLE rule #-}
-
-dropQuotes :: Char -> Bool
-dropQuotes chr
-  | chr == '\"' = True
-  | chr == '\'' = True
-  | otherwise = False
 
 isWindowsAbsolute :: Text.Text -> Bool
 isWindowsAbsolute path

--- a/src/Hadolint/Rule/DL3020.hs
+++ b/src/Hadolint/Rule/DL3020.hs
@@ -20,10 +20,13 @@ rule = simpleRule code severity message check
 isArchive :: Text.Text -> Bool
 isArchive path =
   or
-    ( [ ftype `Text.isSuffixOf` path
+    ( [ ftype `Text.isSuffixOf` dropQuotes path
         | ftype <- archiveFileFormatExtensions
       ]
     )
 
 isUrl :: Text.Text -> Bool
-isUrl path = or ([proto `Text.isPrefixOf` path | proto <- ["https://", "http://", "\"https://", "\"http://"]])
+isUrl path = or
+  [ proto `Text.isPrefixOf` dropQuotes path
+    | proto <- ["https://", "http://"]
+  ]

--- a/stack.yaml
+++ b/stack.yaml
@@ -6,7 +6,7 @@ resolver: lts-17.5
 extra-deps:
   - ShellCheck-0.7.1@sha256:94a6ee5a38e2668204bc95fdc7539a9a4ca7230984157694409444530c23b5a4,3170
   - colourista-0.1.0.0
-  - language-docker-10.1.1
+  - language-docker-10.1.2
   - megaparsec-9.0.0@sha256:920d1e469056c746b532333a078c2a9a195fab5e860e0c9734ee92a28c2bfb65,3117
   - spdx-1.0.0.2@sha256:7dfac9b454ff2da0abb7560f0ffbe00ae442dd5cb76e8be469f77e6988a70fed,2008
 ghc-options:

--- a/test/DL3020.hs
+++ b/test/DL3020.hs
@@ -16,3 +16,6 @@ tests = do
     it "add for url" $ ruleCatchesNot "DL3020" "ADD http://file.com /usr/src/app/"
     it "using add" $ ruleCatches "DL3020" "ADD file /usr/src/app/"
     it "warn for zip" $ ruleCatches "DL3020" "ADD file.zip /usr/src/app/"
+    it "add for tgz with quotes" $ ruleCatchesNot "DL3020" "ADD \"file.tgz\" /usr/src/app/"
+    it "add for url with quotes" $ ruleCatchesNot "DL3020" "ADD \"http://file.com\" /usr/src/app/"
+    it "warn for zip with quotes" $ ruleCatches "DL3020" "ADD \"file.zip\" /usr/src/app/"


### PR DESCRIPTION
### What I did
Generalize the bugfix in DL3020 from a few days ago. This really was about dropping quotes around a string and not about matching quotes at the beginning of a string.
Also bumping versions to incorporate the bugfix regarding heredoc termination in language-docker.

### How to verify it
This should parse fine now:
```Dockerfile
RUN <<EOF
echo $EOF
EOF
```
Tests for the quote dropping mechanic in DL3020 are included.