### PR TITLE
feature: global ignore pragma

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,6 +333,19 @@ RUN cd /tmp && echo "hello!"
 
 The comment "inline ignores" applies only to the statement following it.
 
+## Global ignores
+
+Rules can also be ignored on a per-file basis using the global ignore pragma.
+It works just like inline ignores, excep that it applies to the whole file
+instead of just the next line.
+
+```dockerfile
+# hadolint global ignore=DL3003,DL3006,SC1035
+FROM ubuntu
+
+RUN cd /tmp && echo "foo"
+```
+
 ## Linting Labels
 
 Hadolint is able to check if specific labels are present and conform

--- a/test/Hadolint/PragmaSpec.hs
+++ b/test/Hadolint/PragmaSpec.hs
@@ -11,6 +11,7 @@ spec = do
   let ?config = def
 
   describe "Rules can be ignored with inline comments" $ do
+
     it "ignores single rule" $
       let dockerFile =
             [ "FROM ubuntu",
@@ -18,6 +19,7 @@ spec = do
               "USER root"
             ]
        in ruleCatchesNot "DL3002" $ Text.unlines dockerFile
+
     it "ignores only the given rule" $
       let dockerFile =
             [ "FROM scratch",
@@ -25,6 +27,7 @@ spec = do
               "USER root"
             ]
        in ruleCatches "DL3002" $ Text.unlines dockerFile
+
     it "ignores only the given rule, when multiple passed" $
       let dockerFile =
             [ "FROM scratch",
@@ -32,6 +35,7 @@ spec = do
               "USER root"
             ]
        in ruleCatchesNot "DL3002" $ Text.unlines dockerFile
+
     it "ignores the rule only if directly above the instruction" $
       let dockerFile =
             [ "# hadolint ignore=DL3001,DL3002",
@@ -39,6 +43,7 @@ spec = do
               "USER root"
             ]
        in ruleCatches "DL3002" $ Text.unlines dockerFile
+
     it "won't ignore the rule if passed invalid rule names" $
       let dockerFile =
             [ "FROM scratch",
@@ -46,10 +51,32 @@ spec = do
               "USER root"
             ]
        in ruleCatches "DL3002" $ Text.unlines dockerFile
+
     it "ignores multiple rules correctly, even with some extra whitespace" $
       let dockerFile =
             [ "FROM node as foo",
               "# hadolint ignore=DL3023, DL3021",
+              "COPY --from=foo bar baz ."
+            ]
+       in do
+            ruleCatchesNot "DL3023" $ Text.unlines dockerFile
+            ruleCatchesNot "DL3021" $ Text.unlines dockerFile
+
+
+  describe "Rules can be ignored globally with global ignore pragma" $ do
+
+    it "ignores single rule" $
+      let dockerFile =
+            [ "# hadolint global ignore=DL3002",
+              "FROM ubuntu",
+              "USER root"
+            ]
+       in ruleCatchesNot "DL3002" $ Text.unlines dockerFile
+
+    it "ignores multiple rules correctly, even with some extra whitespace" $
+      let dockerFile =
+            [ "# hadolint global ignore = DL3023 , DL3021",
+              "FROM node as foo",
               "COPY --from=foo bar baz ."
             ]
        in do


### PR DESCRIPTION
Add global variant of the ignore pragma. This allows users to disable rules for the whole dockerfile by using a pragma like:

```dockerfile
# hadolint global ignore=DL3003,SC2035
```

### What I did
- add file-global variant of the ignore pragma
- clean up the pragma parsing code

### How I did it
The file global ignore pragma works almost like the inline ignore pragma. The difference is that it parses into just a set of rules to ignore instead of a map from line-numbers to sets of rules to ignore. Consequently there is no check for line numbers when deciding if a check-failure should be ignored or propagated, all that matters is if that failures code is in that global set of rule codes to ignore.

### How to verify it
The following Dockerfile should not trigger any of the globally ignored rules, but will still trigger all other rules just normal:

```Dockerfile
# hadolint global ignore=DL3002
FROM alpine
USER root
```