### PR TITLE
config: fix config file key `trustedRegistries`

### DIFF
--- a/src/Hadolint/Config/Configuration.hs
+++ b/src/Hadolint/Config/Configuration.hs
@@ -188,7 +188,7 @@ instance Yaml.FromYAML PartialConfiguration where
     partialFormat <- m .:? "output-format"
     override <- m .:? "override" .!= mempty
     ignored <- m .:? "ignored" .!= mempty
-    trusted <- m .:? "trusted-registries" .!= mempty
+    trusted <- m .:? "trustedRegistries" .!= mempty
     partialLabelSchema <- m .:? "label-schema" .!= mempty
     partialStrictLabels <- m .:? "strict-labels" .!= Nothing
     let partialIgnoreRules = coerce (ignored :: [Text])

--- a/test/Hadolint/Config/ConfigfileSpec.hs
+++ b/test/Hadolint/Config/ConfigfileSpec.hs
@@ -117,7 +117,7 @@ spec =
                           { partialIgnoreRules = ["DL3020", "DL3040", "SC1020"] }
 
     it "parse trusted registries" $ do
-      let yaml = [ "trusted-registries:",
+      let yaml = [ "trustedRegistries:",
                    "  - foobar.com",
                    "  - barfoo.com"
                  ]


### PR DESCRIPTION
Fix regression introduced by bf7e48e where the key for configuring the
set of trusted registries had changed.

fixes:  #733

### How to verify it
Config files that worked previous to v2.8.0 should work work again. Specifically, the key `trustedRegistries` should work as described in the documentation.