### PR TITLE
allow lower bound version pinning for apk (DL3018)

### DIFF
--- a/src/Hadolint/Rule/DL3018.hs
+++ b/src/Hadolint/Rule/DL3018.hs
@@ -29,7 +29,7 @@ dl3018 = simpleRule code severity message check
         )
         args
     check _ = True
-    versionFixed package = "=" `Text.isInfixOf` package
+    versionFixed package = "=" `Text.isInfixOf` package || ">=" `Text.isInfixOf` package
     packageFile package = ".apk" `Text.isSuffixOf` package
 {-# INLINEABLE dl3018 #-}
 

--- a/test/Hadolint/Rule/DL3018Spec.hs
+++ b/test/Hadolint/Rule/DL3018Spec.hs
@@ -90,3 +90,14 @@ spec = do
     it "don't trigger when installing from .apk file" $ do
       ruleCatchesNot "DL3018" "RUN apk add mypackage-1.1.1.apk"
       onBuildRuleCatchesNot "DL3018" "RUN apk add mypackage-1.1.1.apk"
+    it "apk add version lower bound (>=) pinned regression" $
+      let dockerFile =
+            [ "RUN apk add --no-cache \\",
+              "flex>=2.6.4-r1 \\",
+              "libffi>=3.2.1-r3 \\",
+              "python2>=2.7.13-r1 \\",
+              "libbz2>=1.0.6-r5"
+            ]
+       in do
+            ruleCatchesNot "DL3018" $ Text.unlines dockerFile
+            onBuildRuleCatchesNot "DL3018" $ Text.unlines dockerFile


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->
This PR addresses #782.

@lorenzo this is still a WIP, since my test is failing. I've never written haskell code before, so perhaps I'm missing something.

### What I did

I've added an or section to the check for DL3018 so that it allows `>=` in `apk add` steps. 

### How I did it

I followed @lorenzo's instructions on #782.

### How to verify it

`stack test`

The tests still fail, I'm not sure how to fix that. I could use some help there. 

Aside: Additionally, this is a thing that could be used in all places where lower bounds are respected by the OS. This is supported even by yum, apt and pip. Should I implement it for those as well?

Thank you for guiding me in fixing this.
