### PR TITLE
options: disable ignore pragma

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,8 @@ Available options:
                            format requirement `format`
   --strict-labels          Do not permit labels other than specified in
                            `label-schema`
+  --disable-ignore-pragma  Disable the inline ignore pragma `# hadolint
+                           ignore=DLxxxx` and report rules anyways.
   -t,--failure-threshold THRESHOLD
                            Exit with failure code only when rules with a
                            severity above THRESHOLD are violated. Accepted
@@ -203,6 +205,7 @@ override:
   info: [string]                        # list of rules
   style: [string]                       # list of rules
 strict-labels: boolean                  # true | false
+disable-ignore-pragma: boolean          # true | false
 trustedRegistries: string | [string]    # registry or list of registries
 ```
 
@@ -288,6 +291,7 @@ HADOLINT_OVERRIDE_INFO=DL3010,DL3020     # comma separated list of rule codes
 HADOLINT_OVERRIDE_STYLE=DL3010,DL3020    # comma separated list of rule codes
 HADOLINT_IGNORE=DL3010,DL3020            # comma separated list of rule codes
 HADOLINT_STRICT_LABELS=1                 # Truthy value e.g. 1, true or yes
+HADOLINT_DISABLE_IGNORE_PRAGMA=1         # Truthy value e.g. 1, true or yes
 HADOLINT_TRUSTED_REGISTRIES              # comma separated list of registry urls
 ```
 
@@ -417,6 +421,7 @@ Please [create an issue][] if you have an idea for a good rule.
 
 | Rule                                                         | Default Severity | Description                                                                                                                                         |
 | :----------------------------------------------------------- | :--------------- | :-------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [DL1001](https://github.com/hadolint/hadolint/wiki/DL1001)   | Ignore           | Please refrain from using inline ignore pragmas `# hadolint ignore=DLxxxx`.                                                                         |
 | [DL3000](https://github.com/hadolint/hadolint/wiki/DL3000)   | Error            | Use absolute WORKDIR.                                                                                                                               |
 | [DL3001](https://github.com/hadolint/hadolint/wiki/DL3001)   | Info             | For some bash commands it makes no sense running them in a Docker container like ssh, vim, shutdown, service, ps, free, top, kill, mount, ifconfig. |
 | [DL3002](https://github.com/hadolint/hadolint/wiki/DL3002)   | Warning          | Last user should not be root.                                                                                                                       |
@@ -471,7 +476,7 @@ Please [create an issue][] if you have an idea for a good rule.
 | [DL3054](https://github.com/hadolint/hadolint/wiki/DL3054)   | Warning          | Label `<label>` is not a valid SPDX license identifier.                                                                                             |
 | [DL3055](https://github.com/hadolint/hadolint/wiki/DL3055)   | Warning          | Label `<label>` is not a valid git hash.                                                                                                            |
 | [DL3056](https://github.com/hadolint/hadolint/wiki/DL3056)   | Warning          | Label `<label>` does not conform to semantic versioning.                                                                                            |
-| [DL3057](https://github.com/hadolint/hadolint/wiki/DL3057)   | IgnoreC          | `HEALTHCHECK` instruction missing.                                                                                                                  |
+| [DL3057](https://github.com/hadolint/hadolint/wiki/DL3057)   | Ignore           | `HEALTHCHECK` instruction missing.                                                                                                                  |
 | [DL3058](https://github.com/hadolint/hadolint/wiki/DL3058)   | Warning          | Label `<label>` is not a valid email format - must be conform to RFC5322.                                                                           |
 | [DL3059](https://github.com/hadolint/hadolint/wiki/DL3059)   | Info             | Multiple consecutive `RUN` instructions. Consider consolidation.                                                                                    |
 | [DL3060](https://github.com/hadolint/hadolint/wiki/DL3060)   | Info             | `yarn cache clean` missing after `yarn install` was run.                                                                                            |

--- a/hadolint.cabal
+++ b/hadolint.cabal
@@ -50,6 +50,7 @@ library
       Hadolint.Pragma
       Hadolint.Process
       Hadolint.Rule
+      Hadolint.Rule.DL1001
       Hadolint.Rule.DL3000
       Hadolint.Rule.DL3001
       Hadolint.Rule.DL3002
@@ -216,6 +217,7 @@ test-suite hadolint-unit-tests
       Hadolint.Formatter.SarifSpec
       Hadolint.Formatter.TTYSpec
       Hadolint.PragmaSpec
+      Hadolint.Rule.DL1001Spec
       Hadolint.Rule.DL3000Spec
       Hadolint.Rule.DL3001Spec
       Hadolint.Rule.DL3002Spec

--- a/src/Hadolint/Config/Commandline.hs
+++ b/src/Hadolint/Config/Commandline.hs
@@ -95,6 +95,7 @@ parseCommandline =
         <*> parseAllowedRegistries
         <*> parseLabelSchema
         <*> parseStrictlabels
+        <*> parseDisableIgnorePragma
         <*> parseFailureThreshold
 
     -- All optional flags with boolean value must not have a default value. The
@@ -226,6 +227,15 @@ parseCommandline =
             ( long "strict-labels"
                 <> help "Do not permit labels other than specified in\
                         \ `label-schema`"
+            )
+        )
+
+    parseDisableIgnorePragma =
+      optional
+        ( flag' True
+            ( long "disable-ignore-pragma"
+                <> help "Disable inline ignore pragmas \
+                        \ `# hadolint ignore=DLxxxx`"
             )
         )
 

--- a/src/Hadolint/Config/Environment.hs
+++ b/src/Hadolint/Config/Environment.hs
@@ -30,6 +30,7 @@ getConfigFromEnvironment =
     <*> getAllowedSet "HADOLINT_ALLOWED_REGISTRIES"
     <*> getLabelSchema "HADOLINT_REQUIRE_LABELS"
     <*> maybeTruthy "HADOLINT_STRICT_LABELS"
+    <*> maybeTruthy "HADOLINT_DISABLE_IGNORE_PRAGMA"
     <*> getFailureThreshold
 
 

--- a/src/Hadolint/Pragma.hs
+++ b/src/Hadolint/Pragma.hs
@@ -1,5 +1,6 @@
 module Hadolint.Pragma
   ( ignored,
+    parseIgnorePragma,
     parseShell
   )
   where
@@ -20,13 +21,13 @@ ignored :: Foldl.Fold (InstructionPos Text) (Map.IntMap (Set.Set RuleCode))
 ignored = Foldl.Fold parse mempty id
   where
     parse acc InstructionPos {instruction = Comment comment, lineNumber = line} =
-      case parseComment comment of
+      case parseIgnorePragma comment of
         Just ignores@(_ : _) -> Map.insert (line + 1) (Set.fromList . fmap RuleCode $ ignores) acc
         _ -> acc
     parse acc _ = acc
 
-parseComment :: Text -> Maybe [Text]
-parseComment =
+parseIgnorePragma :: Text -> Maybe [Text]
+parseIgnorePragma =
   Megaparsec.parseMaybe commentParser
 
 commentParser :: Megaparsec.Parsec Void Text [Text]

--- a/src/Hadolint/Rule/DL1001.hs
+++ b/src/Hadolint/Rule/DL1001.hs
@@ -1,0 +1,19 @@
+module Hadolint.Rule.DL1001 (rule) where
+
+import Hadolint.Pragma
+import Hadolint.Rule
+import Hadolint.Shell (ParsedShell)
+import Language.Docker.Syntax
+
+rule :: Rule ParsedShell
+rule = simpleRule code severity message check
+  where
+    code = "DL1001"
+    severity = DLIgnoreC
+    message = "Please refrain from using inline igore pragmas \
+              \ `# hadolint ignore=DLxxxx`."
+    check (Comment com) =
+      case parseIgnorePragma com of
+        Just _ -> False
+        _ -> True
+    check _ = True

--- a/test/Hadolint/Config/CommandlineSpec.hs
+++ b/test/Hadolint/Config/CommandlineSpec.hs
@@ -300,6 +300,18 @@ spec = do
               mempty { partialStrictLabels = Just True }
           )
 
+    describe "parse disable ignore pragma" $ do
+      it "parse --disable-ignore-pragma" $ do
+        checkCommandline
+          ["--disable-ignore-pragma"]
+          ( CommandlineConfig
+              False
+              Nothing
+              []
+              Nothing
+              mempty { partialDisableIgnorePragma = Just True }
+          )
+
     describe "parse failure thresholds" $ do
       it "parse -t warning" $ do
         checkCommandline ["-t", "warning"] $ CommandlineConfig

--- a/test/Hadolint/Config/ConfigfileSpec.hs
+++ b/test/Hadolint/Config/ConfigfileSpec.hs
@@ -150,6 +150,16 @@ spec =
           conf = parseYaml yaml
       conf `shouldBe` Right mempty { partialStrictLabels = Just False }
 
+    it "parse disable-ignore-pragma: true" $ do
+      let yaml = [ "disable-ignore-pragma: true" ]
+          conf = parseYaml yaml
+      conf `shouldBe` Right mempty { partialDisableIgnorePragma = Just True }
+
+    it "parse disable-ignore-pragma: false" $ do
+      let yaml = [ "disable-ignore-pragma: false" ]
+          conf = parseYaml yaml
+      conf `shouldBe` Right mempty { partialDisableIgnorePragma = Just False }
+
     it "parse `failure-threshold: warning`" $ do
       let yaml = ["failure-threshold: warning"]
           conf = parseYaml yaml

--- a/test/Hadolint/Config/ConfigurationSpec.hs
+++ b/test/Hadolint/Config/ConfigurationSpec.hs
@@ -1,219 +1,43 @@
 module Hadolint.Config.ConfigurationSpec where
 
 import Data.Default
-import qualified Data.Map as Map
-import qualified Data.Set as Set
 import Hadolint
 import Test.Hspec
 
 spec :: SpecWith ()
 spec = do
   describe "Configuration" $ do
-    it "default configuration" $ do
-      def
-        `shouldBe` Configuration
-          False
-          False
-          False
-          TTY
-          mempty
-          mempty
-          mempty
-          mempty
-          mempty
-          mempty
-          mempty
-          False
-          DLInfoC
-
     it "override default configuration with empty config" $ do
       applyPartialConfiguration def mempty
-        `shouldBe` Configuration
-          False
-          False
-          False
-          TTY
-          mempty
-          mempty
-          mempty
-          mempty
-          mempty
-          mempty
-          mempty
-          False
-          DLInfoC
+        `shouldBe` def
 
     it "override default with specific configuration: no-fail" $ do
-      let config =
-            PartialConfiguration
-              (Just True)
-              Nothing
-              Nothing
-              mempty
-              mempty
-              mempty
-              mempty
-              mempty
-              mempty
-              mempty
-              mempty
-              Nothing
-              mempty
+      let config = def { partialNoFail = Just True }
       applyPartialConfiguration def config
-        `shouldBe` Configuration
-          True
-          False
-          False
-          TTY
-          mempty
-          mempty
-          mempty
-          mempty
-          mempty
-          mempty
-          mempty
-          False
-          DLInfoC
+        `shouldBe` def { noFail = True }
 
     it "override default with specific configuration: no-color" $ do
-      let config =
-            PartialConfiguration
-              Nothing
-              (Just True)
-              Nothing
-              mempty
-              mempty
-              mempty
-              mempty
-              mempty
-              mempty
-              mempty
-              mempty
-              Nothing
-              mempty
+      let config = def { partialNoColor = Just True }
       applyPartialConfiguration def config
-        `shouldBe` Configuration
-          False
-          True
-          False
-          TTY
-          mempty
-          mempty
-          mempty
-          mempty
-          mempty
-          mempty
-          mempty
-          False
-          DLInfoC
+        `shouldBe` def { noColor = True }
 
     it "empty should not override: no-color" $ do
-      let config =
-            PartialConfiguration
-              Nothing
-              (Just True)
-              Nothing
-              mempty
-              mempty
-              mempty
-              mempty
-              mempty
-              mempty
-              mempty
-              mempty
-              Nothing
-              mempty
-          config2 =
-            PartialConfiguration
-              Nothing
-              Nothing
-              Nothing
-              mempty
-              mempty
-              mempty
-              mempty
-              mempty
-              mempty
-              mempty
-              mempty
-              Nothing
-              mempty
+      let config = def { partialNoColor = Just True }
+          config2 = def
       applyPartialConfiguration def (config <> config2)
-        `shouldBe` Configuration
-          False
-          True
-          False
-          TTY
-          mempty
-          mempty
-          mempty
-          mempty
-          mempty
-          mempty
-          mempty
-          False
-          DLInfoC
+        `shouldBe` def { noColor = True }
 
     it "override default with specific configuration: verbose" $ do
-      let config =
-            PartialConfiguration
-              Nothing
-              Nothing
-              (Just True)
-              mempty
-              mempty
-              mempty
-              mempty
-              mempty
-              mempty
-              mempty
-              mempty
-              Nothing
-              mempty
+      let config = def { partialVerbose = Just True }
       applyPartialConfiguration def config
-        `shouldBe` Configuration
-          False
-          False
-          True
-          TTY
-          mempty
-          mempty
-          mempty
-          mempty
-          mempty
-          mempty
-          mempty
-          False
-          DLInfoC
+        `shouldBe` def { verbose = True }
 
     it "override default with specific configuration: output-format json" $ do
-      let config =
-            PartialConfiguration
-              Nothing
-              Nothing
-              Nothing
-              (Just Json)
-              mempty
-              mempty
-              mempty
-              mempty
-              mempty
-              mempty
-              mempty
-              Nothing
-              mempty
+      let config = def { partialFormat = Just Json }
       applyPartialConfiguration def config
-        `shouldBe` Configuration
-          False
-          False
-          False
-          Json
-          mempty
-          mempty
-          mempty
-          mempty
-          mempty
-          mempty
-          mempty
-          False
-          DLInfoC
+        `shouldBe` def { format = Json }
+
+    it "override default with specific configuration: disable ignore pragma" $ do
+      let config = def { partialDisableIgnorePragma = Just True }
+      applyPartialConfiguration def config
+        `shouldBe` def { disableIgnorePragma = True }

--- a/test/Hadolint/Config/EnvironmentSpec.hs
+++ b/test/Hadolint/Config/EnvironmentSpec.hs
@@ -145,6 +145,16 @@ spec = do
         conf <- getConfigFromEnvironment
         conf `shouldBe` mempty { partialStrictLabels = Just False }
 
+    withJustEnv "HADOLINT_DISABLE_IGNORE_PRAGMA" "yes" $ do
+      it "parse HADOLINT_DISABLE_IGNORE_PRAGMA=yes" $ do
+        conf <- getConfigFromEnvironment
+        conf `shouldBe` mempty { partialDisableIgnorePragma = Just True }
+
+    withJustEnv "HADOLINT_DISABLE_IGNORE_PRAGMA" "false" $ do
+      it "parse HADOLINT_DISABLE_IGNORE_PRAGMA=false" $ do
+        conf <- getConfigFromEnvironment
+        conf `shouldBe` mempty { partialDisableIgnorePragma = Just False }
+
     withJustEnv "HADOLINT_FAILURE_THRESHOLD" "error" $ do
       it "parse HADOLINT_FAILURE_THRESHOLD=error" $ do
         conf <- getConfigFromEnvironment

--- a/test/Hadolint/Rule/DL1001Spec.hs
+++ b/test/Hadolint/Rule/DL1001Spec.hs
@@ -1,0 +1,41 @@
+module Hadolint.Rule.DL1001Spec (spec) where
+
+import Data.Default
+import Data.Text as Text
+import Helpers
+import Test.Hspec
+
+
+spec :: SpecWith ()
+spec = do
+  let ?config = def
+
+  describe "DL1001 - Please don't use inline ignore pragma." $ do
+    it "catches inline ignore pragma" $ do
+      let file =
+            [ "# hadolint ignore=DL3003",
+              "RUN foo bar"
+            ]
+       in do
+        ruleCatches "DL1001" $ Text.unlines file
+    it "does not catch other pragma" $ do
+      let file =
+            [ "# hadolint shell=powershell",
+              "RUN foo bar"
+            ]
+       in do
+        ruleCatchesNot "DL1001" $ Text.unlines file
+    it "does not catch other comment" $ do
+      let file =
+            [ "# foobar",
+              "RUN foo bar"
+            ]
+       in do
+        ruleCatchesNot "DL1001" $ Text.unlines file
+    it "does not catch when inline ignore pragma is absent" $ do
+      let file =
+            [ "FROM debian",
+              "RUN foo bar"
+            ]
+       in do
+        ruleCatchesNot "DL1001" $ Text.unlines file


### PR DESCRIPTION
- Add new configuration option allowing to disable inline ignore pragmas
- Add new rule DL1001 to allow warning on use of an inline ignore pragma

Inline ignore pragmas `# hadolint ignore=DLxxxx` can cause trouble in
organizations when it is not desirable that individual developers
circumvent centralized CI checks. This configuration options allows
(e.g. in such a CI pipeline) to just ignore the pragma and apply all
rules as usual. The option can be enabled via command line
`--disable-ignore-pragma`, environment variable
`HADOLINT_DISABLE_IGNORE_PRAGMA=1`, or config file
```yaml
disable-ignore-pragma=true
```

Just to prevent any confusion about the ignored pragma, the rule DL1001
can be used to fail the linting process regardless of how the dockerfile
fares, if desired. By default DL1001 is ignored but can be enabled by
setting its severity to the desired level (e.g. via command line option
`--warning=DL1001`).

Changes in the test suite:

- Add tests for `disable-ignore-pragma` options
- Add tests for rule DL1001
- Remove pointless configuration test for content of default
  configuration
- Change configuration tests to a more compact syntax relying on the
  default instance

By changing the manual construction of configuration values to utilize
the default instance, future changes to the configuration do not
necessitate many error prone changes to the test suite. This imporves
reliability and ease of use of the configuration test suite.

fixes: #747
