### PR TITLE
DL3061: fix false positive on pragmas

### DIFF
--- a/src/Hadolint/Rule/DL3061.hs
+++ b/src/Hadolint/Rule/DL3061.hs
@@ -14,6 +14,7 @@ rule = customRule check (emptyState False)
 
     check _ st (From _) = st |> replaceWith True
     check _ st (Comment _) = st
+    check _ st (Pragma _) = st
     check _ st (Arg _ _) = st
     check line st _
       | state st = st

--- a/test/Hadolint/Rule/DL3061Spec.hs
+++ b/test/Hadolint/Rule/DL3061Spec.hs
@@ -23,5 +23,11 @@ spec = do
       ruleCatchesNot "DL3061" "ARG A=B\nFROM foo\nLABEL foo=bar"
       onBuildRuleCatchesNot "DL3061" "ARG A=B\nFROM foo\nLABEL foo=bar"
 
+    it "don't warn: pragma before FROM" $ do
+      ruleCatchesNot "DL3061" "# syntax = docker/dockerfile:1.0-experimental\n\
+                              \FROM node:16-alpine3.13"
+      onBuildRuleCatchesNot "DL3061" "# syntax = docker/dockerfile:1.0-experimental\n\
+                                     \FROM node:16-alpine3.13"
+
     it "don't warn: FROM then ARG then RUN" $ do
       ruleCatchesNot "DL3061" "FROM foo\nARG A=B\nRUN echo bla"


### PR DESCRIPTION
- Fix false positive error DL3061 when encountering a pragma before a
  `FROM` instruction.

In particular `# syntax = docker/dockerfile...` but also `# shell = ...`
pragmas can appear before the first `FROM` instruction without error.

fixes: #795

### How to verify it
This should no longer produce false positive error DL3061 messages:
```Dockerfile
# syntax = docker/dockerfile:1.0-experimental

FROM node:16-alpine3.13 AS builder
WORKDIR /app
COPY ./package*.json ./
```
Thanks to @aaronfi-procore and @subodhdharma for reporting this issue.