### PR TITLE
DL3009: Allow either cache or tmpfs mounts

### DIFF
--- a/src/Hadolint/Rule/DL3009.hs
+++ b/src/Hadolint/Rule/DL3009.hs
@@ -102,11 +102,12 @@ disabledDockerClean args
 
 hasCacheDirectory :: Text.Text -> RunFlags -> Bool
 hasCacheDirectory dir RunFlags { mount } =
-  not ( null $ Set.filter (isCacheMount dir) mount)
+  not ( null $ Set.filter (isCacheOrTmpfsMount dir) mount)
 
-isCacheMount :: Text.Text -> RunMount -> Bool
-isCacheMount dir (CacheMount CacheOpts {cTarget = TargetPath {unTargetPath = t}}) = dir `Text.isPrefixOf` t
-isCacheMount _ _ = False
+isCacheOrTmpfsMount :: Text.Text -> RunMount -> Bool
+isCacheOrTmpfsMount dir (CacheMount CacheOpts {cTarget = TargetPath {unTargetPath = t}}) = dir `Text.isPrefixOf` t
+isCacheOrTmpfsMount dir (TmpfsMount TmpOpts {tTarget = TargetPath {unTargetPath = t}}) = dir `Text.isPrefixOf` t
+isCacheOrTmpfsMount _ _ = False
 
 -- | Even though dockerfiles without a FROM are not valid, we still want to provide some feedback for this rule
 -- so we pretend there is a base image at the start of the file if there is none

--- a/test/Hadolint/Rule/DL3009Spec.hs
+++ b/test/Hadolint/Rule/DL3009Spec.hs
@@ -132,6 +132,50 @@ spec = do
             ruleCatches "DL3009" $ Text.unlines dockerFile
             onBuildRuleCatches "DL3009" $ Text.unlines dockerFile
 
+    it "don't warn: tmpfs mount to apt cache and lists directory" $
+      let dockerFile =
+            [ "RUN \\",
+              "  --mount=type=tmpfs,target=/var/cache/apt \\",
+              "  --mount=type=tmpfs,target=/var/lib/apt \\",
+              "  apt-get update"
+            ]
+       in do
+            ruleCatchesNot "DL3009" $ Text.unlines dockerFile
+            onBuildRuleCatchesNot "DL3009" $ Text.unlines dockerFile
+
+    it "don't warn: tmpfs mount to apt cache and cache mount to lists directory" $
+      let dockerFile =
+            [ "RUN \\",
+              "  --mount=type=tmpfs,target=/var/cache/apt \\",
+              "  --mount=type=cache,target=/var/lib/apt \\",
+              "  apt-get update"
+            ]
+       in do
+            ruleCatchesNot "DL3009" $ Text.unlines dockerFile
+            onBuildRuleCatchesNot "DL3009" $ Text.unlines dockerFile
+
+    it "don't warn: cache mount to apt cache and tmpfs mount to lists directory" $
+      let dockerFile =
+            [ "RUN \\",
+              "  --mount=type=cache,target=/var/cache/apt \\",
+              "  --mount=type=tmpfs,target=/var/lib/apt \\",
+              "  apt-get update"
+            ]
+       in do
+            ruleCatchesNot "DL3009" $ Text.unlines dockerFile
+            onBuildRuleCatchesNot "DL3009" $ Text.unlines dockerFile
+
+    it "don't warn: cache mount to apt cache and lists directory" $
+      let dockerFile =
+            [ "RUN \\",
+              "  --mount=type=cache,target=/var/cache/apt \\",
+              "  --mount=type=cache,target=/var/lib/apt \\",
+              "  apt-get update"
+            ]
+       in do
+            ruleCatchesNot "DL3009" $ Text.unlines dockerFile
+            onBuildRuleCatchesNot "DL3009" $ Text.unlines dockerFile
+
     it "apt no cleanup" $
       let dockerFile =
             [ "FROM scratch",


### PR DESCRIPTION
Allow apt cache and lists directories to be either cache or tmpfs mounts without warning.

DL3009 warns if apt cache or list data is kept unnecessarily in the container image, as this increases the image size. There are several ways to avoid this: 1) remove the cache and lists directories after use, 2) mount a cache from the host to these directories and 3) mount a tmpfs from the host to the directories. This change modifies the DL3009 rule such that it won't trigger a warning if the a mount of type tmpfs is used for either the cache or lists directory.

related-to: hadolint/hadolint#1095
