### PR TITLE
Replace unmaintained actions/setup-haskell with haskell/actions/setup in release gh action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,7 +66,9 @@ jobs:
 
     - name: Setup Haskell
       id: setup-haskell-cabal
-      uses: actions/setup-haskell@v1.1.4
+      uses: haskell/actions/setup@v1.2.6
+      with:
+        ghc-version: 8.10.5
 
     - name: Freeze
       run: cabal freeze


### PR DESCRIPTION
Hi, recently I noticed that a build for a pip package of the hadolint binary I've built - [`hadolint-py`](https://github.com/AleksaC/hadolint-py) has failed on Windows. This happened due to windows binary missing from [`v2.7.0` release](https://github.com/hadolint/hadolint/releases/tag/v2.7.0), which was in turn caused by [an error](https://github.com/hadolint/hadolint/runs/3431250466) in release github action. Even though I'm not familiar with Haskell I went ahead and did a quick google search on the error and according to [this stack overflow question](https://stackoverflow.com/questions/63670698/ghc-exe-could-not-execute-ld-exe-while-installing-zlib) it seems that the problem would be resolved by simply updating the `ghc` version. However this is not possible using `actions/setup-haskell` which is unmaintained now, so I replaced it with a maintained fork `haskell/actions/setup`.

### What I did

I replaced `actions/setup-haskell` with `haskell/actions/setup` in release gh action.

### How I did it

```diff
-      uses: actions/setup-haskell@v1.1.4
+      uses: haskell/actions/setup@v1.2.6
+      with:
+        ghc-version: 8.10.5
```

### How to verify it

I created a branch to run just the builds for the action on push to that branch just to check. The action run can be seen [here](https://github.com/AleksaC/hadolint/runs/3864182723). You can also run the action yourself in a similar way or make a release.
