### PR TITLE
Improve DL3009 rule to properly handle all apt-based package managers

### DIFF
--- a/src/Hadolint/Rule/DL3009.hs
+++ b/src/Hadolint/Rule/DL3009.hs
@@ -28,7 +28,7 @@ dl3009 = veryCustomRule check (emptyState Empty) markFailures
   where
     code = "DL3009"
     severity = DLInfoC
-    message = "Delete the apt-get lists after installing something"
+    message = "Delete the apt lists (/var/lib/apt/lists) after installing something"
 
     check line st (From from) = st |> modify (rememberStage line from)
     check line st (Run (RunArgs args flags))
@@ -76,8 +76,12 @@ forgotToCleanup args
       any (Shell.cmdHasArgs "rm" ["-rf", "/var/lib/apt/lists/*"]) (Shell.presentCommands args)
 
 hasUpdate :: Shell.ParsedShell -> Bool
-hasUpdate args =
-  any (Shell.cmdHasArgs "apt-get" ["update"]) (Shell.presentCommands args)
+hasUpdate args = any isPackageUpdate (Shell.presentCommands args)
+  where
+    isPackageUpdate cmd =
+      Shell.cmdHasArgs "apt" ["update"] cmd ||
+      Shell.cmdHasArgs "apt-get" ["update"] cmd ||
+      Shell.cmdHasArgs "aptitude" ["update"] cmd
 
 disabledDockerClean :: Shell.ParsedShell -> Bool
 disabledDockerClean args

--- a/test/Hadolint/Rule/DL3009Spec.hs
+++ b/test/Hadolint/Rule/DL3009Spec.hs
@@ -10,7 +10,7 @@ spec :: SpecWith ()
 spec = do
   let ?config = def
 
-  describe "DL3009 - Delete the apt-get lists after installing something." $ do
+  describe "DL3009 - Delete the apt lists (/var/lib/apt/lists) after installing something." $ do
     it "apt-get no cleanup" $
       let dockerFile =
             [ "FROM scratch",
@@ -131,3 +131,39 @@ spec = do
        in do
             ruleCatches "DL3009" $ Text.unlines dockerFile
             onBuildRuleCatches "DL3009" $ Text.unlines dockerFile
+
+    it "apt no cleanup" $
+      let dockerFile =
+            [ "FROM scratch",
+              "RUN apt update && apt install python"
+            ]
+       in do
+            ruleCatches "DL3009" $ Text.unlines dockerFile
+            onBuildRuleCatches "DL3009" $ Text.unlines dockerFile
+
+    it "apt cleanup" $
+      let dockerFile =
+            [ "FROM scratch",
+              "RUN apt update && apt install python && rm -rf /var/lib/apt/lists/*"
+            ]
+       in do
+            ruleCatchesNot "DL3009" $ Text.unlines dockerFile
+            onBuildRuleCatchesNot "DL3009" $ Text.unlines dockerFile
+
+    it "aptitude no cleanup" $
+      let dockerFile =
+            [ "FROM scratch",
+              "RUN aptitude update && aptitude install python"
+            ]
+       in do
+            ruleCatches "DL3009" $ Text.unlines dockerFile
+            onBuildRuleCatches "DL3009" $ Text.unlines dockerFile
+
+    it "aptitude cleanup" $
+      let dockerFile =
+            [ "FROM scratch",
+              "RUN aptitude update && aptitude install python && rm -rf /var/lib/apt/lists/*"
+            ]
+       in do
+            ruleCatchesNot "DL3009" $ Text.unlines dockerFile
+            onBuildRuleCatchesNot "DL3009" $ Text.unlines dockerFile


### PR DESCRIPTION
### What I did

Improved DL3009 rule to properly handle all apt-based package managers:
- Added support for apt and aptitude in hasUpdate function
- Updated error message to be more specific about tools and path

### How I did it

1. Enhanced the hasUpdate function to detect update operations from apt and aptitude commands
2. Updated the error message to clearly specify which package managers it applies to and the exact path that needs cleaning

### How to verify it

Create a test Dockerfile with different apt-based package managers:

```dockerfile
FROM ubuntu:20.04

# This will trigger DL3009 (apt-get)
RUN apt-get update && apt-get install -y python3

# This will also trigger DL3009 now (apt)
RUN apt update && apt install -y curl

# This will also trigger DL3009 now (aptitude)
RUN aptitude update && aptitude install -y wget

# This will not trigger DL3009 (proper cleanup)
RUN apt-get update && apt-get install -y git && rm -rf /var/lib/apt/lists/*
```

Run hadolint on the file:
```bash
hadolint Dockerfile
```

The first three RUN instructions should now trigger the DL3009 warning with the updated message.

Fix #1073