### PR TITLE
DL3041, DL3033: Handle RPM package with plus sign

### DIFF
--- a/src/Hadolint/Rule/DL3033.hs
+++ b/src/Hadolint/Rule/DL3033.hs
@@ -56,7 +56,7 @@ isVersionChar c =
   isDigit c
     || isAsciiUpper c
     || isAsciiLower c
-    || c `elem` ['.', '~', '^', '_', ':']
+    || c `elem` ['.', '~', '^', '_', ':', '+']
 
 yumModules :: Shell.ParsedShell -> [Text.Text]
 yumModules args =

--- a/src/Hadolint/Rule/DL3041.hs
+++ b/src/Hadolint/Rule/DL3041.hs
@@ -58,7 +58,7 @@ isVersionChar c =
   isDigit c
     || isAsciiUpper c
     || isAsciiLower c
-    || c `elem` ['.', '~', '^', '_', ':']
+    || c `elem` ['.', '~', '^', '_', ':', '+']
 
 dnfModules :: Shell.ParsedShell -> [Text.Text]
 dnfModules args =

--- a/test/Hadolint/Rule/DL3033Spec.hs
+++ b/test/Hadolint/Rule/DL3033Spec.hs
@@ -28,6 +28,10 @@ spec = do
       ruleCatchesNot "DL3033" "RUN yum install -y rpm-sign-4.16.1.3"
       onBuildRuleCatchesNot "DL3033" "RUN yum install -y rpm-sign-4.16.1.3"
 
+    it "ok with yum version pinning - package name contains `-` and `+`" $ do
+      ruleCatchesNot "DL3033" "RUN yum install -y gcc-c++-1.1.1"
+      onBuildRuleCatchesNot "DL3033" "RUN yum install -y gcc-c++-1.1.1"
+
     it "not ok without yum version pinning - modules" $ do
       ruleCatches "DL3033" "RUN yum module install -y tomcat && yum clean all"
       onBuildRuleCatches "DL3033" "RUN yum module install -y tomcat && yum clean all"

--- a/test/Hadolint/Rule/DL3041Spec.hs
+++ b/test/Hadolint/Rule/DL3041Spec.hs
@@ -41,6 +41,12 @@ spec = do
       onBuildRuleCatchesNot "DL3041" "RUN dnf install -y rpm-sign-4.16.1.3 && dnf clean all"
       onBuildRuleCatchesNot "DL3041" "RUN microdnf install -y rpm-sign-4.16.1.3 && microdnf clean all"
 
+    it "ok with dnf version pinning - package name with `-` and `+`" $ do
+      ruleCatchesNot "DL3041" "RUN dnf install -y gcc-c++-1.1.1"
+      ruleCatchesNot "DL3041" "RUN microdnf install -y gcc-c++-1.1.1"
+      onBuildRuleCatchesNot "DL3041" "RUN dnf install -y gcc-c++-1.1.1"
+      onBuildRuleCatchesNot "DL3041" "RUN microdnf install -y gcc-c++-1.1.1"
+
     it "ok with dnf version pinning - package version with epoch" $ do
       ruleCatchesNot "DL3041" "RUN dnf install -y openssl-1:1.1.1k"
       ruleCatchesNot "DL3041" "RUN microdnf install -y openssl-1:1.1.1k"


### PR DESCRIPTION
**What I did**
Added to Hadolint rule DL3041 and DL3033 to allow plus signs for a.) package names which contain a hyphen and b.) versioning.

**How I did it**
Updated DL3033.hs `isVersionChar` allowable characters to allow '+'
Updated DL3041.hs `isVersionChar` allowable characters '+'
Added tests to DL3033Spec.hs for package name with hyphen and plus sign.
Added tests to DL3041Spec.hs for package name with hyphen and plus sign.

**How to verify it**
Unit Tests:
All unit tests pass successfully

