### PR TITLE
Allow `--platform=$BUILDPLATFORM`

### DIFF
--- a/src/Hadolint/Rule/DL3029.hs
+++ b/src/Hadolint/Rule/DL3029.hs
@@ -10,6 +10,6 @@ rule = simpleRule code severity message check
     severity = DLWarningC
     message = "Do not use --platform flag with FROM"
 
-    check (From BaseImage {platform = Just p}) = p == ""
+    check (From BaseImage {platform = Just p}) = p == "$BUILDPLATFORM"
     check _ = True
 {-# INLINEABLE rule #-}

--- a/test/Hadolint/Rule/DL3029Spec.hs
+++ b/test/Hadolint/Rule/DL3029Spec.hs
@@ -12,3 +12,4 @@ spec = do
   describe "DL3029 - Do not use --platform flag with FROM." $ do
     it "explicit platform flag" $ ruleCatches "DL3029" "FROM --platform=linux debian:jessie"
     it "no platform flag" $ ruleCatchesNot "DL3029" "FROM debian:jessie"
+    it "allow platform $BUILDPLATFORM flag" $ ruleCatchesNot "DL3029" "FROM --platform=$BUILDPLATFORM debian:jessie"


### PR DESCRIPTION
closes #772

### What I did

Allowed the string `$BUILDPLATFORM` in the platform

### How I did it

Allowed it in the rule

### How to verify it

 - Added it to the unit test
 - Tested it with Dockerfile on my PC
