### PR TITLE
DL3013: Fix false positives for VCS, http and local path packages (#389)

### DIFF
--- a/test/Hadolint/Rule/DL3013Spec.hs
+++ b/test/Hadolint/Rule/DL3013Spec.hs
@@ -76,6 +76,12 @@ spec = do
       onBuildRuleCatchesNot
         "DL3013"
         "RUN pip install git+https://github.com/rtfd/r-ext.git@0.6-alpha#egg=r-ext"
+      ruleCatchesNot
+        "DL3013"
+        "RUN pip install git+ssh://github.com/rtfd/r-ext.git@0.6-alpha#egg=r-ext"
+      onBuildRuleCatchesNot
+        "DL3013"
+        "RUN pip install git+ssh://github.com/rtfd/r-ext.git@0.6-alpha#egg=r-ext"
     it "pip install unversioned git" $ do
       ruleCatches
         "DL3013"
@@ -83,6 +89,26 @@ spec = do
       onBuildRuleCatches
         "DL3013"
         "RUN pip install git+https://github.com/rtfd/read-ext.git#egg=read-ext"
+      ruleCatches
+        "DL3013"
+        "RUN pip install git+ssh://github.com/rtfd/read-ext.git#egg=read-ext"
+      onBuildRuleCatches
+        "DL3013"
+        "RUN pip install git+ssh://github.com/rtfd/read-ext.git#egg=read-ext"
+    it "pip install local dir" $ do
+      ruleCatchesNot
+        "DL3013"
+        "RUN pip install foo/bar"
+      onBuildRuleCatchesNot
+        "DL3013"
+        "RUN pip install foo/bar"
+    it "pip install url dir" $ do
+      ruleCatchesNot
+        "DL3013"
+        "RUN pip install https://foo.bar/baz.zip"
+      onBuildRuleCatchesNot
+        "DL3013"
+        "RUN pip install https://foo.bar/baz.zip"
     it "pip install upper bound" $ do
       ruleCatchesNot "DL3013" "RUN pip install 'alabaster>=0.7'"
       onBuildRuleCatchesNot "DL3013" "RUN pip install 'alabaster>=0.7'"

--- a/test/Hadolint/Rule/DL3013Spec.hs
+++ b/test/Hadolint/Rule/DL3013Spec.hs
@@ -102,7 +102,7 @@ spec = do
       onBuildRuleCatchesNot
         "DL3013"
         "RUN pip install foo/bar"
-    it "pip install url dir" $ do
+    it "pip install https url package" $ do
       ruleCatchesNot
         "DL3013"
         "RUN pip install https://foo.bar/baz.zip"


### PR DESCRIPTION
### What I did
- Fix false positive when installing package with other supported VCS
  such as: `pip install bzr+ssh://..@1.0.0`, as described in
  https://pip.pypa.io/en/stable/topics/vcs-support/.
- Fix false positive when installing package from local directory:
  `pip install my/install/path`
- Fix false positive when installing package from http/https url:
  `pip install https://foo.bar/baz-1.0.0.zip`

fixes #389

### How I did it
Extended the previous check for a `git+https` vcs scheme to allow any of the supported vcs sources, such as `git+ssh` and `bzr+ssh`, documented in https://pip.pypa.io/en/stable/topics/vcs-support/. Also added passing check if a package source included a forward slash (/) but is not a valid vcs source.

### How to verify it
Compare the supported VCS in this PR from the VCS supported from the pip documentation https://pip.pypa.io/en/stable/topics/vcs-support/. Also, the following Dockerfile illustrates cases where hadolint now runs without any warnings.

```Dockerfile
FROM python:3.10

RUN pip install --no-cache-dir \
  git+ssh://hello@1.3 \
  hello/bar/baz \
  https://foo.bar/baz-1.0.0.zip
```