### PR TITLE
fix: misidentification of pipenv (#366)

### DIFF
--- a/src/Hadolint/Shell.hs
+++ b/src/Hadolint/Shell.hs
@@ -241,6 +241,7 @@ isPipInstall cmd@(Command name _ _) = isStdPipInstall || isPythonPipInstall
   where
     isStdPipInstall =
       "pip" `Text.isPrefixOf` name
+        && not ("pipenv" `Text.isPrefixOf` name)
         && ["install"] `isInfixOf` getArgs cmd
     isPythonPipInstall =
       "python" `Text.isPrefixOf` name


### PR DESCRIPTION
### What I did

Check that when we detect `pip` it's not actually `pipenv`. This fixes #366.

### How I did it

Add an extra `&& not (…)` check.

### How to verify it

Run Hadolint on this Dockerfile:

```
FROM python:3.10
RUN pip install --no-cache-dir pipenv==2023.2.18 \
 && python3 -m venv /venv
RUN pipenv install --python 3.10 --keep-outdated --ignore-pipfile \
 && rm -rf /root/.cache/pipenv
```

It raises DL3013 on the current version of Hadolint and nothing on my fork.

(Caveat: I had to compile with a newer `base` package, but the change should be simple enough that it makes no difference.)