### PR TITLE
config: respect NO_COLOR specification

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,7 +281,7 @@ docker run --rm -i -v /your/path/to/hadolint.yaml:/.config/hadolint.yaml ghcr.io
 In addition to config files, Hadolint can be configured with environment
 variables.
 ```bash
-NO_COLOR=1                               # Truthy value e.g. 1, true or yes
+NO_COLOR=1                               # Set or unset. See https://no-color.org
 HADOLINT_NOFAIL=1                        # Truthy value e.g. 1, true or yes
 HADOLINT_VERBOSE=1                       # Truthy value e.g. 1, true or yes
 HADOLINT_FORMAT=json                     # Output format (tty | json | checkstyle | codeclimate | gitlab_codeclimate | codacy | sarif )

--- a/src/Hadolint/Config/Environment.hs
+++ b/src/Hadolint/Config/Environment.hs
@@ -19,7 +19,7 @@ getConfigFromEnvironment :: IO PartialConfiguration
 getConfigFromEnvironment =
   PartialConfiguration
     <$> maybeTruthy "HADOLINT_NOFAIL"
-    <*> maybeTruthy "NO_COLOR"
+    <*> isSet "NO_COLOR"
     <*> maybeTruthy "HADOLINT_VERBOSE"
     <*> getFormat
     <*> getOverrideList "HADOLINT_OVERRIDE_ERROR"
@@ -33,6 +33,13 @@ getConfigFromEnvironment =
     <*> maybeTruthy "HADOLINT_DISABLE_IGNORE_PRAGMA"
     <*> getFailureThreshold
 
+
+isSet :: String -> IO (Maybe Bool)
+isSet name = do
+  e <- lookupEnv name
+  case e of
+    Just _ -> return $ Just True
+    Nothing -> return Nothing
 
 maybeTruthy :: String -> IO (Maybe Bool)
 maybeTruthy name = do


### PR DESCRIPTION
- Decide whether to print ANSI color codes or not based on the
  _presence_, not the value of the NO_COLOR environment variable

The specification provided by https://no-color.org regarding the
interpretation of the NO_COLOR environment variable specifically state
that the value does not matter, only whether it is set or not should
change program behavior.
Therefore, Hadolint should respect that and ignore the value.

### How to verify it
Assuming no other settings are in place, `NO_COLOR= hadolint Dockerfile` should result in uncolored output just like `NO_COLOR=true hadolint Dockerfile` and `NO_COLOR=n hadolint Dockerfile`. However `unset NO_COLOR; hadolint Dockerfile` should give colored output.