### PR TITLE
bugfix: handle yum/dnf modularity   #702

### DIFF
--- a/src/Hadolint/Rule/DL3033.hs
+++ b/src/Hadolint/Rule/DL3033.hs
@@ -12,15 +12,40 @@ rule = simpleRule code severity message check
     severity = DLWarningC
     message = "Specify version with `yum install -y <package>-<version>`."
 
-    check (Run (RunArgs args _)) = foldArguments (all versionFixed . yumPackages) args
+    check (Run (RunArgs args _)) =
+      foldArguments (all packageVersionFixed . yumPackages) args
+        && foldArguments (all moduleVersionFixed . yumModules) args
     check _ = True
-
-    versionFixed package =
-      "-" `Text.isInfixOf` package
-        || ".rpm" `Text.isSuffixOf` package
 {-# INLINEABLE rule #-}
 
 yumPackages :: Shell.ParsedShell -> [Text.Text]
 yumPackages args =
-  [ arg | cmd <- Shell.presentCommands args, Shell.cmdHasArgs "yum" ["install"] cmd, arg <- Shell.getArgsNoFlags cmd, arg /= "install"
+  [ arg
+    | cmd <- Shell.presentCommands args,
+      not (Shell.cmdHasArgs "yum" ["module"] cmd),
+      arg <- installFilter cmd
+  ]
+
+packageVersionFixed :: Text.Text -> Bool
+packageVersionFixed package =
+  "-" `Text.isInfixOf` package || ".rpm" `Text.isSuffixOf` package
+
+yumModules :: Shell.ParsedShell -> [Text.Text]
+yumModules args =
+  [ arg
+    | cmd <- Shell.presentCommands args,
+      Shell.cmdHasArgs "yum" ["module"] cmd,
+      arg <- installFilter cmd
+  ]
+
+moduleVersionFixed :: Text.Text -> Bool
+moduleVersionFixed = Text.isInfixOf ":"
+
+installFilter :: Shell.Command -> [Text.Text]
+installFilter cmd =
+  [ arg
+    | Shell.cmdHasArgs "yum" ["install"] cmd,
+      arg <- Shell.getArgsNoFlags cmd,
+      arg /= "install",
+      arg /= "module"
   ]

--- a/test/DL3033.hs
+++ b/test/DL3033.hs
@@ -16,3 +16,11 @@ tests = do
       ruleCatchesNot "DL3033" "RUN bash -c `# not even a yum command`"
       onBuildRuleCatchesNot "DL3033" "RUN yum install -y tomcat-9.2 && yum clean all"
       onBuildRuleCatchesNot "DL3033" "RUN bash -c `# not even a yum command`"
+    it "not ok wihout yum version pinning - modules" $ do
+      ruleCatches "DL3033" "RUN yum module install -y tomcat && yum clean all"
+      onBuildRuleCatches "DL3033" "RUN yum module install -y tomcat && yum clean all"
+    it "ok with yum version pinning - modules" $ do
+      ruleCatchesNot "DL3033" "RUN yum module install -y tomcat:9 && yum clean all"
+      ruleCatchesNot "DL3033" "RUN bash -c `# not even a yum command`"
+      onBuildRuleCatchesNot "DL3033" "RUN yum module install -y tomcat:9 && yum clean all"
+      onBuildRuleCatchesNot "DL3033" "RUN bash -c `# not even a yum command`"

--- a/test/DL3041.hs
+++ b/test/DL3041.hs
@@ -16,3 +16,11 @@ tests = do
       ruleCatchesNot "DL3041" "RUN notdnf install tomcat"
       onBuildRuleCatchesNot "DL3041" "RUN dnf install -y tomcat-9.0.1 && dnf clean all"
       onBuildRuleCatchesNot "DL3041" "RUN notdnf install tomcat"
+    it "not ok without dnf version pinning - moudles" $ do
+      ruleCatches "DL3041" "RUN dnf module install -y tomcat && dnf clean all"
+      onBuildRuleCatches "DL3041" "RUN dnf module install -y tomcat && dnf clean all"
+    it "ok with dnf version pinning - modules" $ do
+      ruleCatchesNot "DL3041" "RUN dnf module install -y tomcat:9 && dnf clean all"
+      ruleCatchesNot "DL3041" "RUN notdnf module install tomcat"
+      onBuildRuleCatchesNot "DL3041" "RUN dnf module install -y tomcat:9 && dnf clean all"
+      onBuildRuleCatchesNot "DL3041" "RUN notdnf module install tomcat"


### PR DESCRIPTION
Fix false positive in DL3033 and DL3041 when dealing with modules. See
https://docs.fedoraproject.org/en-US/modularity/installing-modules/ for
reference wrt. modules.

fixes: #702

### How to verify it
The following Dockerfile should no longer trigger DL3041:
```Dockerfile
FROM registry.access.redhat.com/ubi8/ubi:latest
RUN dnf module install nginx:1.18 -y && \
    dnf clean all --assumeyes
```