### PR TITLE
formatters: Add GNU style formatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ Available options:
   -V,--verbose             Enables verbose logging of hadolint's output to
                            stderr
   -f,--format ARG          The output format for the results [tty | json |
-                           checkstyle | codeclimate | gitlab_codeclimate |
+                           checkstyle | codeclimate | gitlab_codeclimate | gnu |
                            codacy | sonarqube | sarif] (default: tty)
   --error RULECODE         Make the rule `RULECODE` have the level `error`
   --warning RULECODE       Make the rule `RULECODE` have the level `warning`
@@ -194,7 +194,7 @@ In windows, the `%LOCALAPPDATA%` environment variable is used instead of
 
 ```yaml
 failure-threshold: string               # name of threshold level (error | warning | info | style | ignore | none)
-format: string                          # Output format (tty | json | checkstyle | codeclimate | gitlab_codeclimate | codacy)
+format: string                          # Output format (tty | json | checkstyle | codeclimate | gitlab_codeclimate | gnu | codacy)
 ignored: [string]                       # list of rules
 label-schema:                           # See Linting Labels below for specific label-schema details
   author: string                        # Your name
@@ -291,7 +291,7 @@ variables.
 NO_COLOR=1                               # Set or unset. See https://no-color.org
 HADOLINT_NOFAIL=1                        # Truthy value e.g. 1, true or yes
 HADOLINT_VERBOSE=1                       # Truthy value e.g. 1, true or yes
-HADOLINT_FORMAT=json                     # Output format (tty | json | checkstyle | codeclimate | gitlab_codeclimate | codacy | sarif )
+HADOLINT_FORMAT=json                     # Output format (tty | json | checkstyle | codeclimate | gitlab_codeclimate | gnu | codacy | sarif )
 HADOLINT_FAILURE_THRESHOLD=info          # threshold level (error | warning | info | style | ignore | none)
 HADOLINT_OVERRIDE_ERROR=DL3010,DL3020    # comma separated list of rule codes
 HADOLINT_OVERRIDE_WARNING=DL3010,DL3020  # comma separated list of rule codes

--- a/hadolint.cabal
+++ b/hadolint.cabal
@@ -41,6 +41,7 @@ library
       Hadolint.Formatter.Codacy
       Hadolint.Formatter.Codeclimate
       Hadolint.Formatter.Format
+      Hadolint.Formatter.Gnu
       Hadolint.Formatter.Json
       Hadolint.Formatter.Sarif
       Hadolint.Formatter.SonarQube
@@ -212,6 +213,7 @@ test-suite hadolint-unit-tests
       Hadolint.Config.ConfigurationSpec
       Hadolint.Config.EnvironmentSpec
       Hadolint.Config.SpecHook
+      Hadolint.Formatter.GnuSpec
       Hadolint.Formatter.ParseErrorSpec
       Hadolint.Formatter.SarifSpec
       Hadolint.Formatter.TTYSpec

--- a/src/Hadolint/Config/Commandline.hs
+++ b/src/Hadolint/Config/Commandline.hs
@@ -137,7 +137,7 @@ parseCommandline =
               <> short 'f' -- options for the output format
               <> help
                 "The output format for the results [tty | json | checkstyle |\
-                \ codeclimate | gitlab_codeclimate | codacy | sonarqube |\
+                \ codeclimate | gitlab_codeclimate | gnu | codacy | sonarqube |\
                 \ sarif] (default: tty)"
               <> completeWith
                   [ "tty",

--- a/src/Hadolint/Formatter.hs
+++ b/src/Hadolint/Formatter.hs
@@ -12,6 +12,7 @@ import Language.Docker.Parser (DockerfileError)
 import qualified Hadolint.Formatter.Checkstyle as FormatCheckstyle
 import qualified Hadolint.Formatter.Codacy as FormatCodacy
 import qualified Hadolint.Formatter.Codeclimate as FormatCodeclimate
+import qualified Hadolint.Formatter.Gnu as FormatGnu
 import qualified Hadolint.Formatter.Json as FormatJson
 import qualified Hadolint.Formatter.Sarif as FormatSarif
 import qualified Hadolint.Formatter.SonarQube as FormatSonarQube
@@ -31,6 +32,7 @@ printResults format nocolor filePathInReport allResults =
     Codacy -> FormatCodacy.printResults allResults
     CodeclimateJson -> FormatCodeclimate.printResults allResults
     GitlabCodeclimateJson -> FormatCodeclimate.printGitlabResults allResults
+    Gnu -> FormatGnu.printResults allResults
     Json -> FormatJson.printResults allResults
     Sarif -> FormatSarif.printResults allResults
     SonarQube -> FormatSonarQube.printResults allResults

--- a/src/Hadolint/Formatter/Format.hs
+++ b/src/Hadolint/Formatter/Format.hs
@@ -33,6 +33,7 @@ data OutputFormat
   | TTY
   | CodeclimateJson
   | GitlabCodeclimateJson
+  | Gnu
   | Checkstyle
   | Codacy
   | Sarif
@@ -44,6 +45,7 @@ instance Pretty OutputFormat where
   pretty TTY = "tty"
   pretty CodeclimateJson = "codeclimate"
   pretty GitlabCodeclimateJson = "gitlab_codeclimate"
+  pretty Gnu = "gnu"
   pretty Checkstyle = "checkstyle"
   pretty Codacy = "codacy"
   pretty Sarif = "sarif"
@@ -76,6 +78,7 @@ readMaybeOutputFormat "sonarqube" = Just SonarQube
 readMaybeOutputFormat "tty" = Just TTY
 readMaybeOutputFormat "codeclimate" = Just CodeclimateJson
 readMaybeOutputFormat "gitlab_codeclimate" = Just GitlabCodeclimateJson
+readMaybeOutputFormat "gnu" = Just Gnu
 readMaybeOutputFormat "checkstyle" = Just Checkstyle
 readMaybeOutputFormat "codacy" = Just Codacy
 readMaybeOutputFormat "sarif" = Just Sarif

--- a/src/Hadolint/Formatter/Gnu.hs
+++ b/src/Hadolint/Formatter/Gnu.hs
@@ -1,0 +1,72 @@
+-- | Hadolint GNU Format Output
+--
+-- See https://www.gnu.org/prep/standards/html_node/Errors.html for reference.
+
+module Hadolint.Formatter.Gnu
+  ( printResults,
+  )
+where
+
+
+import Data.Text (Text, pack)
+import Hadolint.Formatter.Format
+import Hadolint.Rule (CheckFailure (..), RuleCode (..))
+import Text.Megaparsec (TraversableStream)
+import Text.Megaparsec.Error
+import Text.Megaparsec.Stream (VisualStream)
+import qualified Data.List.NonEmpty as NonEmpty
+import qualified Data.Text.IO as TextIO
+
+
+printResults ::
+  (VisualStream s, TraversableStream s, ShowErrorComponent e, Foldable f) =>
+  f (Result s e) ->
+  IO ()
+printResults = mapM_ printResult
+
+
+printResult ::
+  (VisualStream s, TraversableStream s, ShowErrorComponent e) =>
+  Result s e ->
+  IO ()
+printResult (Result filename errors checks) =
+  printErrors errors >> printChecks filename checks
+
+
+printErrors ::
+  (VisualStream s, TraversableStream s, ShowErrorComponent e, Foldable f) =>
+  f (ParseErrorBundle s e) ->
+  IO ()
+printErrors = mapM_ (TextIO.putStrLn . formatError)
+
+
+printChecks :: (Foldable f) => Text -> f CheckFailure -> IO ()
+printChecks filename = mapM_ (TextIO.putStrLn . formatCheck filename)
+
+
+formatError ::
+  (VisualStream s, TraversableStream s, ShowErrorComponent e) =>
+  ParseErrorBundle s e ->
+  Text
+formatError err@(ParseErrorBundle e _) =
+  pack $
+    "hadolint:"
+      <> stripNewlines
+          ( errorPositionPretty err
+              <> ": "
+              <> parseErrorTextPretty (NonEmpty.head e)
+          )
+
+
+formatCheck :: Text -> CheckFailure -> Text
+formatCheck source (CheckFailure code severity message line) =
+  "hadolint:"
+    <> source
+    <> ":"
+    <> pack (show line)
+    <> ": "
+    <> unRuleCode code
+    <> " "
+    <> severityText severity
+    <> ": "
+    <> message

--- a/test/Hadolint/Formatter/GnuSpec.hs
+++ b/test/Hadolint/Formatter/GnuSpec.hs
@@ -1,0 +1,54 @@
+module Hadolint.Formatter.GnuSpec (spec) where
+
+
+import Helpers
+import Hadolint
+  ( CheckFailure (..),
+    DLSeverity (..),
+    OutputFormat (..),
+  )
+import Test.Hspec
+
+
+spec :: SpecWith ()
+spec = do
+  let ?noColor = False
+
+  describe "Formatter: Gnu" $ do
+    it "print empty results" $ do
+      let checkFails = []
+          expectation = ""
+      assertFormatter Gnu checkFails expectation
+
+    it "print one failed rule" $ do
+      let checkFails =
+            [ CheckFailure
+                { code = "DL2001",
+                  severity = DLWarningC,
+                  message = "test",
+                  line = 1
+                }
+            ]
+          expectation =
+            "hadolint:<string>:1: DL2001 warning: test\n"
+      assertFormatter Gnu checkFails expectation
+
+    it "print multiple failed rules" $ do
+      let checkFails =
+            [ CheckFailure
+                { code = "DL2001",
+                  severity = DLWarningC,
+                  message = "test",
+                  line = 1
+                },
+              CheckFailure
+                { code = "DL2003",
+                  severity = DLInfoC,
+                  message = "test 2",
+                  line = 3
+                }
+            ]
+          expectation =
+            "hadolint:<string>:1: DL2001 warning: test\n\
+            \hadolint:<string>:3: DL2003 info: test 2\n"
+      assertFormatter Gnu checkFails expectation


### PR DESCRIPTION
Add a GNU style formatter to Hadolint.
This formatter enhances Hadolints ability to produce output for
consumption by other programs, notably the integration with Emacs will
become easier. GNU style error messages are
described here: https://www.gnu.org/prep/standards/html_node/Errors.html

This formatter differs in three ways from the default TTY output format:
  - the GNU style has an additional colon after the line number
  - the GNU style has no color output
  - the GNU style includes the name of the program (`hadolint`) in the
    output, since Hadolint is not an interactive program

Adding a new formatter instead of modifying the existing TTY
formatter avoids breaking backwards compatibility. Since the differences
only matters when consuming Hadolint's output with another program,
configuring Hadolint to use this formatter does not hurt usability
either.

fixes: #766

![hadolint-gnu-formatter](https://user-images.githubusercontent.com/17141774/159174838-feca3cf7-9064-4914-9ead-a766dc33df54.png)

