### PR TITLE
Correct documentation example for `failure-threshold`

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,7 +262,8 @@ severity above THRESHOLD are violated (Available in v2.6.0+)
 
 ```yaml
 failure-threshold: info
-warning:
+override:
+  warning:
     - DL3042
     - DL3033
   info:


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

### What I did

Fix an example snippet for `failure-threshold` that was both:
- Invalid (incorrect syntax)
- Incorrect (there's no top-level configuration option "warning" or "info")

### How I did it

Update the example based on how the configuration should be according to the rest of the documentation and verify the syntax with [the first tool I could fine online](https://onlineyamltools.com/convert-yaml-to-json).

### How to verify it

Copy the snippet into a configuration file and see if it 1) works now and 2) didn't work before.