### PR TITLE
DL3059: RUNs and comments mixed

### DIFF
--- a/src/Hadolint/Rule/DL3059.hs
+++ b/src/Hadolint/Rule/DL3059.hs
@@ -19,6 +19,7 @@ rule = customRule check (emptyState Empty)
     check line st (Run (RunArgs _ flags))
       | state st == Acc flags = st |> addFail CheckFailure {..}
       | otherwise = st |> modify (remember flags)
+    check _ st (Comment _) = st
     check _ st _ = st |> modify reset
 {-# INLINEABLE rule #-}
 

--- a/test/DL3059.hs
+++ b/test/DL3059.hs
@@ -17,6 +17,12 @@ tests = do
       ruleCatchesNot "DL3059" "RUN /foo.sh\nWORKDIR /\nRUN /bar.sh"
     it "not ok with two consecutive `RUN`s" $ do
       ruleCatches "DL3059" "RUN /foo.sh\nRUN /bar.sh"
+    it "not ok with two `RUN`s separated by a comment" $ do
+      ruleCatches "DL3059" "RUN /foo.sh\n# a comment\nRUN /bar.sh"
+    it "not ok with two `RUN`s separated by two comment" $ do
+      ruleCatches "DL3059" "RUN /foo.sh\n# a comment\n# another comment\nRUN /bar.sh"
+    it "ok with one `RUN` after a comment" $ do
+      ruleCatchesNot "DL3059" "# a comment\nRUN /foo.sh"
     it "ok with two consecutive `RUN`s when flags are different 1" $ do
       ruleCatchesNot "DL3059" "RUN --mount=type=secret,id=foo /foo.sh\nRUN /bar.sh"
     it "ok with two consecutive `RUN`s when flags are different 2" $ do


### PR DESCRIPTION
Fixes #712

<!--
If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

### What I did

- added tests
- added code to DL3059 so that comments in the Dockerfile won't change the state (the state keeps track of the last line and if it was a `RUN` command.

### How I did it

Just added a case to the pattern matching, which makes the `otherwise` clause not get the comment-instructions.

### How to verify it

Run the tests and/or run hadolint on the Dockerfile from the issue.