### PR TITLE
DL3011: fixup changes in AST

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ dist-newstyle
 
 # travis wait is generating log in PWD
 travis_wait_*.log
+
+cabal.project.local*

--- a/hadolint.cabal
+++ b/hadolint.cabal
@@ -155,7 +155,7 @@ library
     , foldl
     , gitrev >=1.3.1
     , ilist
-    , language-docker >=11.0.0 && <12
+    , language-docker >=12.0.0 && <13
     , megaparsec >=9.0.0
     , mtl
     , network-uri
@@ -197,7 +197,7 @@ executable hadolint
     , containers
     , data-default
     , hadolint
-    , language-docker >=11.0.0 && <12
+    , language-docker >=12.0.0 && <13
     , megaparsec >=9.0.0
     , optparse-applicative >=0.14.0
     , prettyprinter >=1.7.0
@@ -323,7 +323,7 @@ test-suite hadolint-unit-tests
     , foldl
     , hadolint
     , hspec >=2.8.3
-    , language-docker >=11.0.0 && <12
+    , language-docker >=12.0.0 && <13
     , megaparsec >=9.0.0
     , optparse-applicative >=0.14.0
     , silently

--- a/package.yaml
+++ b/package.yaml
@@ -28,7 +28,7 @@ dependencies:
   - base >=4.8 && <5
   - containers
   - data-default
-  - language-docker >=11.0.0 && <12
+  - language-docker >=12.0.0 && <13
   - megaparsec >= 9.0.0
   - optparse-applicative >= 0.14.0
   - text

--- a/src/Hadolint/Rule/DL3011.hs
+++ b/src/Hadolint/Rule/DL3011.hs
@@ -10,7 +10,7 @@ rule = simpleRule code severity message check
     severity = DLErrorC
     message = "Valid UNIX ports range from 0 to 65535"
     check (Expose (Ports ports)) =
-      and [p <= 65535 | Port p _ <- ports]
-        && and [l <= 65535 && m <= 65535 | PortRange l m _ <- ports]
+      and [p <= 65535 | PortSpec (Port p _) <- ports]
+        && and [l <= 65535 && m <= 65535 | PortRangeSpec (PortRange (Port l _) (Port m _)) <- ports]
     check _ = True
 {-# INLINEABLE rule #-}

--- a/test/Hadolint/Rule/DL3011Spec.hs
+++ b/test/Hadolint/Rule/DL3011Spec.hs
@@ -9,6 +9,13 @@ spec :: SpecWith ()
 spec = do
   let ?config = def
 
-  describe "EXPOSE rules" $ do
-    it "invalid port" $ ruleCatches "DL3011" "EXPOSE 80000"
-    it "valid port" $ ruleCatchesNot "DL3011" "EXPOSE 60000"
+  describe "DL3011 - Valid UNIX ports range from 0 to 65535" $ do
+    describe "DL3011 - single port" $ do
+      it "invalid port" $ ruleCatches "DL3011" "EXPOSE 80000"
+      it "valid port" $ ruleCatchesNot "DL3011" "EXPOSE 60000"
+      it "valid port vairable" $ ruleCatchesNot "DL3011" "EXPOSE ${FOOBAR}"
+
+    describe "DL3011 - port range" $ do
+      it "invalid port in range" $ ruleCatches "DL3011" "EXPOSE 40000-80000/tcp"
+      it "valid port range" $ ruleCatchesNot "DL3011" "EXPOSE 40000-60000/tcp"
+      it "valid port range variable" $ ruleCatchesNot "DL3011" "EXPOSE 40000-${FOOBAR}"


### PR DESCRIPTION
Fix up usage of the AST in DL3011 corresponding to the changes to the AST with respect to port ranges in `EXPOSE` instructions.

requires: https://github.com/hadolint/language-docker/pull/85
fixes: https://github.com/hadolint/hadolint/issues/876