### PR TITLE
DL3049: Fix behaviour with multistage builds

### DIFF
--- a/src/Hadolint/Rule/DL3049.hs
+++ b/src/Hadolint/Rule/DL3049.hs
@@ -1,4 +1,4 @@
- module Hadolint.Rule.DL3049 (rule) where
+module Hadolint.Rule.DL3049 (rule) where
 
 import qualified Data.Map as Map
 import qualified Data.Set as Set
@@ -12,15 +12,17 @@ rule :: LabelSchema -> Rule args
 rule labelschema = mconcat $ fmap missingLabelRule (Map.keys labelschema)
 {-# INLINEABLE rule #-}
 
+
 data StageID = StageID
-  { name :: Text.Text,
+  { name :: BaseImage,
     line :: Linenumber
   } deriving (Eq, Ord, Show)
 
 data Acc
-  = Acc StageID (Set.Set StageID) (Set.Set StageID)
+  = Acc StageID (Set.Set StageID) (Set.Set StageID) (Set.Set StageID)
   | Empty
   deriving (Show)
+
 
 -- missingLabelRule
 --
@@ -32,29 +34,52 @@ missingLabelRule label = veryCustomRule check (emptyState Empty) markFailure
     code = "DL3049"
     severity = DLInfoC
     message = "Label `" <> label <> "` is missing."
-    check line state (From BaseImage {image, alias = Just als}) =
-        state |> modify (currentStage (imageName image) (StageID (unImageAlias als) line))
-    check line state (From BaseImage {image, alias = Nothing}) =
-        state |> modify (currentStage (imageName image) (StageID (imageName image) line))
+    check line state (From img) =
+      state |> modify (currentStage (StageID img line))
+    check _ state (Copy (CopyArgs _ _) (CopyFlags _ _ _ (CopySource src))) =
+      state |> modify (markSilentByAlias src)
     check _ state (Label pairs)
-        | label `elem` fmap fst pairs = state |> modify goodStage
-        | otherwise = state
+      | label `elem` fmap fst pairs =
+          state
+            |> modify (markSilentByAlias (getCurrentStageName state))
+            |> modify markGood
+      | otherwise = state
     check _ state _ = state
 
     markFailure :: State Acc -> Failures
-    markFailure (State fails (Acc _ _ b)) = Set.foldl' (Seq.|>) fails (Set.map markFail b)
+    markFailure (State fails (Acc _ _ _ b)) = Set.foldl' (Seq.|>) fails (Set.map markFail b)
     markFailure st = failures st
 
     markFail (StageID _ line) = CheckFailure {..}
 
-currentStage :: Text.Text -> StageID -> Acc -> Acc
-currentStage src stageid (Acc _ g b)
-    | not $ Set.null (Set.filter (predicate src) g) = Acc stageid (g |> Set.insert stageid) b
-    | otherwise = Acc stageid g (b |> Set.insert stageid)
-  where
-    predicate n0 StageID {name = n1} = n1 == n0
-currentStage _ stageid Empty = Acc stageid Set.empty (Set.singleton stageid)
 
-goodStage :: Acc -> Acc
-goodStage (Acc stageid g b) = Acc stageid (g |> Set.insert stageid) (b |> Set.delete stageid)
-goodStage Empty = Empty
+currentStage :: StageID -> Acc -> Acc
+currentStage stageid Empty = Acc stageid Set.empty Set.empty (Set.singleton stageid)
+currentStage stageid (Acc _ g s b)
+  | not $ Set.null (Set.filter (predicate stageid) g) =
+      Acc stageid (g |> Set.insert stageid) s b
+  | otherwise = Acc stageid g s (b |> Set.insert stageid)
+  where
+    predicate (StageID _ _) (StageID BaseImage {alias = Nothing} _) = False
+    predicate (StageID BaseImage {image} _) (StageID BaseImage {alias = Just als} _) =
+      unImageAlias als == imageName image
+
+markGood :: Acc -> Acc
+markGood Empty = Empty
+markGood (Acc stageid good silent bad) =
+  Acc stageid (good |> Set.insert stageid) (silent |> Set.delete stageid) (bad |> Set.delete stageid)
+
+markSilentByAlias :: Text.Text -> Acc -> Acc
+markSilentByAlias _ Empty = Empty
+markSilentByAlias silentname (Acc stageid good silent bad) =
+  Acc stageid good (silent |> Set.union stages) (bad |> remove stages)
+  where
+    stages = Set.filter byName bad
+    byName (StageID BaseImage {alias = Nothing} _) = False
+    byName (StageID BaseImage {alias = Just als} _) = unImageAlias als == silentname
+    remove set fromThis = Set.difference fromThis set
+
+getCurrentStageName :: State Acc -> Text.Text
+getCurrentStageName (State _ (Acc (StageID BaseImage {image, alias = Nothing} _) _ _ _)) = imageName image
+getCurrentStageName (State _ (Acc (StageID BaseImage {alias = Just als} _) _ _ _)) = unImageAlias als
+getCurrentStageName _ = ""


### PR DESCRIPTION
- Fix DL3049 behaviour with multistage builds

In a multistage build, when a stage has an alias, it is reasonable to
assume that it will not be the last stage in the build process. Rather
there will be another stage inheriting or copying from that stage.
Therefore required labels don't necessarily need to be present in the
stage with the alias.

fixes: #758
Signed-off-by: Moritz Röhrich <moritz.rohrich@suse.com>