### PR TITLE
DL3007: Do not error out when latest tag is used alongside a sha256

### DIFF
--- a/src/Hadolint/Rule/DL3007.hs
+++ b/src/Hadolint/Rule/DL3007.hs
@@ -11,6 +11,7 @@ rule = simpleRule code severity message check
     message =
       "Using latest is prone to errors if the image will ever update. Pin the version explicitly \
       \to a release tag"
+    check (From BaseImage {tag = Just _, digest = Just _}) = True
     check (From BaseImage {tag = Just t}) = t /= "latest"
     check _ = True
 {-# INLINEABLE rule #-}

--- a/test/Hadolint/Rule/DL3007Spec.hs
+++ b/test/Hadolint/Rule/DL3007Spec.hs
@@ -20,5 +20,10 @@ spec = do
         "DL3007"
         "FROM hub.docker.io/debian@sha256:\
         \7959ed6f7e35f8b1aaa06d1d8259d4ee25aa85a086d5c125480c333183f9deeb"
+    it "explicit tagged and SHA" $
+      ruleCatchesNot
+        "DL3007"
+        "FROM hub.docker.io/debian:latest@sha256:\
+        \7959ed6f7e35f8b1aaa06d1d8259d4ee25aa85a086d5c125480c333183f9deeb"
     it "explicit tagged with name" $
       ruleCatchesNot "DL3007" "FROM debian:jessie AS builder"


### PR DESCRIPTION
Hello there! 👋 

Thank you for creating and maintaining hadolint! I stumbled upon it about a month ago and it really helped me preventing some footguns. I love the fact this linter can save some of my time 👍 

### What I did

I found an edge case. Docker allows both tags and SHA to be defined in the same base image definition. When this case happens, Docker ignores the tag and just pulls the image associated to its SHA.

Although, Docker ignores the tag, I find the case for having both compelling for humans: it's easier to represent what the image behind a SHA is, if the tag is next to it. 

I used this pattern and usually, hadolint is happy with it. Today, one of the tags was explicitly set to `latest` and `hadolint` bailed out. Here's a patch that changes the behavior to make it consistent no matter what the tag is.

### How I did it

TDD 🙂  I first added the unit test, which failed as expected. Then, I added the new check and ran the unit tests. Let me know what you think! 

By the way, that's my first patch in haskell. I mainly copy-pasted some the lines around. I would be happy to make any requested change 🙂 

### How to verify it

`stack test`
