### PR TITLE
DL3038, DL3040, DL3041: Add support for microdnf

### DIFF
--- a/src/Hadolint/Rule/DL3038.hs
+++ b/src/Hadolint/Rule/DL3038.hs
@@ -15,6 +15,7 @@ rule = simpleRule code severity message check
     check _ = True
 
     forgotDnfYesOption cmd = isDnfInstall cmd && not (hasYesOption cmd)
-    isDnfInstall = Shell.cmdHasArgs "dnf" ["install", "groupinstall", "localinstall"]
+    isDnfInstall = Shell.cmdsHaveArgs dnfCmds ["install", "groupinstall", "localinstall"]
     hasYesOption = Shell.hasAnyFlag ["y", "assumeyes"]
+    dnfCmds = ["dnf", "microdnf"]
 {-# INLINEABLE rule #-}

--- a/src/Hadolint/Rule/DL3040.hs
+++ b/src/Hadolint/Rule/DL3040.hs
@@ -11,13 +11,16 @@ rule = simpleRule code severity message check
     severity = DLWarningC
     message = "`dnf clean all` missing after dnf command."
 
-    check (Run (RunArgs args _)) =
-      foldArguments (Shell.noCommands dnfInstall) args
-        || ( foldArguments (Shell.anyCommands dnfInstall) args
-               && foldArguments (Shell.anyCommands dnfClean) args
-           )
+    check (Run (RunArgs args _)) = all (checkMissingClean args) dnfCmds
     check _ = True
 
-    dnfInstall = Shell.cmdHasArgs "dnf" ["install"]
-    dnfClean = Shell.cmdHasArgs "dnf" ["clean", "all"]
+    checkMissingClean args cmdName =
+      foldArguments (Shell.noCommands $ dnfInstall cmdName) args
+        || ( foldArguments (Shell.anyCommands $ dnfInstall cmdName) args
+               && foldArguments (Shell.anyCommands $ dnfClean cmdName) args
+           )
+
+    dnfInstall cmdName = Shell.cmdHasArgs cmdName ["install"]
+    dnfClean cmdName = Shell.cmdHasArgs cmdName ["clean", "all"]
+    dnfCmds = ["dnf", "microdnf"]
 {-# INLINEABLE rule #-}

--- a/src/Hadolint/Rule/DL3041.hs
+++ b/src/Hadolint/Rule/DL3041.hs
@@ -18,11 +18,14 @@ rule = simpleRule code severity message check
     check _ = True
 {-# INLINEABLE rule #-}
 
+dnfCmds :: [Text.Text]
+dnfCmds = ["dnf", "microdnf"]
+
 dnfPackages :: Shell.ParsedShell -> [Text.Text]
 dnfPackages args =
     [ arg
       | cmd <- Shell.presentCommands args,
-        not (Shell.cmdHasArgs "dnf" ["module"] cmd),
+        not (Shell.cmdsHaveArgs dnfCmds ["module"] cmd),
         arg <- installFilter cmd
     ]
 
@@ -34,7 +37,7 @@ dnfModules :: Shell.ParsedShell -> [Text.Text]
 dnfModules args =
   [ arg
     | cmd <- Shell.presentCommands args,
-      Shell.cmdHasArgs "dnf" ["module"] cmd,
+      Shell.cmdsHaveArgs dnfCmds ["module"] cmd,
       arg <- installFilter cmd
   ]
 
@@ -44,7 +47,7 @@ moduleVersionFixed = Text.isInfixOf ":"
 installFilter :: Shell.Command -> [Text.Text]
 installFilter cmd =
   [ arg
-    | Shell.cmdHasArgs "dnf" ["install"] cmd,
+    | Shell.cmdsHaveArgs dnfCmds ["install"] cmd,
       arg <- Shell.getArgsNoFlags cmd,
       arg /= "install",
       arg /= "module"

--- a/src/Hadolint/Shell.hs
+++ b/src/Hadolint/Shell.hs
@@ -165,6 +165,11 @@ cmdHasArgs expectedName expectedArgs (Command n args _)
   | expectedName /= n = False
   | otherwise = not $ null [arg | CmdPart arg _ <- args, arg `elem` expectedArgs]
 
+cmdsHaveArgs :: [Text.Text] -> [Text.Text] -> Command -> Bool
+cmdsHaveArgs expectedNames expectedArgs (Command n args _)
+  | n `notElem` expectedNames = False
+  | otherwise = not $ null [arg | CmdPart arg _ <- args, arg `elem` expectedArgs]
+
 cmdHasPrefixArg :: Text.Text -> Text.Text -> Command -> Bool
 cmdHasPrefixArg expectedName expectedArg (Command n args _)
   | expectedName /= n = False

--- a/test/Hadolint/Rule/DL3038Spec.hs
+++ b/test/Hadolint/Rule/DL3038Spec.hs
@@ -12,9 +12,13 @@ spec = do
   describe "DL3038 - Use the `-y` switch to avoid manual input `dnf install -y <package>`" $ do
     it "not ok without dnf non-interactive flag" $ do
       ruleCatches "DL3038" "RUN dnf install httpd-2.4.24 && dnf clean all"
+      ruleCatches "DL3038" "RUN microdnf install httpd-2.4.24 && microdnf clean all"
       onBuildRuleCatches "DL3038" "RUN dnf install httpd-2.4.24 && dnf clean all"
+      onBuildRuleCatches "DL3038" "RUN microdnf install httpd-2.4.24 && microdnf clean all"
     it "ok with dnf non-interactive flag" $ do
       ruleCatchesNot "DL3038" "RUN dnf install -y httpd-2.4.24 && dnf clean all"
+      ruleCatchesNot "DL3038" "RUN microdnf install -y httpd-2.4.24 && microdnf clean all"
       ruleCatchesNot "DL3038" "RUN notdnf install httpd"
       onBuildRuleCatchesNot "DL3038" "RUN dnf install -y httpd-2.4.24 && dnf clean all"
+      onBuildRuleCatchesNot "DL3038" "RUN microdnf install -y httpd-2.4.24 && microdnf clean all"
       onBuildRuleCatchesNot "DL3038" "RUN notdnf install httpd"

--- a/test/Hadolint/Rule/DL3040Spec.hs
+++ b/test/Hadolint/Rule/DL3040Spec.hs
@@ -12,9 +12,14 @@ spec = do
   describe "DL3040 - `dnf clean all` missing after dnf command." $ do
     it "no ok without dnf clean all" $ do
       ruleCatches "DL3040" "RUN dnf install -y mariadb-10.4"
+      ruleCatches "DL3040" "RUN microdnf install -y mariadb-10.4"
       onBuildRuleCatches "DL3040" "RUN dnf install -y mariadb-10.4"
+      onBuildRuleCatches "DL3040" "RUN dnf install -y mariadb-10.4 && microdnf clean all"
+      onBuildRuleCatches "DL3040" "RUN microdnf install -y mariadb-10.4"
     it "ok with dnf clean all" $ do
       ruleCatchesNot "DL3040" "RUN dnf install -y mariadb-10.4 && dnf clean all"
+      ruleCatchesNot "DL3040" "RUN microdnf install -y mariadb-10.4 && microdnf clean all"
       ruleCatchesNot "DL3040" "RUN notdnf install mariadb"
       onBuildRuleCatchesNot "DL3040" "RUN dnf install -y mariadb-10.4 && dnf clean all"
+      onBuildRuleCatchesNot "DL3040" "RUN microdnf install -y mariadb-10.4 && microdnf clean all"
       onBuildRuleCatchesNot "DL3040" "RUN notdnf install mariadb"

--- a/test/Hadolint/Rule/DL3041Spec.hs
+++ b/test/Hadolint/Rule/DL3041Spec.hs
@@ -12,17 +12,23 @@ spec = do
   describe "DL3041 - Specify version with `dnf install -y <package>-<version>`" $ do
     it "not ok without dnf version pinning" $ do
       ruleCatches "DL3041" "RUN dnf install -y tomcat && dnf clean all"
+      ruleCatches "DL3041" "RUN microdnf install -y tomcat && microdnf clean all"
       onBuildRuleCatches "DL3041" "RUN dnf install -y tomcat && dnf clean all"
     it "ok with dnf version pinning" $ do
       ruleCatchesNot "DL3041" "RUN dnf install -y tomcat-9.0.1 && dnf clean all"
+      ruleCatchesNot "DL3041" "RUN microdnf install -y tomcat-9.0.1 && microdnf clean all"
       ruleCatchesNot "DL3041" "RUN notdnf install tomcat"
       onBuildRuleCatchesNot "DL3041" "RUN dnf install -y tomcat-9.0.1 && dnf clean all"
+      onBuildRuleCatchesNot "DL3041" "RUN microdnf install -y tomcat-9.0.1 && microdnf clean all"
       onBuildRuleCatchesNot "DL3041" "RUN notdnf install tomcat"
     it "not ok without dnf version pinning - moudles" $ do
       ruleCatches "DL3041" "RUN dnf module install -y tomcat && dnf clean all"
+      ruleCatches "DL3041" "RUN microdnf module install -y tomcat && microdnf clean all"
       onBuildRuleCatches "DL3041" "RUN dnf module install -y tomcat && dnf clean all"
     it "ok with dnf version pinning - modules" $ do
       ruleCatchesNot "DL3041" "RUN dnf module install -y tomcat:9 && dnf clean all"
+      ruleCatchesNot "DL3041" "RUN microdnf module install -y tomcat:9 && microdnf clean all"
       ruleCatchesNot "DL3041" "RUN notdnf module install tomcat"
       onBuildRuleCatchesNot "DL3041" "RUN dnf module install -y tomcat:9 && dnf clean all"
+      onBuildRuleCatchesNot "DL3041" "RUN microdnf module install -y tomcat:9 && microdnf clean all"
       onBuildRuleCatchesNot "DL3041" "RUN notdnf module install tomcat"


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

### What I did
Added so all rules concerning dnf (DL3038, DL3040, DL3041) works analogously for [microdnf](https://github.com/rpm-software-management/microdnf) as well, which closes #742. Note that I have not updated any documentation for the corresponding rule changes, since I wasn't sure if and how this should be done.

### How I did it
Added utility function `cmdsHaveArgs :: [Text.Text] -> [Text.Text] -> Command -> Bool` in `Shell.hs`, which is a generalized version of the function `cmdHasArgs`. The function has been used to check for the rules concerned in this PR.

### How to verify it
Test cases have been added so running the tests should be good enough. One can also run hadolint with the following file:

```Dockerfile
FROM centos:1.0    
    
RUN microdnf install test-1.0.0 && microdnf clean all # Missing -y flag    
RUN microdnf install -y test-1.0.0 # Missing microdnf clean all    
RUN microdnf install -y test && microdnf clean all # Missing version of package test    
RUN microdnf -y install test-1.0.0 && microdnf clean all # Passes all rules 
```

which outputs:

```bash
Dockerfile:3 DL3038 warning: Use the -y switch to avoid manual input `dnf install -y <package`
Dockerfile:4 DL3040 warning: `dnf clean all` missing after dnf command.
Dockerfile:5 DL3041 warning: Specify version with `dnf install -y <package>-<version>`.
```

Note that all warnings says `dnf` and not `microdnf`.