### PR TITLE
Ignore unsatisfiable shellcheck error 1091

### DIFF
--- a/src/Hadolint/Shell.hs
+++ b/src/Hadolint/Shell.hs
@@ -79,7 +79,8 @@ shellcheck (ShellOpts sh env) (ParsedShell txt _ _) =
     script = Text.unpack $ "#!" <> extractShell sh <> "\n" <> printVars <> txt
     exclusions =
       [ 2187, -- exclude the warning about the ash shell not being supported
-        1090 -- requires a directive (shell comment) that can't be expressed in a Dockerfile
+        1090, -- requires a directive (shell comment) that can't be expressed in a Dockerfile
+        1091 -- requires a directive (shell comment) that can't be expressed in a Dockerfile
       ]
 
     extractShell s = fromMaybe "" (listToMaybe . Text.words $ s)


### PR DESCRIPTION
This check is related to SC1090 which is already skipped in PR #344 and background in issue #343.

### What I did

Add SC1091 to list of shellcheck entries to ignore.

### Why I did it

Because SC1090 and SC1091 are essentially the same and SC1090 is already excluded.

### How I did it

Simple addition to existing list.

### How to verify it

Use this `Dockerfile`

```dockerfile
FROM alpine:3
RUN . /etc/sysconfig/somefile
```

before

```sh
$ hadolint Dockerfile
Dockerfile:2 SC1091 info: Not following: File not included in mock.
```

after

```sh
~/.local/bin/hadolint Dockerfile ; echo $?
0
```
