### PR TITLE
Switch to non-rate limited ghcr.io hosted container for pre-commit

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -4,7 +4,7 @@
   description: Runs hadolint Docker image to lint Dockerfiles
   language: docker_image
   types: ["dockerfile"]
-  entry: hadolint/hadolint:v2.8.0 hadolint
+  entry: ghcr.io/hadolint/hadolint:v2.8.0 hadolint
 - id: hadolint
   name: Lint Dockerfiles
   description: Runs hadolint to lint Dockerfiles


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

### What I did

Did run hadolint-docker via pre-commit.

### How I did it

By using a public Github Action runner, which failed due to dockerhub rate limits.

### Solution

Updating the .pre-commit-hooks.yaml to use the ghcr.io hosted public hadolint image, which is not rate limited.
