### PR TITLE
Improve parsing of gem install flag patterns to reduce false positives

### DIFF
--- a/src/Hadolint/Rule/DL3028.hs
+++ b/src/Hadolint/Rule/DL3028.hs
@@ -34,8 +34,15 @@ gems shell =
       not (Shell.cmdHasArgs "gem" ["-v"] cmd),
       not (Shell.cmdHasArgs "gem" ["--version"] cmd),
       not (Shell.cmdHasPrefixArg "gem" "--version=" cmd),
-      arg <- Shell.getArgsNoFlags cmd,
+      let args = Shell.getArgs cmd,
+      let argsUntilDoubleDash = takeWhile (/= "--") args,
+      arg <- removeOptions argsUntilDoubleDash,
       arg /= "install",
-      arg /= "i",
-      arg /= "--"
+      arg /= "i"
   ]
+  where
+    removeOptions [] = []
+    removeOptions (x : xs)
+      | x == "--" = removeOptions xs
+      | "-" `Text.isPrefixOf` x = removeOptions (drop 1 xs)
+      | otherwise = x : removeOptions xs

--- a/test/Hadolint/Rule/DL3028Spec.hs
+++ b/test/Hadolint/Rule/DL3028Spec.hs
@@ -39,6 +39,15 @@ spec = do
         it "does not warn on --version with =" $ do
           ruleCatchesNot "DL3028" "RUN gem install bundler --version='2.0.1'"
           onBuildRuleCatchesNot "DL3028" "RUN gem install bundler --version='2.0.1'"
-        it "does not warn on extra flags" $ do
+        it "does not warn when using extra flags with equal sign and double dashes" $ do
           ruleCatchesNot "DL3028" "RUN gem install bundler:2.0.1 -- --use-system-libraries=true"
           onBuildRuleCatchesNot "DL3028" "RUN gem install bundler:2.0.1 -- --use-system-libraries=true"
+        it "does not warn when using extra flags with double dashes" $ do
+          ruleCatchesNot "DL3028" "RUN gem install bundler:2.0.1 -- --use-system-libraries true"
+          onBuildRuleCatchesNot "DL3028" "RUN gem install bundler:2.0.1 -- --use-system-libraries true"
+        it "does not warn when using extra flags" $ do
+          ruleCatchesNot "DL3028" "RUN gem install bundler:2.0.1 --use-system-libraries true"
+          onBuildRuleCatchesNot "DL3028" "RUN gem install bundler:2.0.1 --use-system-libraries true"
+        it "does not warn when using extra flags with equal sign" $ do
+          ruleCatchesNot "DL3028" "RUN gem install bundler:2.0.1 --use-system-libraries=true"
+          onBuildRuleCatchesNot "DL3028" "RUN gem install bundler:2.0.1 --use-system-libraries=true"


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

### What I did
In Hadolint, there are several gem install flag patterns that result in false positives.

Warnings should not be displayed for the following patterns:

```dockerfile
RUN gem install bundler:2.0.1 -- --use-system-libraries true
RUN gem install bundler:2.0.1 --use-system-libraries true
RUN gem install bundler:2.0.1 --use-system-libraries=true
```

In this PR, I have made adjustments so that these patterns can also be parsed correctly.

### How I did it
I modified the processing to remove options and their subsequent arguments from the list of arguments.

### How to verify it
I have added tests related to the additional patterns.
