### PR TITLE
updated readme for clarity regarding alpine images

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,6 +286,14 @@ a container, use the following command:
 docker run --rm -i -v /your/path/to/hadolint.yaml:/.config/hadolint.yaml hadolint/hadolint < Dockerfile
 # OR
 docker run --rm -i -v /your/path/to/hadolint.yaml:/.config/hadolint.yaml ghcr.io/hadolint/hadolint < Dockerfile
+# OR on an alpine based image
+docker run --rm -i -v /your/path/to/hadolint.yaml:/root/.config/hadolint.yaml ghcr.io/hadolint/hadolint:2.12.0-alpine < Dockerfile
+```
+
+To check if the configuration file has been loaded correctly you may use the -V flag:
+
+```bash
+docker run --rm -i -v /path/to/hadolint.yaml:/root/.config/hadolint.yaml ghcr.io/hadolint/hadolint:2.12.0-alpine hadolint -V
 ```
 
 In addition to config files, Hadolint can be configured with environment


### PR DESCRIPTION
### What I did
Update the readme to reflect the fact that the default documented docker run command will not work on an alpine based image of hadolint, as the default path to the config is not working here. 

### How I did it
Simple update of the readme. I though about fixing this issue in the container image build of hadolint, but that still leaves older versions with the same issue. So you're now aware, the users have a correct readme. Maybe a simple symlink will be enough for future builds.

### How to verify it
Run the following commands and you'll see the first one will not have the configuration file loaded as hadolint is looking for environment variables which are not present in the alpine version:
docker run --rm -i -v /path/to/hadolint.yaml:/.config/hadolint.yaml ghcr.io/hadolint/hadolint:2.12.0-alpine hadolint -V
docker run --rm -i -v /path/to/hadolint.yaml:/root/.config/hadolint.yaml ghcr.io/hadolint/hadolint:2.12.0-alpine hadolint -V