### PR TITLE
DL3048 accepting LABEL keys that contain underscore(s) or slash(es)

### DIFF
--- a/src/Hadolint/Rule/DL3048.hs
+++ b/src/Hadolint/Rule/DL3048.hs
@@ -36,4 +36,4 @@ hasConsecutiveSeparators :: Text.Text -> Bool
 hasConsecutiveSeparators l = ".." `Text.isInfixOf` l || "--" `Text.isInfixOf` l
 
 validChars :: String
-validChars = ['0'..'9'] ++ ['a' .. 'z'] ++ ['.', '-']
+validChars = ['0'..'9'] ++ ['a' .. 'z'] ++ ['.', '-', '_', '/']


### PR DESCRIPTION
Underscores and slashes should be accepted as part of a LABEL key. See  https://docs.docker.com/engine/manage-resources/labels/#key-format-recommendations

<!--
If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

### What I did

### How I did it

### How to verify it
