### PR TITLE
Remove duplicate extension

### DIFF
--- a/hadolint.cabal
+++ b/hadolint.cabal
@@ -134,7 +134,6 @@ library
       StrictData
       TemplateHaskell
       TupleSections
-      PatternSynonyms
   ghc-options: -Wall -Wcompat -Wincomplete-record-updates -Wincomplete-uni-patterns -Wredundant-constraints -optP-Wno-nonportable-include-path -flate-dmd-anal
   build-depends:
       Cabal
@@ -188,7 +187,6 @@ executable hadolint
       StrictData
       TemplateHaskell
       TupleSections
-      PatternSynonyms
   ghc-options: -Wall -Wcompat -Wincomplete-record-updates -Wincomplete-uni-patterns -Wredundant-constraints -optP-Wno-nonportable-include-path -flate-dmd-anal -O2 -threaded -rtsopts "-with-rtsopts=-N5 -A4m"
   build-depends:
       base >=4.8 && <5
@@ -300,7 +298,6 @@ test-suite hadolint-unit-tests
       StrictData
       TemplateHaskell
       TupleSections
-      PatternSynonyms
       ImplicitParams
       OverloadedLists
   ghc-options: -Wall -Wcompat -Wincomplete-record-updates -Wincomplete-uni-patterns -Wredundant-constraints -optP-Wno-nonportable-include-path -flate-dmd-anal

--- a/package.yaml
+++ b/package.yaml
@@ -43,7 +43,6 @@ default-extensions:
   - StrictData
   - TemplateHaskell
   - TupleSections
-  - PatternSynonyms
 
 library:
   source-dirs: src


### PR DESCRIPTION
### What I did
Removed the second redundant `PatternSynonyms` default extension in package.yaml.