### PR TITLE
Add libtinfo-dev

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,6 +7,7 @@ RUN apt-get update \
     build-essential=12.3 \
     libffi-dev=3.2.* \
     libgmp-dev=2:6.1.* \
+    libtinfo-dev=6.* \
     zlib1g-dev=1:1.2.* \
     curl=7.52.* \
     ca-certificates=* \


### PR DESCRIPTION
Fixes https://github.com/hadolint/hadolint/issues/792

### What I did

Fixed the Docker build.

### How I did it

Installed `libtinfo-dev`. I pinned it at `6.*`. Not sure if that's wise, but it feels semver-safe.

### How to verify it

`docker build -f docker/Dockerfile .` now completes successfully.