### PR TITLE
Add release of Darwin arm64 binary

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -249,6 +249,7 @@ jobs:
       name: Set extension to .exe on Windows
       uses: allenevans/set-env@v3.0.0
       with:
+        ARCH: 'x86_64'
         EXT: '.exe'
 
     - name: Set binary OS name
@@ -265,6 +266,14 @@ jobs:
       name: Set binary OS name on Macos
       uses: allenevans/set-env@v3.0.0
       with:
+        ARCH: 'x86_64'
+        BINARY_OS: 'Darwin'
+
+    - if: matrix.os == 'macos-14'
+      name: Set binary OS name on Macos
+      uses: allenevans/set-env@v2.2.0
+      with:
+        ARCH: 'arm64'
         BINARY_OS: 'Darwin'
 
     - if: matrix.os == 'macos-14'


### PR DESCRIPTION
Now that there are M1-based runners for GitHub Actions (https://github.blog/changelog/2024-01-30-github-actions-introducing-the-new-m1-macos-runner-available-to-open-source/), add `arm64` as a binary to release.

Closes:

- https://github.com/hadolint/hadolint/issues/842
- https://github.com/hadolint/hadolint/issues/1004

CC @lorenzo 