### PR TITLE
pre-commit: use new built-in go install

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,13 +1,20 @@
 ---
+- id: hadolint
+  name: Lint Dockerfiles
+  description: Runs hadolint to lint Dockerfiles
+  language: golang
+  types: ["dockerfile"]
+  entry: hadolint
+  minimum_pre_commit_version: 3.0.0
 - id: hadolint-docker
   name: Lint Dockerfiles
   description: Runs hadolint Docker image to lint Dockerfiles
   language: docker_image
   types: ["dockerfile"]
   entry: ghcr.io/hadolint/hadolint hadolint
-- id: hadolint
+- id: hadolint-system
   name: Lint Dockerfiles
-  description: Runs hadolint to lint Dockerfiles
+  description: Runs system-installed hadolint to lint Dockerfiles
   language: system
   types: ["dockerfile"]
   entry: hadolint


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->
fixes #886

### What I did

Use the new `language: golang` feature of pre-commit that install hadolint along other prec-ommit hooks.

### How I did it

See diff.

### How to verify it

This is used by [actionlint](https://github.com/rhysd/actionlint/blob/main/.pre-commit-hooks.yaml), which i use myself.