### PR TITLE
Bring env var for trusted registries in sync with docs (#756)

### DIFF
--- a/src/Hadolint/Config/Environment.hs
+++ b/src/Hadolint/Config/Environment.hs
@@ -27,7 +27,7 @@ getConfigFromEnvironment =
     <*> getOverrideList "HADOLINT_OVERRIDE_INFO"
     <*> getOverrideList "HADOLINT_OVERRIDE_STYLE"
     <*> getOverrideList "HADOLINT_IGNORE"
-    <*> getAllowedSet "HADOLINT_ALLOWED_REGISTRIES"
+    <*> getAllowedSet "HADOLINT_TRUSTED_REGISTRIES"
     <*> getLabelSchema "HADOLINT_REQUIRE_LABELS"
     <*> maybeTruthy "HADOLINT_STRICT_LABELS"
     <*> maybeTruthy "HADOLINT_DISABLE_IGNORE_PRAGMA"

--- a/test/Hadolint/Config/EnvironmentSpec.hs
+++ b/test/Hadolint/Config/EnvironmentSpec.hs
@@ -105,16 +105,16 @@ spec = do
         conf <- getConfigFromEnvironment
         conf `shouldBe` mempty { partialIgnoreRules = ["DL3010", "DL3011"] }
 
-    withJustEnv "HADOLINT_ALLOWED_REGISTRIES" "foobar.com" $ do
-      it "parse HADOLINT_ALLOWED_REGISTRIES=foobar.com" $ do
+    withJustEnv "HADOLINT_TRUSTED_REGISTRIES" "foobar.com" $ do
+      it "parse HADOLINT_TRUSTED_REGISTRIES=foobar.com" $ do
         conf <- getConfigFromEnvironment
         conf `shouldBe` mempty
                           { partialAllowedRegistries =
                               Set.fromList ["foobar.com"]
                           }
 
-    withJustEnv "HADOLINT_ALLOWED_REGISTRIES" "foobar.com,barfoo.com" $ do
-      it "parse HADOLINT_ALLOWED_REGISTIRES=foobar.com,barfoo.com" $ do
+    withJustEnv "HADOLINT_TRUSTED_REGISTRIES" "foobar.com,barfoo.com" $ do
+      it "parse HADOLINT_TRUSTED_REGISTRIES=foobar.com,barfoo.com" $ do
         conf <- getConfigFromEnvironment
         conf `shouldBe` mempty
                           { partialAllowedRegistries =
@@ -190,7 +190,7 @@ unsetAll = do
   unsetEnv "HADOLINT_OVERRIDE_INFO"
   unsetEnv "HADOLINT_OVERRIDE_STYLE"
   unsetEnv "HADOLINT_IGNORE"
-  unsetEnv "HADOLINT_ALLOWED_REGISTRIES"
+  unsetEnv "HADOLINT_TRUSTED_REGISTRIES"
   unsetEnv "HADOLINT_REQUIRE_LABELS"
   unsetEnv "HADOLINT_STRICT_LABELS"
   unsetEnv "HADOLINT_FAILURE_THRESHOLD"


### PR DESCRIPTION
### What I did

Renamed the configuration variable from `HADOLINT_{ALLOWED => TRUSTED}_REGISTRIES` in order to match the documented behaviour.

Closes #756.

### How I did it

Just changed the relevant variable string values.

Didn't update any of the procedure names, since they still seem correct; they are still handling the list of allowed registries.

### How to verify it

Run:

```
HADOLINT_TRUSTED_REGISTRIES=good.example.com hadolint /dev/stdin <<< 'FROM bad.example.org/image:v1.0'
```

Expected output:

```
/dev/stdin:1 DL3026 error: Use only an allowed registry in the FROM image
```