### PR TITLE
fomatters: Add SARIF formatter

### DIFF
--- a/hadolint.cabal
+++ b/hadolint.cabal
@@ -37,10 +37,12 @@ library
       Hadolint.Formatter.Codeclimate
       Hadolint.Formatter.Format
       Hadolint.Formatter.Json
+      Hadolint.Formatter.Sarif
       Hadolint.Formatter.SonarQube
       Hadolint.Formatter.TTY
       Hadolint.Ignore
       Hadolint.Lint
+      Hadolint.Meta
       Hadolint.Process
       Hadolint.Rule
       Hadolint.Rule.DL3000
@@ -123,6 +125,7 @@ library
       RecordWildCards
       StrictData
       ScopedTypeVariables
+      TemplateHaskell
       PatternSynonyms
   ghc-options: -Wall -Wcompat -Wincomplete-record-updates -Wincomplete-uni-patterns -Wredundant-constraints -optP-Wno-nonportable-include-path -flate-dmd-anal
   build-depends:
@@ -140,6 +143,7 @@ library
     , email-validate
     , filepath
     , foldl
+    , gitrev >=1.3.1
     , ilist
     , language-docker >=10.1.2 && <11
     , megaparsec >=9.0.0
@@ -170,13 +174,12 @@ executable hadolint
       RecordWildCards
       StrictData
       ScopedTypeVariables
-      PatternSynonyms
       TemplateHaskell
+      PatternSynonyms
   ghc-options: -Wall -Wcompat -Wincomplete-record-updates -Wincomplete-uni-patterns -Wredundant-constraints -optP-Wno-nonportable-include-path -flate-dmd-anal -O2 -threaded -rtsopts "-with-rtsopts=-N5 -A4m"
   build-depends:
       base >=4.8 && <5
     , containers
-    , gitrev >=1.3.1
     , hadolint
     , language-docker >=10.1.2 && <11
     , megaparsec >=9.0.0
@@ -269,6 +272,7 @@ test-suite hadolint-unit-tests
       RecordWildCards
       StrictData
       ScopedTypeVariables
+      TemplateHaskell
       PatternSynonyms
       ImplicitParams
       OverloadedLists

--- a/package.yaml
+++ b/package.yaml
@@ -35,6 +35,7 @@ default-extensions:
   - RecordWildCards
   - StrictData
   - ScopedTypeVariables
+  - TemplateHaskell
   - PatternSynonyms
 library:
   source-dirs: src
@@ -54,6 +55,7 @@ library:
     - deepseq == 1.4.4.*
     - directory >= 1.3.0
     - filepath
+    - gitrev >=1.3.1
     - ilist
     - mtl
     - network-uri
@@ -74,12 +76,9 @@ executables:
     dependencies:
       - hadolint
       - optparse-applicative >= 0.14.0
-      - gitrev >=1.3.1
       - text
       - containers
     ghc-options: -O2 -threaded -rtsopts "-with-rtsopts=-N5 -A4m"
-    default-extensions:
-      - TemplateHaskell
     when:
       # OS X does not support static build https://developer.apple.com/library/content/qa/qa1118
       - condition: "flag(static) && !(os(osx))"

--- a/src/Hadolint.hs
+++ b/src/Hadolint.hs
@@ -2,6 +2,7 @@ module Hadolint
   ( module Hadolint.Lint,
     module Hadolint.Process,
     module Hadolint.Config,
+    module Hadolint.Meta,
     Result (..),
     OutputFormat (..),
     shallSkipErrorStatus,
@@ -16,10 +17,12 @@ import qualified Hadolint.Formatter.Codacy
 import qualified Hadolint.Formatter.Codeclimate
 import Hadolint.Formatter.Format (Result (..))
 import qualified Hadolint.Formatter.Json
+import qualified Hadolint.Formatter.Sarif
 import qualified Hadolint.Formatter.SonarQube
 import qualified Hadolint.Formatter.TTY
 import Hadolint.Lint
 import Hadolint.Process
+import Hadolint.Meta
 import Language.Docker.Parser (DockerfileError)
 
 data OutputFormat
@@ -30,6 +33,7 @@ data OutputFormat
   | GitlabCodeclimateJson
   | Checkstyle
   | Codacy
+  | Sarif
   deriving (Show, Eq)
 
 shallSkipErrorStatus :: OutputFormat -> Bool
@@ -45,3 +49,4 @@ printResults format nocolor filePathInReport allResults =
     CodeclimateJson -> Hadolint.Formatter.Codeclimate.printResults allResults
     GitlabCodeclimateJson -> Hadolint.Formatter.Codeclimate.printGitlabResults allResults
     Codacy -> Hadolint.Formatter.Codacy.printResults allResults
+    Sarif -> Hadolint.Formatter.Sarif.printResults allResults

--- a/src/Hadolint/Formatter/Sarif.hs
+++ b/src/Hadolint/Formatter/Sarif.hs
@@ -1,0 +1,165 @@
+module Hadolint.Formatter.Sarif
+  ( printResults,
+    formatResult,
+  )
+where
+
+import qualified Control.Foldl as Foldl
+import Data.Aeson hiding (Result)
+import qualified Data.ByteString.Lazy.Char8 as B
+import Data.Sequence as Seq
+import qualified Data.Text as Text
+import Hadolint.Formatter.Format
+  ( Result (..),
+    errorMessage,
+    errorPosition,
+  )
+import Hadolint.Meta
+  ( getShortVersion,
+  )
+import Hadolint.Rule
+  ( CheckFailure (..),
+    DLSeverity (..),
+    unRuleCode,
+  )
+import Text.Megaparsec (TraversableStream)
+import Text.Megaparsec.Error
+import Text.Megaparsec.Pos
+  ( sourceColumn,
+    sourceLine,
+    sourceName,
+    unPos,
+  )
+import Text.Megaparsec.Stream (VisualStream)
+
+data SarifFormat s e
+  = SarifCheck Text.Text CheckFailure
+  | SarifError (ParseErrorBundle s e)
+
+instance
+  ( VisualStream s,
+    TraversableStream s,
+    ShowErrorComponent e
+  ) =>
+  ToJSON (SarifFormat s e)
+  where
+  toJSON (SarifCheck filename CheckFailure {..}) =
+    object
+      [ "ruleId" .= unRuleCode code,
+        "level" .= toSeverity severity,
+        "message"
+          .= object
+            [ "text" .= message
+            ],
+        "locations"
+          .= [ object
+                 [ "physicalLocation"
+                     .= object
+                       [ "artifactLocation"
+                           .= object
+                             [ "uri" .= filename
+                             ],
+                         "region"
+                           .= object
+                             [ "startLine" .= line,
+                               "endLine" .= line,
+                               "startColumn" .= (1 :: Int),
+                               "endColumn" .= (1 :: Int),
+                               "sourceLanguage" .= Text.pack language
+                             ]
+                       ]
+                 ]
+             ]
+      ]
+    where
+      language = if "DL" `Text.isPrefixOf` unRuleCode code
+                    then "dockerfile"
+                    else "sh"
+  toJSON (SarifError err) =
+    object
+      [ "ruleId" .= Text.pack "DL1000",
+        "level" .= Text.pack "error",
+        "message"
+          .= object
+            [ "text" .= errorMessage err
+            ],
+        "locations"
+          .= [ object
+                 [ "physicalLocation"
+                     .= object
+                       [ "artifactLocation"
+                           .= object
+                             [ "uri" .= Text.pack (sourceName pos)
+                             ],
+                         "region"
+                           .= object
+                             [ "startLine" .= linenumber,
+                               "endLine" .= linenumber,
+                               "startColumn" .= column,
+                               "endColumn" .= column,
+                               "sourceLanguage" .= Text.pack "dockerfile"
+                             ]
+                       ]
+                 ]
+             ]
+      ]
+    where
+      pos = errorPosition err
+      linenumber = unPos $ sourceLine pos
+      column = unPos $ sourceColumn pos
+
+formatResult :: Result s e -> Seq (SarifFormat s e)
+formatResult (Result filename errors checks) = allMessages
+  where
+    allMessages = errorMessages <> checkMessages
+    checkMessages = fmap (SarifCheck filename) checks
+    errorMessages = fmap SarifError errors
+
+printResults ::
+  ( VisualStream s,
+    TraversableStream s,
+    ShowErrorComponent e,
+    Foldable f
+  ) =>
+  f (Result s e) ->
+  IO ()
+printResults results =
+  B.putStr . encode $
+    object
+      [ ("version", "2.1.0"),
+        "$schema"
+          .= Text.pack "http://json.schemastore.org/sarif-2.1.0",
+        "runs"
+          .= [ object
+                 [ "tool"
+                     .= object
+                       [ "driver"
+                           .= object
+                             [ ("name", "Hadolint"),
+                               ("fullName", "Haskell Dockerfile Linter"),
+                               ("downloadUri",
+                                  "https://github.com/hadolint/hadolint"),
+                               "version"
+                                 .= Text.pack Hadolint.Meta.getShortVersion,
+                               "shortDescription"
+                                 .= object
+                                   [ ("text",
+  "Dockerfile linter, validate inline bash, written in Haskell")
+                                   ]
+                             ]
+                       ],
+                   "results" .= flattened,
+                   "defaultSourceLanguage" .= Text.pack "dockerfile"
+                 ]
+             ]
+      ]
+  where
+    flattened = Foldl.fold (Foldl.premap formatResult Foldl.mconcat) results
+
+-- | SARIF only specifies three severities "error", "warning" and "note"
+-- We pack our "info" and "style" severities together into the "note" severity
+-- here.
+toSeverity :: DLSeverity -> Text.Text
+toSeverity DLErrorC = "error"
+toSeverity DLWarningC = "warning"
+toSeverity _ = "note"

--- a/src/Hadolint/Meta.hs
+++ b/src/Hadolint/Meta.hs
@@ -1,0 +1,22 @@
+module Hadolint.Meta
+  ( getVersion,
+    getShortVersion
+  )
+where
+
+
+import qualified Development.GitRev
+
+
+getVersion :: String
+getVersion = "Haskell Dockerfile Linter " ++ getShortVersion
+
+getShortVersion :: String
+getShortVersion = v ++ d
+  where
+    version = $(Development.GitRev.gitDescribe)
+    dirty = $(Development.GitRev.gitDirty)
+    v = case version of
+      "UNKONWN" -> "-no-git"
+      _ -> version
+    d = if dirty then "-dirty" else ""


### PR DESCRIPTION
Add formatter for SARIF output format. SARIF is the static analysis
results interchange format, a Microsoft/OASIS standard format for static
analysis tools.
See https://github.com/microsoft/sarif-tutorials
and https://docs.oasis-open.org/sarif/sarif/v2.1.0/sarif-v2.1.0.html

Break long lines in `app/Main.hs`.

### How to verify it
`hadolint -f sarif Dockerfile` should generate a valid SARIF report for that dockerfile. Tools like [jsonschemavalidator](https://www.jsonschemavalidator.net/) can be used to validate the output against the schema spec.

Example dockerfile with output:
```Dockerfile
FROM debian:latest

WORKDIR ./foobar

RUN echo $foo
```
![screengrab2](https://user-images.githubusercontent.com/17141774/132668246-4037108a-be37-47f7-9cf2-82d6b0f2034c.png)
