### PR TITLE
bugfix: typo in DL3026Spec.hs

### DIFF
--- a/test/Hadolint/Rule/DL3026Spec.hs
+++ b/test/Hadolint/Rule/DL3026Spec.hs
@@ -11,7 +11,7 @@ spec :: SpecWith ()
 spec = do
   let ?config = def
 
-  describe "DL2036 - Use only an allowed registry in the FROM image" $ do
+  describe "DL3026 - Use only an allowed registry in the FROM image" $ do
     it "does not warn on empty allowed registries" $ do
       let dockerFile =
             [ "FROM random.com/debian"


### PR DESCRIPTION
### What I did
Fixed a typo in DL3026Spec.hs

### How I did it
Swapped two characters

### How to verify it
Read DL3026Spec.hs