### PR TITLE
DL3026: Trusted registries wildcard domains

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,7 @@ ignored:
 trustedRegistries:
   - docker.io
   - my-company.com:5000
+  - "*.gcr.io"
 ```
 
 If you want to override the severity of specific rules, you can do that too:

--- a/test/Hadolint/Rule/DL3026Spec.hs
+++ b/test/Hadolint/Rule/DL3026Spec.hs
@@ -60,3 +60,29 @@ spec = do
       let ?config = def { allowedRegistries = ["random.com"] }
 
       ruleCatchesNot "DL3026" $ Text.unlines dockerFile
+
+    it "warn on non-allowed wildcard registry" $ do
+      let dockerFile =
+            [ "FROM x.com/debian"
+            ]
+      let ?config = def { allowedRegistries = ["*.random.com"] }
+
+      ruleCatches "DL3026" $ Text.unlines dockerFile
+
+    it "does not warn on allowed wildcard registries" $ do
+      let dockerFile =
+            [ "FROM foo.random.com/debian"
+            ]
+      let ?config = def { allowedRegistries = ["x.com", "*.random.com"] }
+
+      ruleCatchesNot "DL3026" $ Text.unlines dockerFile
+
+    it "does not warn on * registry" $ do
+      let dockerFile =
+            [ "FROM ubuntu:18.04 AS builder1",
+              "FROM zemanlx/ubuntu:18.04 AS builder2",
+              "FROM docker.io/zemanlx/ubuntu:18.04 AS builder3"
+            ]
+      let ?config = def { allowedRegistries = ["*"] }
+
+      ruleCatchesNot "DL3026" $ Text.unlines dockerFile


### PR DESCRIPTION

### What I did

Add support for trusted registry domain wildcards. Private registries like
Artifactory use sub-domain for Docker registries so this will allow users to
allow any repository under a single domain (`--trusted-registry "*.megacorp.com"`).

Refs #630

### How I did it

Modified DL3026 isAllowed to search the registries set for entries that are either prefixed or suffixed with "*". For those
entries the item is matched as a suffix or prefix respectively. 

This is my very first attempt at Haskell, so please let me know if there is a better way to go about it.

### How to verify it

Tests have been added to `DL3026Spec` tho validate the matching rules.
