### PR TITLE
Missing space in DL3047

### DIFF
--- a/src/Hadolint/Rule/DL3047.hs
+++ b/src/Hadolint/Rule/DL3047.hs
@@ -16,7 +16,7 @@ dl3047 = simpleRule code severity message check
     code = "DL3047"
     severity = DLInfoC
     message =
-      "Avoid use of wget without progress bar. Use `wget --progress=dot:giga <url>`.\
+      "Avoid use of wget without progress bar. Use `wget --progress=dot:giga <url>`. \
       \Or consider using `-q` or `-nv` (shorthands for `--quiet` or `--no-verbose`)."
 
     check (Run (RunArgs args _)) = foldArguments (Shell.noCommands forgotProgress) args


### PR DESCRIPTION
Fixes a missing space 

<img width="1280" alt="image" src="https://user-images.githubusercontent.com/71290498/191652958-933cea7d-4790-4cb1-9088-76f19c61a286.png">