### PR TITLE
processing: apply onbuild rule wrapper per rule

### DIFF
--- a/src/Hadolint/Process.hs
+++ b/src/Hadolint/Process.hs
@@ -103,22 +103,10 @@ analyze ::
 analyze config =
   AnalisisResult
     <$> Hadolint.Pragma.ignored
-    <*> Foldl.premap parseShell (failures config <> onBuildFailures config)
+    <*> Foldl.premap parseShell (failures config)
 
 parseShell :: InstructionPos Text.Text -> InstructionPos Shell.ParsedShell
 parseShell = fmap Shell.parseShell
-
-onBuildFailures :: Configuration -> Rule Shell.ParsedShell
-onBuildFailures config =
-  Foldl.prefilter
-    isOnBuild
-    (Foldl.premap unwrapOnbuild (failures config))
-  where
-    isOnBuild InstructionPos {instruction = OnBuild {}} = True
-    isOnBuild _ = False
-
-    unwrapOnbuild inst@InstructionPos {instruction = OnBuild i} = inst {instruction = i}
-    unwrapOnbuild inst = inst
 
 failures :: Configuration -> Rule Shell.ParsedShell
 failures Configuration {allowedRegistries, labelSchema, strictLabels} =

--- a/src/Hadolint/Rule.hs
+++ b/src/Hadolint/Rule.hs
@@ -266,3 +266,16 @@ dropQuotes = Text.dropAround quotes
     quotes '\"' = True
     quotes '\'' = True
     quotes _ = False
+
+
+-- | Unwraps ONBUILD instructions and applies the rule to the content
+--
+onbuild :: Rule args -> Rule args
+onbuild rule =
+  Foldl.prefilter isOnbuild (Foldl.premap unwrapOnbuild (rule))
+  where
+    isOnbuild InstructionPos {instruction = OnBuild {}} = True
+    isOnbuild _ = False
+
+    unwrapOnbuild inst@InstructionPos {instruction = OnBuild i} = inst {instruction = i}
+    unwrapOnbuild inst = inst

--- a/src/Hadolint/Rule/DL1001.hs
+++ b/src/Hadolint/Rule/DL1001.hs
@@ -5,6 +5,7 @@ import Hadolint.Rule
 import Hadolint.Shell (ParsedShell)
 import Language.Docker.Syntax
 
+
 rule :: Rule ParsedShell
 rule = simpleRule code severity message check
   where
@@ -17,3 +18,4 @@ rule = simpleRule code severity message check
         Just _ -> False
         _ -> True
     check _ = True
+{-# INLINEABLE rule #-}

--- a/src/Hadolint/Rule/DL3001.hs
+++ b/src/Hadolint/Rule/DL3001.hs
@@ -5,8 +5,13 @@ import Hadolint.Rule
 import qualified Hadolint.Shell as Shell
 import Language.Docker.Syntax (Instruction (..), RunArgs (..))
 
+
 rule :: Rule Shell.ParsedShell
-rule = simpleRule code severity message check
+rule = dl3001 <> onbuild dl3001
+{-# INLINEABLE rule #-}
+
+dl3001 :: Rule Shell.ParsedShell
+dl3001 = simpleRule code severity message check
   where
     code = "DL3001"
     severity = DLInfoC
@@ -30,4 +35,4 @@ rule = simpleRule code severity message check
           "top",
           "vim"
         ]
-{-# INLINEABLE rule #-}
+{-# INLINEABLE dl3001 #-}

--- a/src/Hadolint/Rule/DL3004.hs
+++ b/src/Hadolint/Rule/DL3004.hs
@@ -4,14 +4,19 @@ import Hadolint.Rule
 import Hadolint.Shell (ParsedShell, usingProgram)
 import Language.Docker.Syntax (Instruction (..), RunArgs (..))
 
+
 rule :: Rule ParsedShell
-rule = simpleRule code severity message check
+rule = dl3004 <> onbuild dl3004
+{-# INLINEABLE rule #-}
+
+dl3004 :: Rule ParsedShell
+dl3004 = simpleRule code severity message check
   where
     code = "DL3004"
     severity = DLErrorC
     message =
-      "Do not use sudo as it leads to unpredictable behavior. Use a tool like gosu to enforce \
-      \root"
+      "Do not use sudo as it leads to unpredictable behavior. Use a tool like\
+      \ gosu to enforce root"
     check (Run (RunArgs args _)) = foldArguments (not . usingProgram "sudo") args
     check _ = True
-{-# INLINEABLE rule #-}
+{-# INLINEABLE dl3004 #-}

--- a/src/Hadolint/Rule/DL3005.hs
+++ b/src/Hadolint/Rule/DL3005.hs
@@ -5,8 +5,13 @@ import Hadolint.Shell (ParsedShell)
 import qualified Hadolint.Shell as Shell
 import Language.Docker.Syntax (Instruction (..), RunArgs (..))
 
+
 rule :: Rule ParsedShell
-rule = simpleRule code severity message check
+rule = dl3005 <> onbuild dl3005
+{-# INLINEABLE rule #-}
+
+dl3005 :: Rule ParsedShell
+dl3005 = simpleRule code severity message check
   where
     code = "DL3005"
     severity = DLErrorC
@@ -14,4 +19,4 @@ rule = simpleRule code severity message check
     check (Run (RunArgs args _)) =
       foldArguments (Shell.noCommands (Shell.cmdHasArgs "apt-get" ["dist-upgrade"])) args
     check _ = True
-{-# INLINEABLE rule #-}
+{-# INLINEABLE dl3005 #-}

--- a/src/Hadolint/Rule/DL3008.hs
+++ b/src/Hadolint/Rule/DL3008.hs
@@ -6,8 +6,13 @@ import Hadolint.Shell (ParsedShell)
 import qualified Hadolint.Shell as Shell
 import Language.Docker.Syntax
 
+
 rule :: Rule ParsedShell
-rule = simpleRule code severity message check
+rule = dl3008 <> onbuild dl3008
+{-# INLINEABLE rule #-}
+
+dl3008 :: Rule ParsedShell
+dl3008 = simpleRule code severity message check
   where
     code = "DL3008"
     severity = DLWarningC
@@ -17,7 +22,7 @@ rule = simpleRule code severity message check
     check (Run (RunArgs args _)) = foldArguments (all versionFixed . aptGetPackages) args
     check _ = True
     versionFixed package = "=" `Text.isInfixOf` package || ("/" `Text.isInfixOf` package || ".deb" `Text.isSuffixOf` package)
-{-# INLINEABLE rule #-}
+{-# INLINEABLE dl3008 #-}
 
 aptGetPackages :: ParsedShell -> [Text.Text]
 aptGetPackages args =

--- a/src/Hadolint/Rule/DL3009.hs
+++ b/src/Hadolint/Rule/DL3009.hs
@@ -20,7 +20,11 @@ data Acc
 
 
 rule :: Rule Shell.ParsedShell
-rule = veryCustomRule check (emptyState Empty) markFailures
+rule = dl3009 <> onbuild dl3009
+{-# INLINEABLE rule #-}
+
+dl3009 :: Rule Shell.ParsedShell
+dl3009 = veryCustomRule check (emptyState Empty) markFailures
   where
     code = "DL3009"
     severity = DLInfoC
@@ -49,7 +53,7 @@ rule = veryCustomRule check (emptyState Empty) markFailures
             -- If the same alias is used in another stage, fail
             pure CheckFailure {..}
           | otherwise = mempty
-{-# INLINEABLE rule #-}
+{-# INLINEABLE dl3009 #-}
 
 rememberStage :: Linenumber -> BaseImage -> Acc -> Acc
 rememberStage line from@BaseImage {image = Image _ als} (Acc _ _ stages o) = Acc from True (Map.insert als line stages) o

--- a/src/Hadolint/Rule/DL3013.hs
+++ b/src/Hadolint/Rule/DL3013.hs
@@ -7,8 +7,13 @@ import Hadolint.Shell (ParsedShell)
 import qualified Hadolint.Shell as Shell
 import Language.Docker.Syntax
 
+
 rule :: Rule ParsedShell
-rule = simpleRule code severity message check
+rule = dl3013 <> onbuild dl3013
+{-# INLINEABLE rule #-}
+
+dl3013 :: Rule ParsedShell
+dl3013 = simpleRule code severity message check
   where
     code = "DL3013"
     severity = DLWarningC
@@ -45,7 +50,7 @@ rule = simpleRule code severity message check
     hasVersionSymbol package = or [s `Text.isInfixOf` package | s <- versionSymbols]
     localPackageFileExtensions = [".whl", ".tar.gz"]
     isLocalPackage package = or [s `Text.isSuffixOf` package | s <- localPackageFileExtensions]
-{-# INLINEABLE rule #-}
+{-# INLINEABLE dl3013 #-}
 
 packages :: Shell.Command -> [Text.Text]
 packages cmd =

--- a/src/Hadolint/Rule/DL3014.hs
+++ b/src/Hadolint/Rule/DL3014.hs
@@ -5,8 +5,13 @@ import Hadolint.Shell (ParsedShell)
 import qualified Hadolint.Shell as Shell
 import Language.Docker.Syntax
 
+
 rule :: Rule ParsedShell
-rule = simpleRule code severity message check
+rule = dl3014 <> onbuild dl3014
+{-# INLINEABLE rule #-}
+
+dl3014 :: Rule ParsedShell
+dl3014 = simpleRule code severity message check
   where
     code = "DL3014"
     severity = DLWarningC
@@ -18,4 +23,4 @@ rule = simpleRule code severity message check
     forgotAptYesOption cmd = isAptGetInstall cmd && not (hasYesOption cmd)
     isAptGetInstall = Shell.cmdHasArgs "apt-get" ["install"]
     hasYesOption = Shell.hasAnyFlag ["y", "yes", "q", "assume-yes"]
-{-# INLINEABLE rule #-}
+{-# INLINEABLE dl3014 #-}

--- a/src/Hadolint/Rule/DL3015.hs
+++ b/src/Hadolint/Rule/DL3015.hs
@@ -5,8 +5,13 @@ import Hadolint.Shell (ParsedShell)
 import qualified Hadolint.Shell as Shell
 import Language.Docker.Syntax
 
+
 rule :: Rule ParsedShell
-rule = simpleRule code severity message check
+rule = dl3015 <> onbuild dl3015
+{-# INLINEABLE rule #-}
+
+dl3015 :: Rule ParsedShell
+dl3015 = simpleRule code severity message check
   where
     code = "DL3015"
     severity = DLInfoC
@@ -20,4 +25,4 @@ rule = simpleRule code severity message check
     disablesRecommendOption cmd =
       Shell.hasFlag "no-install-recommends" cmd
         || Shell.hasArg "APT::Install-Recommends=false" cmd
-{-# INLINEABLE rule #-}
+{-# INLINEABLE dl3015 #-}

--- a/src/Hadolint/Rule/DL3016.hs
+++ b/src/Hadolint/Rule/DL3016.hs
@@ -7,6 +7,11 @@ import Hadolint.Shell (ParsedShell)
 import qualified Hadolint.Shell as Shell
 import Language.Docker.Syntax (Instruction (..), RunArgs (..))
 
+
+rule :: Rule ParsedShell
+rule = dl3016 <> onbuild dl3016
+{-# INLINEABLE rule #-}
+
 -- | Rule for pinning NPM packages to version, tag, or commit
 --  supported formats by Hadolint
 --    npm install (with no args, in package dir)
@@ -15,8 +20,8 @@ import Language.Docker.Syntax (Instruction (..), RunArgs (..))
 --    npm install [<@scope>/]<name>@<version>
 --    npm install git[+http|+https]://<git-host>/<git-user>/<repo-name>[#<commit>|#semver:<semver>]
 --    npm install git+ssh://<git-host>:<git-user>/<repo-name>[#<commit>|#semver:<semver>]
-rule :: Rule ParsedShell
-rule = simpleRule code severity message check
+dl3016 :: Rule ParsedShell
+dl3016 = simpleRule code severity message check
   where
     code = "DL3016"
     severity = DLWarningC
@@ -26,7 +31,7 @@ rule = simpleRule code severity message check
 
     check (Run (RunArgs args _)) = foldArguments (Shell.noCommands forgotToPinVersion) args
     check _ = True
-{-# INLINEABLE rule #-}
+{-# INLINEABLE dl3016 #-}
 
 
 forgotToPinVersion :: Shell.Command -> Bool

--- a/src/Hadolint/Rule/DL3018.hs
+++ b/src/Hadolint/Rule/DL3018.hs
@@ -6,8 +6,13 @@ import Hadolint.Shell (ParsedShell)
 import qualified Hadolint.Shell as Shell
 import Language.Docker.Syntax
 
+
 rule :: Rule ParsedShell
-rule = simpleRule code severity message check
+rule = dl3018 <> onbuild dl3018
+{-# INLINEABLE rule #-}
+
+dl3018 :: Rule ParsedShell
+dl3018 = simpleRule code severity message check
   where
     code = "DL3018"
     severity = DLWarningC
@@ -26,7 +31,7 @@ rule = simpleRule code severity message check
     check _ = True
     versionFixed package = "=" `Text.isInfixOf` package
     packageFile package = ".apk" `Text.isSuffixOf` package
-{-# INLINEABLE rule #-}
+{-# INLINEABLE dl3018 #-}
 
 apkAddPackages :: ParsedShell -> [Text.Text]
 apkAddPackages args =

--- a/src/Hadolint/Rule/DL3019.hs
+++ b/src/Hadolint/Rule/DL3019.hs
@@ -7,8 +7,13 @@ import qualified Data.Set as Set
 import qualified Data.Text as Text
 import qualified Hadolint.Shell as Shell
 
+
 rule :: Rule ParsedShell
-rule = simpleRule code severity message check
+rule = dl3019 <> onbuild dl3019
+{-# INLINEABLE rule #-}
+
+dl3019 :: Rule ParsedShell
+dl3019 = simpleRule code severity message check
   where
     code = "DL3019"
     severity = DLInfoC
@@ -18,7 +23,7 @@ rule = simpleRule code severity message check
     check (Run (RunArgs args flags)) = hasCacheMount flags
       || foldArguments (Shell.noCommands forgotCacheOption) args
     check _ = True
-{-# INLINEABLE rule #-}
+{-# INLINEABLE dl3019 #-}
 
 hasCacheMount :: RunFlags -> Bool
 hasCacheMount RunFlags { mount } =

--- a/src/Hadolint/Rule/DL3022.hs
+++ b/src/Hadolint/Rule/DL3022.hs
@@ -9,7 +9,7 @@ rule = customRule check (emptyState Set.empty)
   where
     code = "DL3022"
     severity = DLWarningC
-    message = "COPY --from should reference a previously defined FROM alias"
+    message = "`COPY --from` should reference a previously defined `FROM` alias"
 
     check _ st (From BaseImage {alias = Just (ImageAlias als)}) = st |> modify (Set.insert als)
     check line st (Copy (CopyArgs _ _ _ _ (CopySource s)))

--- a/src/Hadolint/Rule/DL3023.hs
+++ b/src/Hadolint/Rule/DL3023.hs
@@ -8,7 +8,7 @@ rule = customRule check (emptyState Nothing)
   where
     code = "DL3023"
     severity = DLErrorC
-    message = "COPY --from should reference a previously defined FROM alias"
+    message = "`COPY --from` cannot reference its own `FROM` alias"
 
     check _ st f@(From _) = st |> replaceWith (Just f) -- Remember the last FROM instruction found
     check line st@(State _ (Just fromInstr)) (Copy (CopyArgs _ _ _ _ (CopySource stageName)))

--- a/src/Hadolint/Rule/DL3027.hs
+++ b/src/Hadolint/Rule/DL3027.hs
@@ -1,18 +1,22 @@
 module Hadolint.Rule.DL3027 (rule) where
 
 import Hadolint.Rule
-import Hadolint.Shell (ParsedShell)
-import qualified Hadolint.Shell as Shell
+import Hadolint.Shell (ParsedShell, usingProgram)
 import Language.Docker.Syntax
 
+
 rule :: Rule ParsedShell
-rule = simpleRule code severity message check
+rule = dl3027 <> onbuild dl3027
+{-# INLINEABLE rule #-}
+
+dl3027 :: Rule ParsedShell
+dl3027 = simpleRule code severity message check
   where
     code = "DL3027"
     severity = DLWarningC
-    message =
-      "Do not use apt as it is meant to be a end-user tool, use apt-get or apt-cache instead"
+    message = "Do not use apt as it is meant to be a end-user tool, use apt-get\
+              \ or apt-cache instead"
 
-    check (Run (RunArgs args _)) = foldArguments (not . Shell.usingProgram "apt") args
+    check (Run (RunArgs args _)) = foldArguments (not . usingProgram "apt") args
     check _ = True
-{-# INLINEABLE rule #-}
+{-# INLINEABLE dl3027 #-}

--- a/src/Hadolint/Rule/DL3028.hs
+++ b/src/Hadolint/Rule/DL3028.hs
@@ -6,8 +6,13 @@ import Hadolint.Shell (ParsedShell)
 import qualified Hadolint.Shell as Shell
 import Language.Docker.Syntax (Instruction (..), RunArgs (..))
 
+
 rule :: Rule ParsedShell
-rule = simpleRule code severity message check
+rule = dl3028 <> onbuild dl3028
+{-# INLINEABLE rule #-}
+
+dl3028 :: Rule ParsedShell
+dl3028 = simpleRule code severity message check
   where
     code = "DL3028"
     severity = DLWarningC
@@ -19,7 +24,7 @@ rule = simpleRule code severity message check
     check _ = True
 
     versionFixed package = ":" `Text.isInfixOf` package
-{-# INLINEABLE rule #-}
+{-# INLINEABLE dl3028 #-}
 
 gems :: Shell.ParsedShell -> [Text.Text]
 gems shell =

--- a/src/Hadolint/Rule/DL3030.hs
+++ b/src/Hadolint/Rule/DL3030.hs
@@ -4,8 +4,13 @@ import Hadolint.Rule
 import qualified Hadolint.Shell as Shell
 import Language.Docker.Syntax
 
+
 rule :: Rule Shell.ParsedShell
-rule = simpleRule code severity message check
+rule = dl3030 <> onbuild dl3030
+{-# INLINEABLE rule #-}
+
+dl3030 :: Rule Shell.ParsedShell
+dl3030 = simpleRule code severity message check
   where
     code = "DL3030"
     severity = DLWarningC
@@ -17,4 +22,4 @@ rule = simpleRule code severity message check
     forgotYumYesOption cmd = isYumInstall cmd && not (hasYesOption cmd)
     isYumInstall = Shell.cmdHasArgs "yum" ["install", "groupinstall", "localinstall"]
     hasYesOption = Shell.hasAnyFlag ["y", "assumeyes"]
-{-# INLINEABLE rule #-}
+{-# INLINEABLE dl3030 #-}

--- a/src/Hadolint/Rule/DL3032.hs
+++ b/src/Hadolint/Rule/DL3032.hs
@@ -4,8 +4,13 @@ import Hadolint.Rule
 import qualified Hadolint.Shell as Shell
 import Language.Docker.Syntax
 
+
 rule :: Rule Shell.ParsedShell
-rule = simpleRule code severity message check
+rule = dl3032 <> onbuild dl3032
+{-# INLINEABLE rule #-}
+
+dl3032 :: Rule Shell.ParsedShell
+dl3032 = simpleRule code severity message check
   where
     code = "DL3032"
     severity = DLWarningC
@@ -20,4 +25,4 @@ rule = simpleRule code severity message check
 
     yumInstall = Shell.cmdHasArgs "yum" ["install"]
     yumClean = Shell.cmdHasArgs "yum" ["clean", "all"]
-{-# INLINEABLE rule #-}
+{-# INLINEABLE dl3032 #-}

--- a/src/Hadolint/Rule/DL3033.hs
+++ b/src/Hadolint/Rule/DL3033.hs
@@ -5,8 +5,13 @@ import Hadolint.Rule
 import qualified Hadolint.Shell as Shell
 import Language.Docker.Syntax
 
+
 rule :: Rule Shell.ParsedShell
-rule = simpleRule code severity message check
+rule = dl3033 <> onbuild dl3033
+{-# INLINEABLE rule #-}
+
+dl3033 :: Rule Shell.ParsedShell
+dl3033 = simpleRule code severity message check
   where
     code = "DL3033"
     severity = DLWarningC
@@ -16,7 +21,7 @@ rule = simpleRule code severity message check
       foldArguments (all packageVersionFixed . yumPackages) args
         && foldArguments (all moduleVersionFixed . yumModules) args
     check _ = True
-{-# INLINEABLE rule #-}
+{-# INLINEABLE dl3033 #-}
 
 yumPackages :: Shell.ParsedShell -> [Text.Text]
 yumPackages args =

--- a/src/Hadolint/Rule/DL3034.hs
+++ b/src/Hadolint/Rule/DL3034.hs
@@ -4,8 +4,13 @@ import Hadolint.Rule
 import qualified Hadolint.Shell as Shell
 import Language.Docker.Syntax
 
+
 rule :: Rule Shell.ParsedShell
-rule = simpleRule code severity message check
+rule = dl3034 <> onbuild dl3034
+{-# INLINEABLE rule #-}
+
+dl3034 :: Rule Shell.ParsedShell
+dl3034 = simpleRule code severity message check
   where
     code = "DL3034"
     severity = DLWarningC
@@ -27,4 +32,4 @@ rule = simpleRule code severity message check
           "patch"
         ]
     hasYesOption = Shell.hasAnyFlag ["non-interactive", "n", "no-confirm", "y"]
-{-# INLINEABLE rule #-}
+{-# INLINEABLE dl3034 #-}

--- a/src/Hadolint/Rule/DL3035.hs
+++ b/src/Hadolint/Rule/DL3035.hs
@@ -4,8 +4,13 @@ import Hadolint.Rule
 import qualified Hadolint.Shell as Shell
 import Language.Docker.Syntax
 
+
 rule :: Rule Shell.ParsedShell
-rule = simpleRule code severity message check
+rule = dl3035 <> onbuild dl3035
+{-# INLINEABLE rule #-}
+
+dl3035 :: Rule Shell.ParsedShell
+dl3035 = simpleRule code severity message check
   where
     code = "DL3035"
     severity = DLWarningC
@@ -23,4 +28,4 @@ rule = simpleRule code severity message check
         )
         args
     check _ = True
-{-# INLINEABLE rule #-}
+{-# INLINEABLE dl3035 #-}

--- a/src/Hadolint/Rule/DL3036.hs
+++ b/src/Hadolint/Rule/DL3036.hs
@@ -4,8 +4,13 @@ import Hadolint.Rule
 import qualified Hadolint.Shell as Shell
 import Language.Docker.Syntax
 
+
 rule :: Rule Shell.ParsedShell
-rule = simpleRule code severity message check
+rule = dl3036 <> onbuild dl3036
+{-# INLINEABLE rule #-}
+
+dl3036 :: Rule Shell.ParsedShell
+dl3036 = simpleRule code severity message check
   where
     code = "DL3036"
     severity = DLWarningC
@@ -20,4 +25,4 @@ rule = simpleRule code severity message check
 
     zypperInstall = Shell.cmdHasArgs "zypper" ["install", "in"]
     zypperClean = Shell.cmdHasArgs "zypper" ["clean", "cc"]
-{-# INLINEABLE rule #-}
+{-# INLINEABLE dl3036 #-}

--- a/src/Hadolint/Rule/DL3037.hs
+++ b/src/Hadolint/Rule/DL3037.hs
@@ -5,8 +5,13 @@ import Hadolint.Rule
 import qualified Hadolint.Shell as Shell
 import Language.Docker.Syntax
 
+
 rule :: Rule Shell.ParsedShell
-rule = simpleRule code severity message check
+rule = dl3037 <> onbuild dl3037
+{-# INLINEABLE rule #-}
+
+dl3037 :: Rule Shell.ParsedShell
+dl3037 = simpleRule code severity message check
   where
     code = "DL3037"
     severity = DLWarningC
@@ -22,7 +27,7 @@ rule = simpleRule code severity message check
         || "<=" `Text.isInfixOf` package
         || "<" `Text.isInfixOf` package
         || ".rpm" `Text.isSuffixOf` package
-{-# INLINEABLE rule #-}
+{-# INLINEABLE dl3037 #-}
 
 zypperPackages :: Shell.ParsedShell -> [Text.Text]
 zypperPackages args =

--- a/src/Hadolint/Rule/DL3038.hs
+++ b/src/Hadolint/Rule/DL3038.hs
@@ -4,8 +4,13 @@ import Hadolint.Rule
 import qualified Hadolint.Shell as Shell
 import Language.Docker.Syntax
 
+
 rule :: Rule Shell.ParsedShell
-rule = simpleRule code severity message check
+rule = dl3038 <> onbuild dl3038
+{-# INLINEABLE rule #-}
+
+dl3038 :: Rule Shell.ParsedShell
+dl3038 = simpleRule code severity message check
   where
     code = "DL3038"
     severity = DLWarningC
@@ -18,4 +23,4 @@ rule = simpleRule code severity message check
     isDnfInstall = Shell.cmdsHaveArgs dnfCmds ["install", "groupinstall", "localinstall"]
     hasYesOption = Shell.hasAnyFlag ["y", "assumeyes"]
     dnfCmds = ["dnf", "microdnf"]
-{-# INLINEABLE rule #-}
+{-# INLINEABLE dl3038 #-}

--- a/src/Hadolint/Rule/DL3040.hs
+++ b/src/Hadolint/Rule/DL3040.hs
@@ -4,8 +4,13 @@ import Hadolint.Rule
 import qualified Hadolint.Shell as Shell
 import Language.Docker.Syntax
 
+
 rule :: Rule Shell.ParsedShell
-rule = simpleRule code severity message check
+rule = dl3040 <> onbuild dl3040
+{-# INLINEABLE rule #-}
+
+dl3040 :: Rule Shell.ParsedShell
+dl3040 = simpleRule code severity message check
   where
     code = "DL3040"
     severity = DLWarningC
@@ -23,4 +28,4 @@ rule = simpleRule code severity message check
     dnfInstall cmdName = Shell.cmdHasArgs cmdName ["install"]
     dnfClean cmdName = Shell.cmdHasArgs cmdName ["clean", "all"]
     dnfCmds = ["dnf", "microdnf"]
-{-# INLINEABLE rule #-}
+{-# INLINEABLE dl3040 #-}

--- a/src/Hadolint/Rule/DL3041.hs
+++ b/src/Hadolint/Rule/DL3041.hs
@@ -5,8 +5,13 @@ import Hadolint.Rule
 import qualified Hadolint.Shell as Shell
 import Language.Docker.Syntax
 
+
 rule :: Rule Shell.ParsedShell
-rule = simpleRule code severity message check
+rule = dl3041 <> onbuild dl3041
+{-# INLINEABLE rule #-}
+
+dl3041 :: Rule Shell.ParsedShell
+dl3041 = simpleRule code severity message check
   where
     code = "DL3041"
     severity = DLWarningC
@@ -16,7 +21,7 @@ rule = simpleRule code severity message check
       foldArguments (all packageVersionFixed . dnfPackages) args
         && foldArguments (all moduleVersionFixed . dnfModules) args
     check _ = True
-{-# INLINEABLE rule #-}
+{-# INLINEABLE dl3041 #-}
 
 dnfCmds :: [Text.Text]
 dnfCmds = ["dnf", "microdnf"]

--- a/src/Hadolint/Rule/DL3042.hs
+++ b/src/Hadolint/Rule/DL3042.hs
@@ -26,7 +26,11 @@ data Acc
 
 
 rule :: Rule Shell.ParsedShell
-rule = customRule check (emptyState Empty)
+rule = dl3042 <> onbuild dl3042
+{-# INLINEABLE rule #-}
+
+dl3042 :: Rule Shell.ParsedShell
+dl3042 = customRule check (emptyState Empty)
   where
     code = "DL3042"
     severity = DLWarningC
@@ -40,7 +44,7 @@ rule = customRule check (emptyState Empty)
       | foldArguments (Shell.noCommands forgotNoCacheDir) args = st
       | otherwise = st |> addFail CheckFailure {..}
     check _ st _ = st
-{-# INLINEABLE rule #-}
+{-# INLINEABLE dl3042 #-}
 
 forgotNoCacheDir :: Shell.Command -> Bool
 forgotNoCacheDir cmd =  Shell.isPipInstall cmd

--- a/src/Hadolint/Rule/DL3046.hs
+++ b/src/Hadolint/Rule/DL3046.hs
@@ -6,8 +6,13 @@ import Hadolint.Shell (ParsedShell)
 import qualified Hadolint.Shell as Shell
 import Language.Docker.Syntax (Instruction (..), RunArgs (..))
 
+
 rule :: Rule ParsedShell
-rule = simpleRule code severity message check
+rule = dl3046 <> onbuild dl3046
+{-# INLINEABLE rule #-}
+
+dl3046 :: Rule ParsedShell
+dl3046 = simpleRule code severity message check
   where
     code = "DL3046"
     severity = DLWarningC
@@ -21,4 +26,4 @@ rule = simpleRule code severity message check
     hasLFlag = Shell.hasAnyFlag ["l", "no-log-init"]
     hasUFlag = Shell.hasAnyFlag ["u", "uid"]
     hasLongUID cmd = any ((> 5) . Text.length) (Shell.getFlagArg "u" cmd)
-{-# INLINEABLE rule #-}
+{-# INLINEABLE dl3046 #-}

--- a/src/Hadolint/Rule/DL3047.hs
+++ b/src/Hadolint/Rule/DL3047.hs
@@ -5,8 +5,13 @@ import Hadolint.Shell (ParsedShell)
 import qualified Hadolint.Shell as Shell
 import Language.Docker.Syntax
 
+
 rule :: Rule ParsedShell
-rule = simpleRule code severity message check
+rule = dl3047 <> onbuild dl3047
+{-# INLINEABLE rule #-}
+
+dl3047 :: Rule ParsedShell
+dl3047 = simpleRule code severity message check
   where
     code = "DL3047"
     severity = DLInfoC
@@ -33,4 +38,4 @@ rule = simpleRule code severity message check
     hasNoVerboseFlag cmd =
       Shell.hasAnyFlag ["no-verbose"] cmd
         || Shell.cmdHasArgs "wget" ["-nv"] cmd
-{-# INLINEABLE rule #-}
+{-# INLINEABLE dl3047 #-}

--- a/src/Hadolint/Rule/DL3060.hs
+++ b/src/Hadolint/Rule/DL3060.hs
@@ -16,8 +16,13 @@ data Acc
   | Empty
   deriving (Show)
 
+
 rule :: Rule Shell.ParsedShell
-rule = veryCustomRule check (emptyState Empty) markFailures
+rule = dl3060 <> onbuild dl3060
+{-# INLINEABLE rule #-}
+
+dl3060 :: Rule Shell.ParsedShell
+dl3060 = veryCustomRule check (emptyState Empty) markFailures
   where
     code = "DL3060"
     severity = DLInfoC
@@ -42,7 +47,7 @@ rule = veryCustomRule check (emptyState Empty) markFailures
           | BaseImage {alias = Just (ImageAlias als)} <- from,
             Just _ <- Map.lookup als active = pure CheckFailure {..}
           | otherwise = mempty
-{-# INLINEABLE rule #-}
+{-# INLINEABLE dl3060 #-}
 
 rememberStage :: Linenumber -> BaseImage -> Acc -> Acc
 rememberStage line stage@BaseImage {image = Image _ als} Empty =

--- a/src/Hadolint/Rule/DL4001.hs
+++ b/src/Hadolint/Rule/DL4001.hs
@@ -5,8 +5,12 @@ import Hadolint.Rule
 import qualified Hadolint.Shell as Shell
 import Language.Docker.Syntax (Instruction (..), RunArgs (..))
 
+
 rule :: Rule Shell.ParsedShell
-rule = customRule check (emptyState Set.empty)
+rule = dl4001 <> onbuild dl4001
+
+dl4001 :: Rule Shell.ParsedShell
+dl4001 = customRule check (emptyState Set.empty)
   where
     code = "DL4001"
     severity = DLWarningC

--- a/src/Hadolint/Rule/DL4005.hs
+++ b/src/Hadolint/Rule/DL4005.hs
@@ -5,8 +5,12 @@ import Hadolint.Shell (ParsedShell)
 import qualified Hadolint.Shell as Shell
 import Language.Docker.Syntax
 
+
 rule :: Rule ParsedShell
-rule = simpleRule code severity message check
+rule = dl4005 <> onbuild dl4005
+
+dl4005 :: Rule ParsedShell
+dl4005 = simpleRule code severity message check
   where
     code = "DL4005"
     severity = DLWarningC

--- a/src/Hadolint/Rule/Shellcheck.hs
+++ b/src/Hadolint/Rule/Shellcheck.hs
@@ -19,7 +19,11 @@ data Acc
 
 
 rule :: Rule Shell.ParsedShell
-rule = customRule check (emptyState Empty)
+rule = scrule <> onbuild scrule
+{-# INLINEABLE rule #-}
+
+scrule :: Rule Shell.ParsedShell
+scrule = customRule check (emptyState Empty)
   where
     check _ st (From _) = st |> modify newStage
     check _ st (Arg name _) = st |> modify (addVars [name])
@@ -40,7 +44,7 @@ rule = customRule check (emptyState Empty)
               | c <- Shell.shellcheck options script
             ]
     check _ st _ = st
-{-# INLINEABLE rule #-}
+{-# INLINEABLE scrule #-}
 
 newStage :: Acc -> Acc
 newStage Empty =

--- a/test/Hadolint/Rule/DL3047Spec.hs
+++ b/test/Hadolint/Rule/DL3047Spec.hs
@@ -16,58 +16,68 @@ spec = do
             [ "FROM node as foo",
               "RUN wget my.xyz"
             ]
-       in ruleCatches "DL3047" $ Text.unlines dockerFile
+       in do ruleCatches "DL3047" $ Text.unlines dockerFile
+             onBuildRuleCatches "DL3047" $ Text.unlines dockerFile
     it "does not warn when running with --progress option" $
       let dockerFile =
             [ "FROM node as foo",
               "RUN wget --progress=dot:giga my.xyz"
             ]
-       in ruleCatchesNot "DL3047" $ Text.unlines dockerFile
+       in do ruleCatchesNot "DL3047" $ Text.unlines dockerFile
+             onBuildRuleCatchesNot "DL3047" $ Text.unlines dockerFile
     it "does not warn when running with -q (quiet short option) and without --progress option" $
       let dockerFile =
             [ "FROM node as foo",
               "RUN wget -q my.xyz"
             ]
-       in ruleCatchesNot "DL3047" $ Text.unlines dockerFile
+       in do ruleCatchesNot "DL3047" $ Text.unlines dockerFile
+             onBuildRuleCatchesNot "DL3047" $ Text.unlines dockerFile
     it "does not warn when running with --quiet (quiet long option) and without --progress option" $
       let dockerFile =
             [ "FROM node as foo",
               "RUN wget --quiet my.xyz"
             ]
-       in ruleCatchesNot "DL3047" $ Text.unlines dockerFile
+       in do ruleCatchesNot "DL3047" $ Text.unlines dockerFile
+             onBuildRuleCatchesNot "DL3047" $ Text.unlines dockerFile
     it "does not warn when running with -nv (no-verbose short option) and without --progress option" $
       let dockerFile =
             [ "FROM node as foo",
               "RUN wget -nv my.xyz"
             ]
-       in ruleCatchesNot "DL3047" $ Text.unlines dockerFile
+       in do ruleCatchesNot "DL3047" $ Text.unlines dockerFile
+             onBuildRuleCatchesNot "DL3047" $ Text.unlines dockerFile
     it "does not warn when running with --no-verbose (no-verbose long option) and without --progress option" $
       let dockerFile =
             [ "FROM node as foo",
               "RUN wget --no-verbose my.xyz"
             ]
-       in ruleCatchesNot "DL3047" $ Text.unlines dockerFile
+       in do ruleCatchesNot "DL3047" $ Text.unlines dockerFile
+             onBuildRuleCatchesNot "DL3047" $ Text.unlines dockerFile
     it "does not warn when running with --output-file (output-file long option) and without --progress option" $
       let dockerFile =
             [ "FROM node as foo",
               "RUN wget --output-file=/tmp/wget.log my.xyz"
             ]
-       in ruleCatchesNot "DL3047" $ Text.unlines dockerFile
+       in do ruleCatchesNot "DL3047" $ Text.unlines dockerFile
+             onBuildRuleCatchesNot "DL3047" $ Text.unlines dockerFile
     it "does not warn when running with -o (output-file long option) and without --progress option" $
       let dockerFile =
             [ "FROM node as foo",
               "RUN wget -o /tmp/wget.log my.xyz"
             ]
-       in ruleCatchesNot "DL3047" $ Text.unlines dockerFile
+       in do ruleCatchesNot "DL3047" $ Text.unlines dockerFile
+             onBuildRuleCatchesNot "DL3047" $ Text.unlines dockerFile
     it "does not warn when running with --append-output (append-output long option) and without --progress option" $
       let dockerFile =
             [ "FROM node as foo",
               "RUN wget --append-output=/tmp/wget.log my.xyz"
             ]
-       in ruleCatchesNot "DL3047" $ Text.unlines dockerFile
+       in do ruleCatchesNot "DL3047" $ Text.unlines dockerFile
+             onBuildRuleCatchesNot "DL3047" $ Text.unlines dockerFile
     it "does not warn when running with -a (append-output long option) and without --progress option" $
       let dockerFile =
             [ "FROM node as foo",
               "RUN wget -a /tmp/wget.log my.xyz"
             ]
-       in ruleCatchesNot "DL3047" $ Text.unlines dockerFile
+       in do ruleCatchesNot "DL3047" $ Text.unlines dockerFile
+             onBuildRuleCatchesNot "DL3047" $ Text.unlines dockerFile


### PR DESCRIPTION
- Apply `onbuild` wrapper per-rule rather than on all rules combined
- Apply `onbuild` wrapper only for rules needing it
- Inline rules _and_ their `onbuild` wrapped counterparts
- Test for DL3047 also when inside an `ONBUILD` statement

The `onbuild` wrapper makes sure a rule is also applied to the AST
branch inside an `ONBUILD` instruction. But this is not necessary for
all rules, for example rules dealing exclusively with `FROM`
instructions need not be applied because that would be invalid syntax
anyways.
Moving the `onbuild` wrapper to apply to each rule individually instead
of the fold of all rules permits granular control over which rules are
applied inside of an `ONBUILD` instruction and crucially also enables
the ability to not apply rules on the AST branch inside of an `ONBUILD`
instruction, if so desired.
In addition to that the inlining for the rules has been adjusted such
that all rules and their `onbuild` wrapped counterparts are inlined into
the fold, before that the fold between the unwrapped and wrapped rules
were both not inlined themselves.

fixes: #798