### PR TITLE
DL3021: Fix behavior with quotes in target path

### DIFF
--- a/src/Hadolint/Rule/DL3021.hs
+++ b/src/Hadolint/Rule/DL3021.hs
@@ -15,6 +15,8 @@ rule = simpleRule code severity message check
       | length sources > 1 = endsWithSlash t
       | otherwise = True
     check _ = True
-
-    endsWithSlash (TargetPath t) = not (Text.null t) && Text.last t == '/'
 {-# INLINEABLE rule #-}
+
+endsWithSlash :: TargetPath -> Bool
+endsWithSlash (TargetPath t) =
+  not (Text.null t) && (Text.last . dropQuotes) t == '/'

--- a/test/Hadolint/Rule/DL3021Spec.hs
+++ b/test/Hadolint/Rule/DL3021Spec.hs
@@ -13,3 +13,5 @@ spec = do
     it "no warn on 2 args" $ ruleCatchesNot "DL3021" "COPY foo bar"
     it "warn on 3 args" $ ruleCatches "DL3021" "COPY foo bar baz"
     it "no warn on 3 args" $ ruleCatchesNot "DL3021" "COPY foo bar baz/"
+    it "warn on 3 args with quotes" $ ruleCatches "DL3021" "COPY foo bar \"baz\""
+    it "no warn on 3 args with quotes" $ ruleCatchesNot "DL3021" "COPY foo bar \"baz/\""


### PR DESCRIPTION
DL3021 makes sure the target path is a directory by making sure it ends
with a `/` if there are more than two arguments to a `COPY` instruction.
This should work regardless of whether or not that target path is
quoted.

fixes: #749

### How to verify it
This should no longer erroneously trigger DL3021:
```Dockerfile
COPY fileA fileB fileC "/var/lib/destination/"
```
