### PR TITLE
bugfix: display version string correctly

### DIFF
--- a/src/Hadolint/Meta.hs
+++ b/src/Hadolint/Meta.hs
@@ -4,7 +4,9 @@ module Hadolint.Meta
   )
 where
 
-import qualified Development.GitRev
+import Data.Version (showVersion)
+import Development.GitRev (gitDirty, gitDescribe)
+import Paths_hadolint (version)
 
 
 getVersion :: String
@@ -13,9 +15,10 @@ getVersion = "Haskell Dockerfile Linter " ++ getShortVersion
 getShortVersion :: String
 getShortVersion = v ++ d
   where
-    version = $(Development.GitRev.gitDescribe)
-    dirty = $(Development.GitRev.gitDirty)
-    v = case version of
-      "UNKONWN" -> "-no-git"
-      _ -> version
+    gitVersion = $(gitDescribe)
+    cabalVersion = showVersion version
+    dirty = $(gitDirty)
+    v = case gitVersion of
+      "UNKNOWN" -> cabalVersion ++ "-no-git"
+      _ -> gitVersion
     d = if dirty then "-dirty" else ""


### PR DESCRIPTION
Construct the version string correctly when not compiling in a git
directory.
This bug was caused by a typo and a misunderstanding of the code when
the version string logic was moved from app/Main.hs to
src/Hadolint/Meta.hs in commit 3b1de5a

fixes: #730

### How to verify it
To verify that this actually fixes the issue, check out this commit, remove or rename the `.git` directory and compile Hadolint from source. The result should show the version string from the `.cabal` file and the `-no-git` ending.
```
$ hadolint -v
Haskell Dockerfile Linter 2.8.0-no-git
```
When compiling from source with the `.git` directory, the result should show the corresponding git tag and the short git hash.