### PR TITLE
fix(DL3029): allow BUILDPLATFORM and TARGETPLATFORM variables

### DIFF
--- a/src/Hadolint/Rule/DL3029.hs
+++ b/src/Hadolint/Rule/DL3029.hs
@@ -1,5 +1,6 @@
 module Hadolint.Rule.DL3029 (rule) where
 
+import qualified Data.Text as Text
 import Hadolint.Rule
 import Language.Docker.Syntax
 
@@ -10,6 +11,6 @@ rule = simpleRule code severity message check
     severity = DLWarningC
     message = "Do not use --platform flag with FROM"
 
-    check (From BaseImage {platform = Just p}) = p == "$BUILDPLATFORM"
+    check (From BaseImage {platform = Just p}) = "BUILDPLATFORM" `Text.isInfixOf` p || "TARGETPLATFORM" `Text.isInfixOf` p
     check _ = True
 {-# INLINEABLE rule #-}

--- a/test/Hadolint/Rule/DL3029Spec.hs
+++ b/test/Hadolint/Rule/DL3029Spec.hs
@@ -12,4 +12,9 @@ spec = do
   describe "DL3029 - Do not use --platform flag with FROM." $ do
     it "explicit platform flag" $ ruleCatches "DL3029" "FROM --platform=linux debian:jessie"
     it "no platform flag" $ ruleCatchesNot "DL3029" "FROM debian:jessie"
-    it "allow platform $BUILDPLATFORM flag" $ ruleCatchesNot "DL3029" "FROM --platform=$BUILDPLATFORM debian:jessie"
+    it "allows platform $BUILDPLATFORM flag" $ ruleCatchesNot "DL3029" "FROM --platform=$BUILDPLATFORM debian:jessie"
+    it "allows platform \"$BUILDPLATFORM\" flag" $ ruleCatchesNot "DL3029" "FROM --platform=\"$BUILDPLATFORM\" debian:jessie"
+    it "allows platform ${BUILDPLATFORM} flag" $ ruleCatchesNot "DL3029" "FROM --platform=${BUILDPLATFORM} debian:jessie"
+    it "allows platform ${BUILDPLATFORM:-} flag" $ ruleCatchesNot "DL3029" "FROM --platform=${BUILDPLATFORM:-} debian:jessie"
+    it "allows platform \"${BUILDPLATFORM:-}\" flag" $ ruleCatchesNot "DL3029" "FROM --platform=\"${BUILDPLATFORM:-}\" debian:jessie"
+    it "allows platform $TARGETPLATFORM flag" $ ruleCatchesNot "DL3029" "FROM --platform=$TARGETPLATFORM debian:jessie"


### PR DESCRIPTION
Closes #861

### What I did

Allowed `BUILDPLATFORM` and `TARGETPLATFORM` in `FROM --plaform=`

### How I did it

Updated the existing rule to check if the value contains one of the variables. This is the lazy way without getting into complex regex.

### How to verify it

I added new tests, but I have not been able to run anything. I tried to use `nix-shell` to get a development environment, but the compilation is never ending. This is also my first time touching Haskell code, so I barely understand a quarter of the changes I made :sweat_smile: