### PR TITLE
DL3059: ignore chains of commands

### DIFF
--- a/src/Hadolint/Rule/DL3059.hs
+++ b/src/Hadolint/Rule/DL3059.hs
@@ -1,30 +1,44 @@
 module Hadolint.Rule.DL3059 (rule) where
 
 import Hadolint.Rule
+import qualified Hadolint.Shell as Shell
 import Language.Docker.Syntax
 
 
 data Acc
-  = Acc RunFlags
+  = Acc { flags :: RunFlags, count :: Int }
   | Empty
-  deriving (Eq, Show)
+  deriving (Eq)
 
-rule :: Rule args
+-- | This Rule catches multiple consecutive `RUN` instructions.
+-- It ignores the case where multiple commands are chained together (e.g. with
+-- `&&`) because in that case the programmer most likely has deliberately
+-- chosen to use multiuple `RUN` instructions. Cases where --mount=xxx flags
+-- differ are excluded as well.
+rule :: Rule Shell.ParsedShell
 rule = customRule check (emptyState Empty)
   where
     code = "DL3059"
     severity = DLInfoC
     message = "Multiple consecutive `RUN` instructions. Consider consolidation."
 
-    check line st (Run (RunArgs _ flags))
-      | state st == Acc flags = st |> addFail CheckFailure {..}
-      | otherwise = st |> modify (remember flags)
+    check line st (Run (RunArgs ar fl))
+      | state st == Empty =
+          st |> modify (remember fl (foldArguments countCommands ar))
+      | flags (state st) /= fl =
+          st |> modify (remember fl (foldArguments countCommands ar))
+      | foldArguments countCommands ar > 2 || count (state st) > 2 =
+          st |> modify (remember fl (foldArguments countCommands ar))
+      | otherwise = st |> addFail CheckFailure {..}
     check _ st (Comment _) = st
     check _ st _ = st |> modify reset
 {-# INLINEABLE rule #-}
 
-remember :: RunFlags -> Acc -> Acc
-remember flags _ = Acc flags
+remember :: RunFlags -> Int -> Acc -> Acc
+remember fl cn _ = Acc { flags = fl, count = cn }
 
 reset :: Acc -> Acc
 reset _ = Empty
+
+countCommands :: Shell.ParsedShell -> Int
+countCommands script = length $ Shell.presentCommands script

--- a/test/DL3059.hs
+++ b/test/DL3059.hs
@@ -20,11 +20,13 @@ tests = do
     it "not ok with two `RUN`s separated by a comment" $ do
       ruleCatches "DL3059" "RUN /foo.sh\n# a comment\nRUN /bar.sh"
     it "not ok with two `RUN`s separated by two comment" $ do
-      ruleCatches "DL3059" "RUN /foo.sh\n# a comment\n# another comment\nRUN /bar.sh"
+      ruleCatches "DL3059" "RUN /foo.sh\n# a comment\n# another comment\nRUN\
+                           \ /bar.sh"
     it "ok with one `RUN` after a comment" $ do
       ruleCatchesNot "DL3059" "# a comment\nRUN /foo.sh"
     it "ok with two consecutive `RUN`s when flags are different 1" $ do
-      ruleCatchesNot "DL3059" "RUN --mount=type=secret,id=foo /foo.sh\nRUN /bar.sh"
+      ruleCatchesNot "DL3059" "RUN --mount=type=secret,id=foo /foo.sh\nRUN\
+                              \ /bar.sh"
     it "ok with two consecutive `RUN`s when flags are different 2" $ do
       let dfile = [ "RUN --mount=type=secret,id=foo /foo.sh",
                     "RUN --mount=type=secret,id=bar /bar.sh"
@@ -33,5 +35,37 @@ tests = do
     it "not ok with two consecutive `RUN`s when flags are equal" $ do
       let dfile = [ "RUN --mount=type=secret,id=foo /foo.sh",
                     "RUN --mount=type=secret,id=foo /bar.sh"
+                  ]
+       in ruleCatches "DL3059" $ Text.unlines dfile
+
+    it "ok with two consecutive `RUN`s when commands are chained 1" $ do
+      let dfile = [ "RUN foo && bar",
+                    "RUN foobar"
+                  ]
+       in ruleCatchesNot "DL3059" $ Text.unlines dfile
+    it "ok with two consecutive `RUN`s when commands are chained 2" $ do
+      let dfile = [ "RUN foo; bar",
+                    "RUN foobar"
+                  ]
+       in ruleCatchesNot "DL3059" $ Text.unlines dfile
+    it "ok with two consecutive `RUN`s when commands are chained 3" $ do
+      let dfile = [ "RUN foobar",
+                    "RUN foo && bar"
+                  ]
+       in ruleCatchesNot "DL3059" $ Text.unlines dfile
+    it "ok with two consecutive `RUN`s when commands are chained 4" $ do
+      let dfile = [ "RUN foobar",
+                    "RUN foo; bar"
+                  ]
+       in ruleCatchesNot "DL3059" $ Text.unlines dfile
+    it "ok with two consecutive `RUN`s when commands are chained 5" $ do
+      let dfile = [ "RUN foo && bar",
+                    "RUN foo; bar"
+                  ]
+       in ruleCatchesNot "DL3059" $ Text.unlines dfile
+    it "not ok when more than one `RUN` has just one command in a row" $ do
+      let dfile = [ "RUN foo && bar",
+                    "RUN foo",
+                    "RUN bar"
                   ]
        in ruleCatches "DL3059" $ Text.unlines dfile


### PR DESCRIPTION
- Make DL3059 ignore consecutive `RUN` instructions if they contain
  chained-together commands.
- Add tests

Multiple consecutive `RUN` instruction usually are a sign of trouble in
a Dockerfile. But when the developer has chained together multiple
commands in a `RUN` instruction and still uses multiple consecutive
`RUN` instructions, it can be assumed that this is a consious choice and
thus DL3059 should ignore this.
This behaviour helps to quell DL3059s tendency to force developers to do
'cache busting' when not necessary but will still catch cases where each
command is mindlessly put into its own `RUN` instruction.

fixes: #715

### How to verify it
This Dockerfile should no longer trigger DL3059
```Dockerfile
RUN apk add --no-cache \
    curl \
    tar
RUN curl -LO https://github.com/dominikbraun/timetrace/releases/download/${VERSION}/timetrace-linux-amd64.tar.gz && \
    tar -xvf timetrace-linux-amd64.tar.gz -C /bin && \
    rm -f timetrace-linux-amd64.tar.gz
```
While this Dockerfile should still trigger DL3059 (multiple times)
```Dockerfile
RUN apt-get update
RUN apt-get install -y --no-install-recommends curl tar
RUN curl -LO https://foo.bar/download/this.tar
RUN tar -xf this.tar
RUN rm -f this.tar
```