### PR TITLE
Add Super-Linter to Code Review docs

### DIFF
--- a/docs/INTEGRATION.md
+++ b/docs/INTEGRATION.md
@@ -36,6 +36,10 @@ Then add the CI step on codeship-steps.yml with the path of the dockerfile
 [Mega-Linter](https://nvuillam.github.io/mega-linter/) aggregates 70 linters, including [hadolint](
 https://nvuillam.github.io/mega-linter/descriptors/dockerfile_hadolint/) out of the box.
 
+### Super-Linter
+
+[Super-Linter](https://github.com/github/super-linter) combines multiple linters, including hadolint out of the box.
+
 ## Continuous Integration
 
 ### Travis CI

--- a/docs/INTEGRATION.md
+++ b/docs/INTEGRATION.md
@@ -38,7 +38,8 @@ https://nvuillam.github.io/mega-linter/descriptors/dockerfile_hadolint/) out of 
 
 ### Super-Linter
 
-[Super-Linter](https://github.com/github/super-linter) combines multiple linters, including hadolint out of the box.
+[Super-Linter](https://github.com/github/super-linter) combines multiple linters, including
+hadolint out of the box.
 
 ## Continuous Integration
 


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

### What I did

Add [Super-Linter](https://github.com/github/super-linter) to "Code Review" section in docs.

I use Super-Linter in most of my projects and it's awesome. Check out [this podcast by Bret Fisher](https://podcast.bretfisher.com/episodes/lint-everything-with-super-linter) to learn more about it. People should be aware that it includes hadolint.

### How I did it

Update the `docs/INTEGRATION.md` file.

### How to verify it

Review the updated docs.