### PR TITLE
unpin docker version in pre-commit hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -4,7 +4,7 @@
   description: Runs hadolint Docker image to lint Dockerfiles
   language: docker_image
   types: ["dockerfile"]
-  entry: ghcr.io/hadolint/hadolint:v2.9.3 hadolint
+  entry: ghcr.io/hadolint/hadolint hadolint
 - id: hadolint
   name: Lint Dockerfiles
   description: Runs hadolint to lint Dockerfiles


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

### What I did
eliminating inconsistency. e.g. for version 2.10.0, pre-commit hooks points to outdated version https://github.com/hadolint/hadolint/blob/47e3022493cb0d51e5af21ee346d4b25bc02bfcd/.pre-commit-hooks.yaml#L7

### How I did it
unpinning the version from the docker hook, behaves in the same manner as the native hook.
this is not the best approach, since each version will pull the latest docker image but will also run on the latest version that is installed on the operating system. the best way to handle the issue is to pin the exact version with each release.

### How to verify it
 set `.pre-commit-config.yaml` as follows
```yaml
  - repo: https://github.com/hadolint/hadolint
    rev: 23b2b76fe7b757658019ca4e080efa208784621b
    hooks:
      - id: hadolint-docker
```
then execute pre-commit and see whether the latest docker images has been pulled
```shell
$ pre-commit run -a hadolint-docker
$ docker run --rm ghcr.io/hadolint/hadolint /bin/hadolint --version
Haskell Dockerfile Linter 2.10.0
```