### PR TITLE
DL3026 must warn on non allowed registries at `COPY --from` instructions

### DIFF
--- a/test/Hadolint/Rule/DL3026Spec.hs
+++ b/test/Hadolint/Rule/DL3026Spec.hs
@@ -86,3 +86,11 @@ spec = do
       let ?config = def { allowedRegistries = ["*"] }
 
       ruleCatchesNot "DL3026" $ Text.unlines dockerFile
+
+    it "warn on non-allowed registry using COPY --from" $ do
+      let dockerFile =
+            [ "COPY --from not-allowed.org/debian /tmp /tmp"
+            ]
+      let ?config = def { allowedRegistries = ["allowed.com"] }
+
+      ruleCatches "DL3026" $ Text.unlines dockerFile


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

Fixes #1054.

### What I did

### How I did it

### How to verify it
