### PR TITLE
DL3057: fix multiple warnings for multistage builds

### DIFF
--- a/test/Hadolint/Rule/DL3057Spec.hs
+++ b/test/Hadolint/Rule/DL3057Spec.hs
@@ -1,6 +1,7 @@
 module Hadolint.Rule.DL3057Spec (spec) where
 
 import Data.Default
+import Data.Text as Text
 import Helpers
 import Test.Hspec
 
@@ -10,11 +11,63 @@ spec = do
   let ?config = def
 
   describe "DL3057 - `HEALTHCHECK instruction missing" $ do
-    it "warn with no HEALTHCHECK instructions" $
-      ruleCatches "DL3057" "FROM scratch"
-    it "ok with one HEALTHCHECK instruction" $
-      ruleCatchesNot "DL3057" "FROM scratch\nHEALTHCHECK CMD /bin/bla"
-    it "ok with inheriting HEALTHCHECK instruction" $
-      ruleCatchesNot "DL3057" "FROM scratch AS base\nHEALTHCHECK CMD /bin/bla\nFROM base"
-    it "warn when not inheriting with no HEALTHCHECK instruction" $
-      ruleCatches "DL3057" "FROM scratch AS base\nHEALTHCHECK CMD /bin/bla\nFROM scratch"
+
+    it "warn with no HEALTHCHECK instructions" $ do
+      let dockerfile = Text.unlines
+            [ "FROM scratch"
+            ]
+       in ruleCatches "DL3057" dockerfile
+
+    it "ok when HEALTHCHECK is explicitly disabled" $ do
+      let dockerfile = Text.unlines
+            [ "FROM scratch",
+              "HEALTHCHECK NONE"
+            ]
+       in ruleCatchesNot "DL3057" dockerfile
+
+    it "ok with one HEALTHCHECK instruction" $ do
+      let dockerfile = Text.unlines
+            [ "FROM scratch",
+              "HEALTHCHECK CMD /bin/bla"
+            ]
+       in ruleCatchesNot "DL3057" dockerfile
+
+    it "ok with inheriting HEALTHCHECK instruction" $ do
+      let dockerfile = Text.unlines
+            [ "FROM scratch AS base",
+              "HEALTHCHECK CMD /bin/bla",
+              "FROM base"
+            ]
+       in ruleCatchesNot "DL3057" dockerfile
+
+    it "ok with ending inheritance chain with HEALTCHECK" $ do
+      let dockerfile = Text.unlines
+            [ "FROM scratch AS base1",
+              "FROM base1 AS base2",
+              "FROM base2 AS base3",
+              "FROM base3 AS end",
+              "HEALTHCHECK NONE"
+            ]
+       in ruleCatchesNot "DL3057" dockerfile
+
+    it "warn when inheritance chain bifurcates" $ do
+      let dockerfile = Text.unlines
+            [ "FROM scratch AS base1",
+              "FROM base1 AS base2",
+              "FROM base2 AS base3.1",
+              "FROM base2 AS base3.2",  -- This will trigger DL3057
+              "",
+              "FROM base3.1 AS end1",
+              "HEALTHCHECK NONE",
+              "",
+              "FROM base3.2 AS end2"  -- This will trigger DL3057
+            ]
+       in ruleCatches "DL3057" dockerfile
+
+    it "warn when not inheriting with no HEALTHCHECK instruction" $ do
+      let dockerfile = Text.unlines
+            [ "FROM scratch AS base",
+              "HEALTHCHECK CMD /bin/bla",
+              "FROM scratch"
+            ]
+       in ruleCatches "DL3057" dockerfile


### PR DESCRIPTION
DL3057 checks that images produced in multistage builds have a
healthcheck (if the rule is enabled). But if one stage already has the
healthcheck instruction, the other stages should not trigger a warning.
If the stage comes earlier, it's obviously not used as a build result,
therefore doesn't need a healthcheck instruction on its own.
If the stage comes later, it will inherit the healthcheck instruction
from the stage that has it.

This fix works because when a healthcheck is found in a build stage,
that stage is marked as good, but also all stages it inherited from are
also marked as good. Only stages that don't inherit the healthcheck
instruction remain marked as bad, if they don't have the instruction
themselves. Therefore Dockerfiles, which produce multiple images are
also considered.

fixes: #843
Signed-off-by: Moritz Röhrich <moritz.rohrich@suse.com>

### How to verify it
This does not trigger DL3057 at all anymore:
```Dockerfile
FROM opensuse/leap:15.4 AS base0
FROM base0 AS base1
HEALTHCHECK NONE
FROM base1
```

This triggers for the last stage only:
```Dockerfile
FROM opensuse/leap:15.4 AS base0
FROM base0 AS base1
FROM base1 AS base2.1
HEALTHCHECK NONE

FROM base1 AS base2.2
```
