### PR TITLE
Tests: Fix test suite for SARIF formatter

### DIFF
--- a/test/Hadolint/Formatter/SarifSpec.hs
+++ b/test/Hadolint/Formatter/SarifSpec.hs
@@ -1,11 +1,10 @@
 module Hadolint.Formatter.SarifSpec (spec) where
 
+import Data.Aeson
 import Helpers
 import Hadolint
   ( CheckFailure (..),
     DLSeverity (..),
-    Result(..),
-    printResults,
     OutputFormat (..),
     getShortVersion,
   )
@@ -15,18 +14,200 @@ import Test.Hspec
 spec :: SpecWith ()
 spec = do
   let ?noColor = True
+  let version = String "2.1.0"
+      schema = String "http://json.schemastore.org/sarif-2.1.0"
+      defSrcLang = String "dockerfile"
+      tool =
+        Object
+          [ "driver" .=
+              Object
+                [ "name" .= String "Hadolint",
+                  "fullName" .= String "Haskell Dockerfile Linter",
+                  "downloadUri" .=
+                    String "https://github.com/hadolint/hadolint",
+                  "version" .= getShortVersion,
+                  "shortDescription" .=
+                    Object
+                      [ "text" .= String "Dockerfile linter, validate inline\
+                                         \ bash, written in Haskell"
+                      ]
+                ]
+          ]
 
   describe "Formatter: Sarif" $ do
     it "print empty results" $ do
       let checkFails = []
-          expectation = "{\"runs\":[{\"defaultSourceLanguage\":\"dockerfi\
-                        \le\",\"results\":[],\"tool\":{\"driver\":{\"full\
-                        \Name\":\"Haskell Dockerfile Linter\",\"downloadU\
-                        \ri\":\"https://github.com/hadolint/hadolint\",\"\
-                        \shortDescription\":{\"text\":\"Dockerfile linter\
-                        \, validate inline bash, written in Haskell\"},\"\
-                        \name\":\"Hadolint\",\"version\":\""
-                        ++ getShortVersion
-                        ++ "\"}}}],\"version\":\"2.1.0\",\"$schema\
-                           \\":\"http://json.schemastore.org/sarif-2.1.0\"}"
-      assertFormatter Sarif checkFails expectation
+          expectation =
+            Object
+              [ "version" .= version,
+                "$schema" .= schema,
+                "runs" .=
+                  Array
+                    [ Object
+                        [ "tool" .= tool,
+                          "results" .= Array [],
+                          "defaultSourceLanguage" .= defSrcLang
+                        ]
+                    ]
+              ]
+      assertFormatterJson Sarif checkFails expectation
+
+    it "print one failed rule" $ do
+      let checkFails =
+            [ CheckFailure
+                { code = "DL2001",
+                  severity = DLWarningC,
+                  message = "test",
+                  line = 1
+                }
+            ]
+          expectation =
+            Object
+              [ "version" .= version,
+                "$schema" .= schema,
+                "runs" .=
+                  Array
+                    [ Object
+                        [ "tool" .= tool,
+                          "results" .=
+                            Array
+                              [ Object
+                                  [ "level" .= String "warning",
+                                    "locations" .=
+                                      Array
+                                        [ Object
+                                            [ "physicalLocation" .=
+                                                Object
+                                                  [ "artifactLocation" .=
+                                                      Object
+                                                        [ "uri" .=
+                                                            String "<string>"
+                                                        ],
+                                                    "region" .=
+                                                      Object
+                                                        [ "startLine" .=
+                                                            Number 1.0,
+                                                          "endLine" .=
+                                                            Number 1.0,
+                                                          "startColumn" .=
+                                                            Number 1.0,
+                                                          "endColumn" .=
+                                                            Number 1.0,
+                                                          "sourceLanguage" .=
+                                                            String "dockerfile"
+                                                        ]
+                                                  ]
+                                            ]
+                                        ],
+                                    "message" .=
+                                      Object
+                                        [ "text" .= String "test"
+                                        ],
+                                    "ruleId" .= String "DL2001"
+                                  ]
+                              ],
+                          "defaultSourceLanguage" .= defSrcLang
+                        ]
+                    ]
+              ]
+      assertFormatterJson Sarif checkFails expectation
+
+    it "print multiple failed rules" $ do
+      let checkFails =
+            [ CheckFailure
+                { code = "DL2001",
+                  severity = DLWarningC,
+                  message = "test",
+                  line = 1
+                },
+              CheckFailure
+                { code = "DL2003",
+                  severity = DLInfoC,
+                  message = "test 2",
+                  line = 3
+                }
+            ]
+          expectation =
+            Object
+              [ "version" .= version,
+                "$schema" .= schema,
+                "runs" .=
+                  Array
+                    [ Object
+                        [ "tool" .= tool,
+                          "results" .=
+                            Array
+                              [ Object
+                                  [ "level" .= String "warning",
+                                    "locations" .=
+                                      Array
+                                        [ Object
+                                            [ "physicalLocation" .=
+                                                Object
+                                                  [ "artifactLocation" .=
+                                                      Object
+                                                        [ "uri" .=
+                                                            String "<string>"
+                                                        ],
+                                                    "region" .=
+                                                      Object
+                                                        [ "startLine" .=
+                                                            Number 1.0,
+                                                          "endLine" .=
+                                                            Number 1.0,
+                                                          "startColumn" .=
+                                                            Number 1.0,
+                                                          "endColumn" .=
+                                                            Number 1.0,
+                                                          "sourceLanguage" .=
+                                                            String "dockerfile"
+                                                        ]
+                                                  ]
+                                            ]
+                                        ],
+                                    "message" .=
+                                      Object
+                                        [ "text" .= String "test"
+                                        ],
+                                    "ruleId" .= String "DL2001"
+                                  ],
+                                Object
+                                  [ "level" .= String "note",
+                                    "locations" .=
+                                      Array
+                                        [ Object
+                                            [ "physicalLocation" .=
+                                                Object
+                                                  [ "artifactLocation" .=
+                                                      Object
+                                                        [ "uri" .=
+                                                            String "<string>"
+                                                        ],
+                                                    "region" .=
+                                                      Object
+                                                        [ "startLine" .=
+                                                            Number 3.0,
+                                                          "endLine" .=
+                                                            Number 3.0,
+                                                          "startColumn" .=
+                                                            Number 1.0,
+                                                          "endColumn" .=
+                                                            Number 1.0,
+                                                          "sourceLanguage" .=
+                                                            String "dockerfile"
+                                                        ]
+                                                  ]
+                                            ]
+                                        ],
+                                    "message" .=
+                                      Object
+                                        [ "text" .= String "test 2"
+                                        ],
+                                    "ruleId" .= String "DL2003"
+                                  ]
+                              ],
+                          "defaultSourceLanguage" .= defSrcLang
+                        ]
+                    ]
+              ]
+      assertFormatterJson Sarif checkFails expectation

--- a/test/Helpers.hs
+++ b/test/Helpers.hs
@@ -1,6 +1,8 @@
 module Helpers where
 
 import Control.Monad (unless, when)
+import qualified Data.ByteString.Lazy.Char8 as BSC
+import Data.Aeson hiding (Result)
 import Hadolint (Configuration (..), OutputFormat (..), printResults)
 import Hadolint.Formatter.Format (Result (..))
 import Hadolint.Formatter.TTY (formatCheck)
@@ -136,3 +138,16 @@ assertFormatter formatter failures expectation = do
   (cap, _) <- capture
                 (printResults formatter ?noColor (Just "<string>") results)
   cap `shouldBe` expectation
+
+assertFormatterJson
+  :: (HasCallStack, ?noColor :: Bool) =>
+  OutputFormat ->
+  [CheckFailure] ->
+  Value ->
+  Assertion
+assertFormatterJson formatter failures expectation = do
+  let results =
+        NonEmpty.fromList [ Result "<string>" mempty (Seq.fromList failures) ]
+  (cap, _) <- capture
+                (printResults formatter ?noColor (Just "<string>") results)
+  decode (BSC.pack cap) `shouldBe` Just expectation


### PR DESCRIPTION
- Test the result of the SARIF formatter by re-decoding the result and
comparing it against a known good JSON value. This removes the tests
dependence on the order the elemets of JSON object are printed in, which
is not necessarily deterministic.

- Extend the test suite for the SARIF formatter to test non-empty
linting results.

possibly fixes:  #753