### PR TITLE
Allow rm yum cache clean up

### DIFF
--- a/src/Hadolint/Rule/DL3032.hs
+++ b/src/Hadolint/Rule/DL3032.hs
@@ -24,5 +24,6 @@ dl3032 = simpleRule code severity message check
     check _ = True
 
     yumInstall = Shell.cmdHasArgs "yum" ["install"]
-    yumClean = Shell.cmdHasArgs "yum" ["clean", "all"]
+    yumClean args = Shell.cmdHasArgs "yum" ["clean", "all"] args
+      || Shell.cmdHasArgs "rm" ["-rf", "/var/cache/yum/*"] args
 {-# INLINEABLE dl3032 #-}

--- a/src/Hadolint/Rule/DL3040.hs
+++ b/src/Hadolint/Rule/DL3040.hs
@@ -26,6 +26,7 @@ dl3040 = simpleRule code severity message check
            )
 
     dnfInstall cmdName = Shell.cmdHasArgs cmdName ["install"]
-    dnfClean cmdName = Shell.cmdHasArgs cmdName ["clean", "all"]
+    dnfClean cmdName args = Shell.cmdHasArgs cmdName ["clean", "all"] args 
+      || Shell.cmdHasArgs "rm" ["-rf", "/var/cache/yum/*"] args
     dnfCmds = ["dnf", "microdnf"]
 {-# INLINEABLE dl3040 #-}

--- a/test/Hadolint/Rule/DL3032Spec.hs
+++ b/test/Hadolint/Rule/DL3032Spec.hs
@@ -18,3 +18,6 @@ spec = do
       ruleCatchesNot "DL3032" "RUN bash -c `# not even a yum command`"
       onBuildRuleCatchesNot "DL3032" "RUN yum install -y mariadb-10.4 && yum clean all"
       onBuildRuleCatchesNot "DL3032" "RUN bash -c `# not even a yum command`"
+    it "ok with rm -rf /var/cache/yum/*" $ do
+      ruleCatchesNot "DL3032" "RUN yum install -y mariadb-10.4 && rm -rf /var/cache/yum/*"
+      onBuildRuleCatchesNot "DL3032" "RUN yum install -y mariadb-10.4 && rm -rf /var/cache/yum/*"

--- a/test/Hadolint/Rule/DL3040Spec.hs
+++ b/test/Hadolint/Rule/DL3040Spec.hs
@@ -23,3 +23,8 @@ spec = do
       onBuildRuleCatchesNot "DL3040" "RUN dnf install -y mariadb-10.4 && dnf clean all"
       onBuildRuleCatchesNot "DL3040" "RUN microdnf install -y mariadb-10.4 && microdnf clean all"
       onBuildRuleCatchesNot "DL3040" "RUN notdnf install mariadb"
+    it "ok with rm /var/cache/yum" $ do
+      ruleCatchesNot "DL3040" "RUN dnf install -y mariadb-10.4 && rm -rf /var/cache/yum/*"
+      ruleCatchesNot "DL3040" "RUN microdnf install -y mariadb-10.4 && rm -rf /var/cache/yum/*"
+      onBuildRuleCatchesNot "DL3040" "RUN dnf install -y mariadb-10.4 && rm -rf /var/cache/yum/*"
+      onBuildRuleCatchesNot "DL3040" "RUN microdnf install -y mariadb-10.4 && rm -rf /var/cache/yum/*"


### PR DESCRIPTION
Update DL3032 and DL3040 to allow explicit yum cache clean up after install.

Fixes #796

<!--
If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

### What I did

Update DL3032 and DL3040 to allow explicit yum cache clean up after install using `rm -rf /var/cache/yum/*`

### How I did it

Added `||` condition to clean up rules.

### How to verify it

Unit tests have been added for both rules.