### PR TITLE
DL3041, DL3033: Handle RPM package epoch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ stack.yaml.lock
 
 #cabal
 dist-newstyle
+dist
 
 # travis wait is generating log in PWD
 travis_wait_*.log

--- a/src/Hadolint/Rule/DL3033.hs
+++ b/src/Hadolint/Rule/DL3033.hs
@@ -4,6 +4,7 @@ import qualified Data.Text as Text
 import Hadolint.Rule
 import qualified Hadolint.Shell as Shell
 import Language.Docker.Syntax
+import Data.Char (isDigit, isAsciiUpper, isAsciiLower)
 
 
 rule :: Rule Shell.ParsedShell
@@ -32,8 +33,30 @@ yumPackages args =
   ]
 
 packageVersionFixed :: Text.Text -> Bool
-packageVersionFixed package =
-  "-" `Text.isInfixOf` package || ".rpm" `Text.isSuffixOf` package
+packageVersionFixed package
+  | length parts <= 1 = False  -- No dashes, definitively no version
+  | ".rpm" `Text.isSuffixOf` package = True  -- rpm files always have a version
+  | otherwise = isVersionLike $ drop 1 parts
+  where
+    parts = Text.splitOn "-" package
+
+isVersionLike :: [Text.Text] -> Bool
+isVersionLike parts =
+  case parts of
+    [] -> False  -- No parts after splitting by hyphen
+    _ -> all partIsValid parts && any partStartsWithDigit parts
+  where
+    partIsValid part = Text.all isVersionChar part
+    partStartsWithDigit part = case Text.uncons part of
+                                 Just (c, _) -> isDigit c
+                                 Nothing -> False -- Empty Text
+
+isVersionChar :: Char -> Bool
+isVersionChar c =
+  isDigit c
+    || isAsciiUpper c
+    || isAsciiLower c
+    || c `elem` ['.', '~', '^', '_', ':']
 
 yumModules :: Shell.ParsedShell -> [Text.Text]
 yumModules args =

--- a/src/Hadolint/Rule/DL3041.hs
+++ b/src/Hadolint/Rule/DL3041.hs
@@ -54,7 +54,11 @@ isVersionLike parts =
                                  Nothing -> False -- Empty Text
 
 isVersionChar :: Char -> Bool
-isVersionChar c = isDigit c || isAsciiUpper c || isAsciiLower c || c `elem` ['.', '~', '^', '_']
+isVersionChar c =
+  isDigit c
+    || isAsciiUpper c
+    || isAsciiLower c
+    || c `elem` ['.', '~', '^', '_', ':']
 
 dnfModules :: Shell.ParsedShell -> [Text.Text]
 dnfModules args =

--- a/test/Hadolint/Rule/DL3033Spec.hs
+++ b/test/Hadolint/Rule/DL3033Spec.hs
@@ -13,14 +13,25 @@ spec = do
     it "not ok without yum version pinning" $ do
       ruleCatches "DL3033" "RUN yum install -y tomcat && yum clean all"
       onBuildRuleCatches "DL3033" "RUN yum install -y tomcat && yum clean all"
+
     it "ok with yum version pinning" $ do
       ruleCatchesNot "DL3033" "RUN yum install -y tomcat-9.2 && yum clean all"
       ruleCatchesNot "DL3033" "RUN bash -c `# not even a yum command`"
       onBuildRuleCatchesNot "DL3033" "RUN yum install -y tomcat-9.2 && yum clean all"
       onBuildRuleCatchesNot "DL3033" "RUN bash -c `# not even a yum command`"
+
+    it "ok with yum version pinning - version contains epoch" $ do
+      ruleCatchesNot "DL3033" "RUN yum install -y openssl-1:1.1.1k"
+      onBuildRuleCatchesNot "DL3033" "RUN yum install -y openssl-1:1.1.1k"
+
+    it "ok with yum version pinning - package name contains `-`" $ do
+      ruleCatchesNot "DL3033" "RUN yum install -y rpm-sign-4.16.1.3"
+      onBuildRuleCatchesNot "DL3033" "RUN yum install -y rpm-sign-4.16.1.3"
+
     it "not ok without yum version pinning - modules" $ do
       ruleCatches "DL3033" "RUN yum module install -y tomcat && yum clean all"
       onBuildRuleCatches "DL3033" "RUN yum module install -y tomcat && yum clean all"
+
     it "ok with yum version pinning - modules" $ do
       ruleCatchesNot "DL3033" "RUN yum module install -y tomcat:9 && yum clean all"
       ruleCatchesNot "DL3033" "RUN bash -c `# not even a yum command`"

--- a/test/Hadolint/Rule/DL3041Spec.hs
+++ b/test/Hadolint/Rule/DL3041Spec.hs
@@ -10,32 +10,48 @@ spec = do
   let ?config = def
 
   describe "DL3041 - Specify version with `dnf install -y <package>-<version>`" $ do
+
     it "not ok without dnf version pinning" $ do
       ruleCatches "DL3041" "RUN dnf install -y tomcat && dnf clean all"
       ruleCatches "DL3041" "RUN microdnf install -y tomcat && microdnf clean all"
       onBuildRuleCatches "DL3041" "RUN dnf install -y tomcat && dnf clean all"
+
     it "not ok without dnf version pinning - package name with `-`" $ do
       ruleCatches "DL3041" "RUN dnf install -y rpm-sign && dnf clean all"
       ruleCatches "DL3041" "RUN microdnf install -y rpm-sign && microdnf clean all"
       onBuildRuleCatches "DL3041" "RUN dnf install -y rpm-sign && dnf clean all"
+
     it "ok with dnf version pinning" $ do
       ruleCatchesNot "DL3041" "RUN dnf install -y tomcat-9.0.1 && dnf clean all"
       ruleCatchesNot "DL3041" "RUN microdnf install -y tomcat-9.0.1 && microdnf clean all"
-      ruleCatchesNot "DL3041" "RUN notdnf install tomcat"
       onBuildRuleCatchesNot "DL3041" "RUN dnf install -y tomcat-9.0.1 && dnf clean all"
       onBuildRuleCatchesNot "DL3041" "RUN microdnf install -y tomcat-9.0.1 && microdnf clean all"
+
+    it "ok with version pinning if command is not `dnf` or `microdnf`" $ do
+      ruleCatchesNot "DL3041" "RUN notdnf install openssl-1:1.1.1k"
+      onBuildRuleCatchesNot "DL3041" "RUN notdnf install openssl-1:1.1.1k"
+
+    it "ok without version pinning if command is not `dnf` or `microdnf`" $ do
+      ruleCatchesNot "DL3041" "RUN notdnf install tomcat"
       onBuildRuleCatchesNot "DL3041" "RUN notdnf install tomcat"
+
     it "ok with dnf version pinning - package name with `-`" $ do
       ruleCatchesNot "DL3041" "RUN dnf install -y rpm-sign-4.16.1.3 && dnf clean all"
       ruleCatchesNot "DL3041" "RUN microdnf install -y rpm-sign-4.16.1.3 && microdnf clean all"
-      ruleCatchesNot "DL3041" "RUN notdnf install rpm-sign"
       onBuildRuleCatchesNot "DL3041" "RUN dnf install -y rpm-sign-4.16.1.3 && dnf clean all"
       onBuildRuleCatchesNot "DL3041" "RUN microdnf install -y rpm-sign-4.16.1.3 && microdnf clean all"
-      onBuildRuleCatchesNot "DL3041" "RUN notdnf install rpm-sign"
+
+    it "ok with dnf version pinning - package version with epoch" $ do
+      ruleCatchesNot "DL3041" "RUN dnf install -y openssl-1:1.1.1k"
+      ruleCatchesNot "DL3041" "RUN microdnf install -y openssl-1:1.1.1k"
+      onBuildRuleCatchesNot "DL3041" "RUN dnf install -y openssl-1:1.1.1k"
+      onBuildRuleCatchesNot "DL3041" "RUN microdnf install -y openssl-1:1.1.1k"
+
     it "not ok without dnf version pinning - modules" $ do
       ruleCatches "DL3041" "RUN dnf module install -y tomcat && dnf clean all"
       ruleCatches "DL3041" "RUN microdnf module install -y tomcat && microdnf clean all"
       onBuildRuleCatches "DL3041" "RUN dnf module install -y tomcat && dnf clean all"
+
     it "ok with dnf version pinning - modules" $ do
       ruleCatchesNot "DL3041" "RUN dnf module install -y tomcat:9 && dnf clean all"
       ruleCatchesNot "DL3041" "RUN microdnf module install -y tomcat:9 && microdnf clean all"


### PR DESCRIPTION
In Fedora, RHEL and similar distributions, packages may have an epoch prefixed to their version. This is an integer separated by a colon from the actual version number. The epoch is used to make all packages sortable, regardless of whether the upstream project uses sortable version identifiers.
To deal with this, in Hadolint we must accept that a dnf or yum package may contain a colon in their version number.

related-to: hadolint/hadolint#1117