### PR TITLE
Enable file-path-in-report flag for codeclimate formatters

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ Available options:
   -c,--config FILENAME     Path to the configuration file
   --file-path-in-report FILEPATHINREPORT
                            The file path referenced in the generated report.
-                           This only applies for the 'checkstyle' format and is
+                           This only applies for the 'checkstyle', 'codeclimate', and 'gitlab_codeclimate' formats and is
                            useful when running Hadolint with Docker to set the
                            correct file path.
   --no-fail                Don't exit with a failure status code when any rule

--- a/src/Hadolint/Config/Commandline.hs
+++ b/src/Hadolint/Config/Commandline.hs
@@ -75,7 +75,8 @@ parseCommandline =
             ( long "file-path-in-report"
                 <> metavar "FILEPATHINREPORT"
                 <> help "The file path referenced in the generated report.\
-                        \ This only applies for the 'checkstyle' format and is\
+                        \ This only applies for the 'checkstyle', 'codeclimate',\
+                        \ and 'gitlab_codeclimate' formats and is\
                         \ useful when running Hadolint with Docker to set the\
                         \ correct file path."
             )

--- a/src/Hadolint/Formatter.hs
+++ b/src/Hadolint/Formatter.hs
@@ -30,8 +30,8 @@ printResults format nocolor filePathInReport allResults =
   case format of
     Checkstyle -> FormatCheckstyle.printResults allResults filePathInReport
     Codacy -> FormatCodacy.printResults allResults
-    CodeclimateJson -> FormatCodeclimate.printResults allResults
-    GitLabCodeclimateJson -> FormatCodeclimate.printGitLabResults allResults
+    CodeclimateJson -> FormatCodeclimate.printResults allResults filePathInReport
+    GitLabCodeclimateJson -> FormatCodeclimate.printGitLabResults allResults filePathInReport
     Gnu -> FormatGnu.printResults allResults
     Json -> FormatJson.printResults allResults
     Sarif -> FormatSarif.printResults allResults

--- a/src/Hadolint/Formatter/Codeclimate.hs
+++ b/src/Hadolint/Formatter/Codeclimate.hs
@@ -89,14 +89,16 @@ errorToIssue err =
     line = unPos (sourceLine pos)
     column = unPos (sourceColumn pos)
 
-checkToIssue :: Text.Text -> CheckFailure -> Issue
-checkToIssue fileName CheckFailure {..} =
+checkToIssue :: Text.Text -> Maybe FilePath -> CheckFailure -> Issue
+checkToIssue fileName filePathInReport CheckFailure {..} =
   Issue
     { checkName = unRuleCode code,
       description = message,
-      location = LocLine fileName line,
+      location = LocLine reportFileName line,
       impact = severityText severity
     }
+  where
+    reportFileName = if null filePathInReport then fileName else getFilePath filePathInReport
 
 severityText :: DLSeverity -> Text.Text
 severityText severity =
@@ -117,23 +119,38 @@ issueToFingerprintIssue i =
       fingerprint = generateFingerprint i
     }
 
-formatResult :: (VisualStream s, TraversableStream s, ShowErrorComponent e) => Result s e -> Seq Issue
-formatResult (Result filename errors checks) = (errorToIssue <$> errors) <> (checkToIssue filename <$> checks)
+formatResult :: (VisualStream s, TraversableStream s, ShowErrorComponent e) => Result s e -> Maybe FilePath -> Seq Issue
+formatResult (Result filename errors checks) filePathInReport = (errorToIssue <$> errors) <> (checkToIssue filename filePathInReport <$> checks)
 
-formatGitLabResult :: (VisualStream s, TraversableStream s, ShowErrorComponent e) => Result s e -> Seq FingerprintIssue
-formatGitLabResult result = issueToFingerprintIssue <$> formatResult result
+formatGitLabResult :: 
+  (VisualStream s, TraversableStream s, ShowErrorComponent e) => 
+  Result s e -> Maybe FilePath ->
+  Seq FingerprintIssue
+formatGitLabResult result filePathInReport = issueToFingerprintIssue <$> (formatResult result filePathInReport)
 
-printResult :: (VisualStream s, TraversableStream s, ShowErrorComponent e) => Result s e -> IO ()
-printResult result = mapM_ output (formatResult result)
+printResult :: (VisualStream s, TraversableStream s, ShowErrorComponent e) => Result s e -> Maybe FilePath -> IO ()
+printResult result filePathInReport = mapM_ output (formatResult result filePathInReport)
   where
     output value = do
       B.putStr (encode value)
       B.putStr (B.singleton 0x00)
 
-printResults :: (VisualStream s, TraversableStream s, ShowErrorComponent e, Foldable f) => f (Result s e) -> IO ()
-printResults = mapM_ printResult
-
-printGitLabResults :: (Foldable f, VisualStream s, TraversableStream s, ShowErrorComponent e) => f (Result s e) -> IO ()
-printGitLabResults results = B.putStr . encode $ flattened
+printResults :: (VisualStream s, TraversableStream s, ShowErrorComponent e, Foldable f) => f (Result s e) -> Maybe FilePath -> IO ()
+printResults results filePathInReport = flattened
   where
-    flattened = Foldl.fold (Foldl.premap formatGitLabResult Foldl.mconcat) results
+    flattened = Foldl.fold (Foldl.premap printResult Foldl.mconcat) results filePathInReport
+
+printGitLabResults :: 
+  (Foldable f, VisualStream s, TraversableStream s, ShowErrorComponent e) =>
+  f (Result s e) -> Maybe FilePath ->
+  IO ()
+printGitLabResults results filePathInReport = B.putStr . encode $ flattened
+  where
+    flattened = Foldl.fold (Foldl.premap formatGitLabResult Foldl.mconcat) results filePathInReport
+
+getFilePath :: Maybe FilePath -> Text.Text 
+getFilePath Nothing = ""
+getFilePath (Just filePath) = toText [filePath]
+
+toText :: [FilePath] -> Text.Text 
+toText = foldMap Text.pack


### PR DESCRIPTION
Fixes #1016

### What I did
Add support for the `--file-path-in-report` flag for both the `codeclimate` and `gitlab_codeclimate` formats, similar to how `checkstyle` is handled.  Similar approaches may be able to used for other formatters but I kept the scope of this limited to the one.

### How I did it
I felt compelled to at least try my hand at this after submitting #1016 as it seemed straight forward enough.  This is based on how the existing `codeclimate` formatter handled the flag.  I had never so much as looked at Haskell prior to today, so maybe this is garbage.  Feel free to take it, leave it, or modify it.

### How to verify it
Run with both `-f gitlab_codeclimate` and `--file-path-in-report /some/path/to/Dockerfile` arguments and observe that the output path matches the `--file-path-in-report` value.
