### PR TITLE
DL3014: Fix false positive on double quiet

### DIFF
--- a/src/Hadolint/Rule/DL3014.hs
+++ b/src/Hadolint/Rule/DL3014.hs
@@ -22,5 +22,9 @@ dl3014 = simpleRule code severity message check
 
     forgotAptYesOption cmd = isAptGetInstall cmd && not (hasYesOption cmd)
     isAptGetInstall = Shell.cmdHasArgs "apt-get" ["install"]
-    hasYesOption = Shell.hasAnyFlag ["y", "yes", "q", "assume-yes"]
+    hasYesOption cmd =
+      Shell.hasAnyFlag ["y", "yes", "qq", "assume-yes"] cmd
+        || ( Shell.countFlag "q" cmd == 2 )
+        || ( Shell.countFlag "quiet" cmd == 2 )
+        || "-q=2" `elem` Shell.getArgs cmd
 {-# INLINEABLE dl3014 #-}

--- a/src/Hadolint/Shell.hs
+++ b/src/Hadolint/Shell.hs
@@ -205,6 +205,9 @@ getArgsNoFlags args = map arg $ filter (notAFlagId . partId) (arguments args)
 hasFlag :: Text.Text -> Command -> Bool
 hasFlag flag Command {flags} = not $ null [f | CmdPart f _ <- flags, f == flag]
 
+countFlag :: Text.Text -> Command -> Int
+countFlag flag Command {flags} = length [ f | CmdPart f _ <- flags, f == flag ]
+
 hasAnyFlag :: [Text.Text] -> Command -> Bool
 hasAnyFlag fs Command {flags} = not $ null [f | CmdPart f _ <- flags, f `elem` fs]
 
@@ -217,9 +220,9 @@ dropFlagArg flagsToDrop Command {name, arguments, flags} = Command name filterdA
     idsToDrop = Set.fromList [getValueId fId arguments | CmdPart f fId <- flags, f `elem` flagsToDrop]
     filterdArgs = [arg | arg@(CmdPart _ aId) <- arguments, not (aId `Set.member` idsToDrop)]
 
--- | given a flag and a command, return list of arguments for that particulat
+-- | given a flag and a command, return list of arguments for that particular
 -- flag. E.g., if the command is `useradd -u 12345 luser` and this function is
--- called for the command `u`, it returns ["12345"].
+-- called for the flag `u`, it returns ["12345"].
 getFlagArg :: Text.Text -> Command -> [Text.Text]
 getFlagArg flag Command {arguments, flags} = extractArgs
   where

--- a/test/Hadolint/Rule/DL3014Spec.hs
+++ b/test/Hadolint/Rule/DL3014Spec.hs
@@ -13,12 +13,18 @@ spec = do
     it "apt-get auto yes" $ do
       ruleCatches "DL3014" "RUN apt-get install python"
       onBuildRuleCatches "DL3014" "RUN apt-get install python"
+
+    describe "Insufficient Quiet Levels" $ do
+      it "apt-get -q" $ do
+        ruleCatches "DL3014" "RUN apt-get install -q python"
+        onBuildRuleCatches "DL3014" "RUN apt-get install -q python"
+      it "apt-get --quiet" $ do
+        ruleCatches "DL3014" "RUN apt-get install --quiet python"
+        onBuildRuleCatches "DL3014" "RUN apt-get install -q python"
+
     it "apt-get yes shortflag" $ do
       ruleCatchesNot "DL3014" "RUN apt-get install -yq python"
       onBuildRuleCatchesNot "DL3014" "RUN apt-get install -yq python"
-    it "apt-get yes quiet level 2 implies -y" $ do
-      ruleCatchesNot "DL3014" "RUN apt-get install -qq python"
-      onBuildRuleCatchesNot "DL3014" "RUN apt-get install -qq python"
     it "apt-get yes different pos" $ do
       ruleCatchesNot "DL3014" "RUN apt-get install -y python"
       onBuildRuleCatchesNot "DL3014" "RUN apt-get install -y python"
@@ -31,3 +37,18 @@ spec = do
     it "apt-get with assume-yes" $ do
       ruleCatchesNot "DL3014" "RUN apt-get --assume-yes install python"
       onBuildRuleCatchesNot "DL3014" "RUN apt-get --assume-yes install python"
+
+    describe "Quiet level 2 implies assume-yes" $ do
+      it "apt-get -qq" $ do
+        ruleCatchesNot "DL3014" "RUN apt-get install -qq python"
+        onBuildRuleCatchesNot "DL3014" "RUN apt-get install -qq python"
+      it "apt-get -q -q" $ do
+        ruleCatchesNot "DL3014" "RUN apt-get install -q -q python"
+        onBuildRuleCatchesNot "DL3014" "RUN apt-get install -q -q python"
+      it "apt-get -q=2" $ do
+        ruleCatchesNot "DL3014" "RUN apt-get install -q=2 python"
+        onBuildRuleCatchesNot "DL3014" "RUN apt-get install -q=2 python"
+      it "apt-get --quiet --quiet" $ do
+        ruleCatchesNot "DL3014" "RUN apt-get install --quiet --quiet python"
+        onBuildRuleCatchesNot "DL3014"
+          "RUN apt-get install --quiet --quiet python"


### PR DESCRIPTION
`apt-get` can take the `--quiet` or `-q` argument to increase its quietness level. At the maximum of 2, this will also imply `assume-yes` i.e. the `-y` flag. Therefore if the necessary quietness level has been configured by command line parameters, DL3014 should not alert the user to the missing `-y` flag.

fixes: #911

Signed-off-by: Moritz Röhrich <moritz.rohrich@suse.com>

### How to verify it
Unittests are included. In any case, the following Dockerfile should no longer produce warning DL3014:

```Dockerfile
FROM debian:stable-slim
RUN apt-get update && apt-get install --quiet --quiet sl
```