### PR TITLE
fix(DL3041): Prevent false negatives for packages which include a dash in their package name

### DIFF
--- a/test/Hadolint/Rule/DL3041Spec.hs
+++ b/test/Hadolint/Rule/DL3041Spec.hs
@@ -14,6 +14,10 @@ spec = do
       ruleCatches "DL3041" "RUN dnf install -y tomcat && dnf clean all"
       ruleCatches "DL3041" "RUN microdnf install -y tomcat && microdnf clean all"
       onBuildRuleCatches "DL3041" "RUN dnf install -y tomcat && dnf clean all"
+    it "not ok without dnf version pinning - package name with `-`" $ do
+      ruleCatches "DL3041" "RUN dnf install -y rpm-sign && dnf clean all"
+      ruleCatches "DL3041" "RUN microdnf install -y rpm-sign && microdnf clean all"
+      onBuildRuleCatches "DL3041" "RUN dnf install -y rpm-sign && dnf clean all"
     it "ok with dnf version pinning" $ do
       ruleCatchesNot "DL3041" "RUN dnf install -y tomcat-9.0.1 && dnf clean all"
       ruleCatchesNot "DL3041" "RUN microdnf install -y tomcat-9.0.1 && microdnf clean all"
@@ -21,6 +25,13 @@ spec = do
       onBuildRuleCatchesNot "DL3041" "RUN dnf install -y tomcat-9.0.1 && dnf clean all"
       onBuildRuleCatchesNot "DL3041" "RUN microdnf install -y tomcat-9.0.1 && microdnf clean all"
       onBuildRuleCatchesNot "DL3041" "RUN notdnf install tomcat"
+    it "ok with dnf version pinning - package name with `-`" $ do
+      ruleCatchesNot "DL3041" "RUN dnf install -y rpm-sign-4.16.1.3 && dnf clean all"
+      ruleCatchesNot "DL3041" "RUN microdnf install -y rpm-sign-4.16.1.3 && microdnf clean all"
+      ruleCatchesNot "DL3041" "RUN notdnf install rpm-sign"
+      onBuildRuleCatchesNot "DL3041" "RUN dnf install -y rpm-sign-4.16.1.3 && dnf clean all"
+      onBuildRuleCatchesNot "DL3041" "RUN microdnf install -y rpm-sign-4.16.1.3 && microdnf clean all"
+      onBuildRuleCatchesNot "DL3041" "RUN notdnf install rpm-sign"
     it "not ok without dnf version pinning - modules" $ do
       ruleCatches "DL3041" "RUN dnf module install -y tomcat && dnf clean all"
       ruleCatches "DL3041" "RUN microdnf module install -y tomcat && microdnf clean all"


### PR DESCRIPTION
### What I did
Prevent false negatives for packages which include a dash in their package name

### How I did it
Tries to validate presence of a version based on the following assumptions:
- At least one "-" must be present
- All dash-separated parts after the first must contain only valid version characters (according to Fedora Versioning Guidelines)
- At least one dash-separated part after the first must start with a digit

### How to verify it
Unit tests included

Fixes #1002

Please note that this is my first time writing Haskell, so please suggest changes if there are better ways to do this.