### PR TITLE
fix: false positive in `DL3022`

### DIFF
--- a/src/Hadolint/Rule/DL3022.hs
+++ b/src/Hadolint/Rule/DL3022.hs
@@ -3,7 +3,6 @@ module Hadolint.Rule.DL3022 (rule) where
 import qualified Data.Set as Set
 import qualified Data.Text as Text
 import qualified Data.Text.Read as Read
-
 import Hadolint.Rule
 import Language.Docker.Syntax
 
@@ -15,6 +14,7 @@ rule = customRule check (emptyState Set.empty)
     message = "`COPY --from` should reference a previously defined `FROM` alias"
 
     check _ st (From BaseImage {alias = Just (ImageAlias als)}) = st |> modify (Set.insert als)
+    check _ st (From BaseImage {}) = st |> modify (Set.insert $ Text.pack $ show $ length (state st))
     check line st (Copy (CopyArgs _ _) (CopyFlags _ _ _ (CopySource s)))
       | ":" `Text.isInfixOf` dropQuotes s = st
       | Set.member s (state st) = st

--- a/src/Hadolint/Rule/DL3022.hs
+++ b/src/Hadolint/Rule/DL3022.hs
@@ -2,6 +2,8 @@ module Hadolint.Rule.DL3022 (rule) where
 
 import qualified Data.Set as Set
 import qualified Data.Text as Text
+import qualified Data.Text.Read as Read
+
 import Hadolint.Rule
 import Language.Docker.Syntax
 
@@ -16,6 +18,8 @@ rule = customRule check (emptyState Set.empty)
     check line st (Copy (CopyArgs _ _) (CopyFlags _ _ _ (CopySource s)))
       | ":" `Text.isInfixOf` dropQuotes s = st
       | Set.member s (state st) = st
-      | otherwise = st |> addFail CheckFailure {..}
+      | otherwise = case Read.decimal s of
+                      Right (v, _) | v < length (state st) -> st
+                      _ -> st |> addFail CheckFailure {..}
     check _ st _ = st
 {-# INLINEABLE rule #-}

--- a/src/Hadolint/Rule/DL3022.hs
+++ b/src/Hadolint/Rule/DL3022.hs
@@ -6,20 +6,41 @@ import qualified Data.Text.Read as Read
 import Hadolint.Rule
 import Language.Docker.Syntax
 
+data Acc
+  = Acc { count :: Int, names :: Set.Set Text.Text }
+  | Empty
+  deriving (Eq)
+
 rule :: Rule args
-rule = customRule check (emptyState Set.empty)
+rule = customRule check (emptyState Empty)
   where
     code = "DL3022"
     severity = DLWarningC
     message = "`COPY --from` should reference a previously defined `FROM` alias"
 
-    check _ st (From BaseImage {alias = Just (ImageAlias als)}) = st |> modify (Set.insert als)
-    check _ st (From BaseImage {}) = st |> modify (Set.insert $ Text.pack $ show $ length (state st))
+    check _ st (From BaseImage {alias = Just (ImageAlias als)}) = st |> modify (incAndAddName als)
+    check _ st (From BaseImage {}) = st |> modify incCount
     check line st (Copy (CopyArgs _ _) (CopyFlags _ _ _ (CopySource s)))
       | ":" `Text.isInfixOf` dropQuotes s = st
-      | Set.member s (state st) = st
+      | isMember s (state st) = st
       | otherwise = case Read.decimal s of
-                      Right (v, _) | v < length (state st) -> st
+                      Right (v, _) | v < nameCount (state st) -> st
                       _ -> st |> addFail CheckFailure {..}
     check _ st _ = st
 {-# INLINEABLE rule #-}
+
+incAndAddName :: Text.Text -> Acc -> Acc
+incAndAddName s Empty = Acc { count = 1, names = Set.singleton s }
+incAndAddName s Acc { count, names } = Acc { count = count + 1, names = Set.insert s names }
+
+incCount :: Acc -> Acc
+incCount Empty = Acc { count = 1, names = Set.empty }
+incCount Acc { count, names } = Acc { count = count + 1, names = names }
+
+isMember :: Text.Text -> Acc -> Bool
+isMember _ Empty = False
+isMember s Acc { names } = Set.member s names
+
+nameCount :: Acc -> Int
+nameCount Empty = 0
+nameCount Acc { count } = count

--- a/test/Hadolint/Rule/DL3022Spec.hs
+++ b/test/Hadolint/Rule/DL3022Spec.hs
@@ -39,3 +39,11 @@ spec = do
               "COPY --from=0 foo ."
             ]
       in ruleCatchesNot "DL3022" $ Text.unlines dockerFile
+    it "don't warn on valid stage count as --from=<count>" $
+      let dockerFile =
+            [ "FROM scratch",
+              "RUN foo",
+              "FROM node",
+              "COPY --from=0 foo ."
+            ]
+      in ruleCatchesNot "DL3022" $ Text.unlines dockerFile

--- a/test/Hadolint/Rule/DL3022Spec.hs
+++ b/test/Hadolint/Rule/DL3022Spec.hs
@@ -30,3 +30,12 @@ spec = do
             ]
        in ruleCatchesNot "DL3022" $ Text.unlines dockerFile
     it "don't warn on external images" $ ruleCatchesNot "DL3022" "COPY --from=haskell:latest bar ."
+    it "warn on invalid stage count as --from=<count>" $ ruleCatches "DL3022" "COPY --from=0 bar ."
+    it "don't warn on valid stage count as --from=<count>" $
+      let dockerFile =
+            [ "FROM scratch as build",
+              "RUN foo",
+              "FROM node",
+              "COPY --from=0 foo ."
+            ]
+      in ruleCatchesNot "DL3022" $ Text.unlines dockerFile


### PR DESCRIPTION
### What I did

Simple patch to fix bug with hadolint raising false positives if the stages are mentioned by index rather than names.
Such as,
```dockerfile
FROM X as stage1
RUN # do some work, likely, build something to copy

FROM Y as stage2
COPY --from=0 bar .
```

### How I did it

I use decimal conversion over string to get the index and compare it to the count of the stages in source, not sure if there was a better way to write the code I just wrote it because I needed it to be fixed.

### How to verify it

Added a couple tests to `DL3022Spec.hs`


#### Note: Let me know if there are any mistakes I will fix em. Though as it's a weekend I might not always be available.