### PR TITLE
Fix README to match real --failure-threshold behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ Available options:
                            ignore=DLxxxx`
   -t,--failure-threshold THRESHOLD
                            Exit with failure code only when rules with a
-                           severity equal to or above THRESHOLD are violated.
+                           severity above THRESHOLD are violated.
                            Accepted values: [error | warning | info | style |
                            ignore | none] (default: info)
 ```


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

### What I did
Fixed docs regarding --failure-threshold param

### How to verify it
Tested different values and looke at docs at https://github.com/hadolint/hadolint/blob/master/contrib/hadolint.json#L22