### PR TITLE
bugfix: config file key for output format

### DIFF
--- a/src/Hadolint/Config/Configuration.hs
+++ b/src/Hadolint/Config/Configuration.hs
@@ -192,7 +192,7 @@ instance Yaml.FromYAML PartialConfiguration where
     partialNoFail <- m .:? "no-fail" .!= Nothing
     partialNoColor <- m .:? "no-color" .!= Nothing
     partialVerbose <- m .:? "verbose" .!= Nothing
-    partialFormat <- m .:? "output-format"
+    partialFormat <- m .:? "format"
     override <- m .:? "override" .!= mempty
     ignored <- m .:? "ignored" .!= mempty
     trusted <- m .:? "trustedRegistries" .!= mempty

--- a/test/Hadolint/Config/ConfigfileSpec.hs
+++ b/test/Hadolint/Config/ConfigfileSpec.hs
@@ -46,13 +46,13 @@ spec =
           conf = parseYaml yaml
       conf `shouldBe` Right mempty { partialVerbose = Just False }
 
-    it "parse `output-format: json`" $ do
-      let yaml = ["output-format: json"]
+    it "parse `format: json`" $ do
+      let yaml = ["format: json"]
           conf = parseYaml yaml
       conf `shouldBe` Right mempty { partialFormat = Just Json }
 
-    it "parse `output-format: sarif`" $ do
-      let yaml = ["output-format: sarif"]
+    it "parse `format: sarif`" $ do
+      let yaml = ["format: sarif"]
           conf = parseYaml yaml
       conf `shouldBe` Right mempty { partialFormat = Just Sarif }
 


### PR DESCRIPTION
Make Hadolint read the desired output format from the key `format` in
the config file, instead of `output-format`. This is more convenient,
consistent with the command line options and consistent with the
documentation.

fixes: #775