### PR TITLE
DL3034: support --non-interactive and -n

### DIFF
--- a/src/Hadolint/Rule/DL3034.hs
+++ b/src/Hadolint/Rule/DL3034.hs
@@ -26,5 +26,5 @@ rule = simpleRule code severity message check
           "si",
           "patch"
         ]
-    hasYesOption = Shell.hasAnyFlag ["no-confirm", "y"]
+    hasYesOption = Shell.hasAnyFlag ["non-interactive", "n", "no-confirm", "y"]
 {-# INLINEABLE rule #-}

--- a/test/DL3034.hs
+++ b/test/DL3034.hs
@@ -12,7 +12,11 @@ tests = do
       ruleCatches "DL3034" "RUN zypper install httpd=2.4.24 && zypper clean"
       onBuildRuleCatches "DL3034" "RUN zypper install httpd=2.4.24 && zypper clean"
     it "ok with non-interactive switch present" $ do
+      ruleCatchesNot "DL3034" "RUN zypper install -n httpd=2.4.24 && zypper clean"
+      ruleCatchesNot "DL3034" "RUN zypper install --non-interactive httpd=2.4.24 && zypper clean"
       ruleCatchesNot "DL3034" "RUN zypper install -y httpd=2.4.24 && zypper clean"
       ruleCatchesNot "DL3034" "RUN zypper install --no-confirm httpd=2.4.24 && zypper clean"
+      onBuildRuleCatchesNot "DL3034" "RUN zypper install -n httpd=2.4.24 && zypper clean"
+      onBuildRuleCatchesNot "DL3034" "RUN zypper install --non-interactive httpd=2.4.24 && zypper clean"
       onBuildRuleCatchesNot "DL3034" "RUN zypper install -y httpd=2.4.24 && zypper clean"
       onBuildRuleCatchesNot "DL3034" "RUN zypper install --no-confirm httpd=2.4.24 && zypper clean"


### PR DESCRIPTION
Whitelist `--non-interactive, -n` zypper install options.

from the zypper command help
```
--non-interactive, -n	Do not ask anything, use default answers
-y, --no-confirm            Don't require user interaction. Alias for the --non-interactive global
                            option.
```