### PR TITLE
DL3022 support for copying from images

### DIFF
--- a/src/Hadolint/Rule/DL3022.hs
+++ b/src/Hadolint/Rule/DL3022.hs
@@ -1,6 +1,7 @@
 module Hadolint.Rule.DL3022 (rule) where
 
 import qualified Data.Set as Set
+import qualified Data.Text as Text
 import Hadolint.Rule
 import Language.Docker.Syntax
 
@@ -13,6 +14,7 @@ rule = customRule check (emptyState Set.empty)
 
     check _ st (From BaseImage {alias = Just (ImageAlias als)}) = st |> modify (Set.insert als)
     check line st (Copy (CopyArgs _ _ _ _ (CopySource s)))
+      | ":" `Text.isInfixOf` dropQuotes s = st
       | Set.member s (state st) = st
       | otherwise = st |> addFail CheckFailure {..}
     check _ st _ = st

--- a/test/Hadolint/Rule/DL3022Spec.hs
+++ b/test/Hadolint/Rule/DL3022Spec.hs
@@ -29,3 +29,4 @@ spec = do
               "RUN baz"
             ]
        in ruleCatchesNot "DL3022" $ Text.unlines dockerFile
+    it "don't warn on external images" $ ruleCatchesNot "DL3022" "COPY --from=haskell:latest bar ."


### PR DESCRIPTION
According to discussion in #197 I've tried to provide improvement for DL3022. I don't know if it works, info below.

### What I did

Tried to implement @lorenzo'a [suggestion](https://github.com/hadolint/hadolint/issues/197#issuecomment-1084586639) :wink: 

### How I did it

Blindfoldly :laughing: 

### How to verify it

Probably `stack test`. I couldn't verify it because I coudn't get it to work:

```
$ stack test
(...)
hspec-core> [40 of 40] Compiling Test.Hspec.Core.Runner
hspec-core> /usr/bin/ld.gold: error: cannot find -ltinfo
hspec-core> collect2: error: ld returned 1 exit status
hspec-core> `gcc' failed in phase `Linker'. (Exit code: 1)
Progress 1/4

--  While building package hspec-core-2.9.4 (scroll up to its section to see the error) using:
      /home/codito/.stack/setup-exe-cache/x86_64-linux-tinfo6/Cabal-simple_mPHDZzAJ_3.2.1.0_ghc-8.10.7 --builddir=.stack-work/dist/x86_64-linux-tinfo6/Cabal-3.2.1.0 build --ghc-options " -fdiagnostics-color=always"
    Process exited with code: ExitFailure 1
```

I just thought I will create a PR and see what happens in Github Actions.