### PR TITLE
docs: update link to Haskell

### DIFF
--- a/README.md
+++ b/README.md
@@ -640,7 +640,7 @@ stack test
 [best practice]: https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices
 [shellcheck]: https://github.com/koalaman/shellcheck
 [release page]: https://github.com/hadolint/hadolint/releases/latest
-[haskell]: https://www.haskell.org/platform/
+[haskell]: https://www.haskell.org/downloads/
 [stack]: http://docs.haskellstack.org/en/stable/install_and_upgrade.html
 [integration]: docs/INTEGRATION.md
 [code review platform integrations]: docs/INTEGRATION.md#code-review


### PR DESCRIPTION
The Haskell Platform is deprecated since 2022 and is no longer the recommended way of installing Haskell. For the latest recommended way to install Haskell please see the Downloads page.