### PR TITLE
DL3010: Allow intentionally unextracted archives

### DIFF
--- a/hadolint.cabal
+++ b/hadolint.cabal
@@ -118,15 +118,16 @@ library
   hs-source-dirs:
       src
   default-extensions:
-      OverloadedStrings
-      NamedFieldPuns
-      DeriveGeneric
       DeriveAnyClass
-      RecordWildCards
-      StrictData
-      ScopedTypeVariables
-      TemplateHaskell
+      DeriveGeneric
+      NamedFieldPuns
+      OverloadedStrings
       PatternSynonyms
+      RecordWildCards
+      ScopedTypeVariables
+      StrictData
+      TemplateHaskell
+      TupleSections
   ghc-options: -Wall -Wcompat -Wincomplete-record-updates -Wincomplete-uni-patterns -Wredundant-constraints -optP-Wno-nonportable-include-path -flate-dmd-anal
   build-depends:
       Cabal
@@ -167,15 +168,16 @@ executable hadolint
   hs-source-dirs:
       app
   default-extensions:
-      OverloadedStrings
-      NamedFieldPuns
-      DeriveGeneric
       DeriveAnyClass
-      RecordWildCards
-      StrictData
-      ScopedTypeVariables
-      TemplateHaskell
+      DeriveGeneric
+      NamedFieldPuns
+      OverloadedStrings
       PatternSynonyms
+      RecordWildCards
+      ScopedTypeVariables
+      StrictData
+      TemplateHaskell
+      TupleSections
   ghc-options: -Wall -Wcompat -Wincomplete-record-updates -Wincomplete-uni-patterns -Wredundant-constraints -optP-Wno-nonportable-include-path -flate-dmd-anal -O2 -threaded -rtsopts "-with-rtsopts=-N5 -A4m"
   build-depends:
       base >=4.8 && <5
@@ -265,15 +267,16 @@ test-suite hadolint-unit-tests
   hs-source-dirs:
       test
   default-extensions:
-      OverloadedStrings
-      NamedFieldPuns
-      DeriveGeneric
       DeriveAnyClass
-      RecordWildCards
-      StrictData
-      ScopedTypeVariables
-      TemplateHaskell
+      DeriveGeneric
+      NamedFieldPuns
+      OverloadedStrings
       PatternSynonyms
+      RecordWildCards
+      ScopedTypeVariables
+      StrictData
+      TemplateHaskell
+      TupleSections
       ImplicitParams
       OverloadedLists
   ghc-options: -Wall -Wcompat -Wincomplete-record-updates -Wincomplete-uni-patterns -Wredundant-constraints -optP-Wno-nonportable-include-path -flate-dmd-anal

--- a/package.yaml
+++ b/package.yaml
@@ -28,15 +28,16 @@ dependencies:
   - megaparsec >= 9.0.0
   - language-docker >=10.1.2 && <11
 default-extensions:
-  - OverloadedStrings
-  - NamedFieldPuns
-  - DeriveGeneric
   - DeriveAnyClass
-  - RecordWildCards
-  - StrictData
-  - ScopedTypeVariables
-  - TemplateHaskell
+  - DeriveGeneric
+  - NamedFieldPuns
+  - OverloadedStrings
   - PatternSynonyms
+  - RecordWildCards
+  - ScopedTypeVariables
+  - StrictData
+  - TemplateHaskell
+  - TupleSections
 library:
   source-dirs: src
   generated-other-modules:

--- a/src/Hadolint/Rule/DL3010.hs
+++ b/src/Hadolint/Rule/DL3010.hs
@@ -1,21 +1,138 @@
 module Hadolint.Rule.DL3010 (rule) where
 
 import Data.Foldable (toList)
+import Data.Function ((&))
+import Data.List.NonEmpty (NonEmpty)
+import qualified Data.Set as Set
+import qualified Data.Sequence as Seq
 import qualified Data.Text as Text
 import Hadolint.Rule
+import qualified Hadolint.Shell as Shell
 import Language.Docker.Syntax
 
-rule :: Rule args
-rule = simpleRule code severity message check
+
+data Acc
+  = Acc
+      { archives :: Set.Set (Linenumber, Text.Text),
+        extracted :: Set.Set (Linenumber, Text.Text)
+      }
+  | Empty
+
+rule :: Rule Shell.ParsedShell
+rule = veryCustomRule check (emptyState Empty) markFailures
   where
     code = "DL3010"
     severity = DLInfoC
-    message = "Use ADD for extracting archives into an image"
-    check (Copy (CopyArgs srcs _ _ _ NoSource)) =
-      and
-        [ not (format `Text.isSuffixOf` src)
-          | SourcePath src <- toList srcs,
-            format <- archiveFileFormatExtensions
-        ]
-    check _ = True
+    message = "Use `ADD` for extracting archives into an image"
+
+    check _ _ (From _) = emptyState Empty
+    check line st (Copy (CopyArgs srcs tgt _ _ NoSource)) =
+      st |> modify (rememberArchives line srcs tgt)
+    check _ st (Run (RunArgs args _))
+      | Acc archives _ <- state st,
+        ex <- foldArguments (getExtractedArchives archives) args =
+          st |> modify (markExtracted ex)
+      | otherwise = st
+    check _ st _ = st
+
+    markFailures :: State Acc -> Failures
+    markFailures (State fails (Acc _ e)) =
+      Set.foldl' (Seq.|>) fails (Set.map makeFail e)
+    markFailures st = failures st
+
+    makeFail :: (Linenumber, Text.Text) -> CheckFailure
+    makeFail (line, _) = CheckFailure {..}
 {-# INLINEABLE rule #-}
+
+
+extractsThisArchive :: (Linenumber, Text.Text) -> Shell.Command -> Bool
+extractsThisArchive (_, archive) cmd =
+  (isTarExtractCommand cmd || isUnzipCommand cmd) && archive `elem` arguments
+  where
+    arguments = map basename $ Shell.getArgsNoFlags cmd
+
+getExtractedArchives ::
+  Set.Set (Linenumber, Text.Text) ->
+  Shell.ParsedShell ->
+  Set.Set (Linenumber, Text.Text)
+getExtractedArchives archives shell =
+  Set.filter
+    (\a -> any (extractsThisArchive a) cmds)
+    archives
+  where
+    cmds = Shell.presentCommands shell
+
+isTarExtractCommand :: Shell.Command -> Bool
+isTarExtractCommand cmd@(Shell.Command name _ _) =
+  name == "tar" && (any longExtractFlags args || any shortExtractFlags args)
+  where
+    longExtractFlags f = f `elem` ["--extract", "--get"]
+    shortExtractFlags f = "-" `Text.isPrefixOf` f && "x" `Text.isInfixOf` f
+    args = Shell.getArgs cmd
+
+isUnzipCommand :: Shell.Command -> Bool
+isUnzipCommand (Shell.Command name _ _) =
+  name `elem`
+    [ "unzip",
+      "gunzip",
+      "bunzip2",
+      "unlzma",
+      "unxz",
+      "zgz",
+      "uncompress",
+      "zcat",
+      "gzcat"
+    ]
+
+markExtracted :: Set.Set (Linenumber, Text.Text) -> Acc -> Acc
+markExtracted _ Empty = Empty
+markExtracted exarcv Acc {archives, extracted} =
+  Acc { archives, extracted = Set.union exarcv extracted }
+
+rememberArchives ::
+  Linenumber ->
+  NonEmpty SourcePath ->
+  TargetPath ->
+  Acc ->
+  Acc
+rememberArchives line paths target Empty =
+  if isArchive $ unTargetPath target
+    then Acc
+          { archives = Set.singleton (line, basename $ unTargetPath target),
+            extracted = Set.empty
+          }
+    else Acc
+          { archives =
+              paths
+                & toList
+                & map (basename . unSourcePath)
+                & Set.fromList
+                & Set.filter isArchive
+                & Set.map (line,),
+            extracted = Set.empty
+          }
+rememberArchives line paths target Acc {archives, extracted} =
+  if isArchive $ unTargetPath target
+    then Acc
+          { archives =
+              Set.insert (line, basename $ unTargetPath target) archives,
+            extracted
+          }
+    else Acc
+          { archives =
+              paths
+                & toList
+                & map (basename . unSourcePath)
+                & Set.fromList
+                & Set.filter isArchive
+                & Set.map (line,)
+                & Set.union archives,
+            extracted
+          }
+
+basename :: Text.Text -> Text.Text
+basename = Text.takeWhileEnd (\c -> c /= '/' && c /= '\\') . dropQuotes
+
+isArchive :: Text.Text -> Bool
+isArchive src =
+  any (`Text.isSuffixOf` dropQuotes src) archiveFileFormatExtensions

--- a/test/DL3010.hs
+++ b/test/DL3010.hs
@@ -1,5 +1,6 @@
 module DL3010 (tests) where
 
+import Data.Text as Text
 import Helpers
 import Test.Hspec
 
@@ -7,7 +8,52 @@ import Test.Hspec
 tests :: SpecWith ()
 tests = do
   let ?rulesConfig = mempty
-  describe "COPY rules" $ do
-    it "use add" $ ruleCatches "DL3010" "COPY packaged-app.tar /usr/src/app"
-    it "use not add" $ ruleCatchesNot "DL3010" "COPY package.json /usr/src/app"
-    it "ignore: copy from previous stage" $ ruleCatchesNot "DL3010" "COPY --from=builder /usr/local/share/some.tar /opt/some.tar"
+  describe "DL3010 - Use `ADD` for extracting archives into an image" $ do
+    it "catch: copy archive then extract 1" $
+      let dockerFile =
+            [ "COPY packaged-app.tar /usr/src/app",
+              "RUN tar -xf /usr/src/app/packaged-app.tar"
+            ]
+      in do
+        ruleCatches "DL3010" $ Text.unlines dockerFile
+    it "catch: copy archive then extract 2" $
+      let dockerFile =
+            [ "COPY packaged-app.tar /usr/src/app",
+              "WORKDIR /usr/src/app",
+              "RUN foo bar && echo something && tar -xf packaged-app.tar"
+            ]
+      in do
+        ruleCatches "DL3010" $ Text.unlines dockerFile
+    it "catch: copy archive then extract 3" $
+      let dockerFile =
+            [ "COPY foo/bar/packaged-app.tar /foo.tar",
+              "RUN tar -xf /foo.tar"
+            ]
+      in do
+        ruleCatches "DL3010" $ Text.unlines dockerFile
+    it "catch: copy archive then extract windows paths 1" $
+      let dockerFile =
+            [ "COPY build\\foo\\bar.tar.gz \"C:\\Program Files\\Foo\"",
+              "RUN tar -xf \"C:\\Program Files\\Foo\\bar.tar.gz\""
+            ]
+      in do
+        ruleCatches "DL3010" $ Text.unlines dockerFile
+    it "catch: copy archive then extract windows paths 2" $
+      let dockerFile =
+            [ "COPY build\\foo\\bar.tar.gz \"C:\\Program Files\\foo.tar.gz\"",
+              "RUN tar -xf foo.tar.gz"
+            ]
+      in do
+        ruleCatches "DL3010" $ Text.unlines dockerFile
+    it "ignore: copy archive without extract" $
+      let dockerFile =
+            [ "COPY packaged-app.tar /usr/src/app",
+              "FROM debian:11 as newstage"
+            ]
+      in do
+        ruleCatchesNot "DL3010" $ Text.unlines dockerFile
+    it "ignore: non archive" $
+      ruleCatchesNot "DL3010" "COPY package.json /usr/src/app"
+    it "ignore: copy from previous stage" $
+      ruleCatchesNot "DL3010"
+        "COPY --from=builder /usr/local/share/some.tar /opt/some.tar"


### PR DESCRIPTION
- Add advanced logic to DL3010 to detect archive extraction.
- Add more specific tests for DL3010

Sometimes it is desired to copy an archive into a Docker image. In these
cases, DL3010 should not trigger. This can be detected by searching for
commands extracting an archive that was added by a `COPY` instruction
earlier.
The new behaviour triggers only if an archive is `COPY`ed into the image
_and_ extracted (e.g. by `RUN tar -xf archive-foo.tar.gz`).

fixes: #709
