### PR TITLE
Allow version pinning with variables in yum and dnf

### DIFF
--- a/src/Hadolint/Rule/DL3033.hs
+++ b/src/Hadolint/Rule/DL3033.hs
@@ -60,7 +60,7 @@ isVersionChar c =
     || c `elem` ['.', '~', '^', '_', ':', '+', '$', '{', '}']
 
 isVariableStartChar :: Char -> Bool
-isVariableStartChar c = c `elem` ['$']
+isVariableStartChar c = c == '$'
 
 yumModules :: Shell.ParsedShell -> [Text.Text]
 yumModules args =

--- a/src/Hadolint/Rule/DL3033.hs
+++ b/src/Hadolint/Rule/DL3033.hs
@@ -44,19 +44,23 @@ isVersionLike :: [Text.Text] -> Bool
 isVersionLike parts =
   case parts of
     [] -> False  -- No parts after splitting by hyphen
-    _ -> all partIsValid parts && any partStartsWithDigit parts
+    _ -> all partIsValid parts && any partStartsWithDigitOrVariable parts
   where
     partIsValid = Text.all isVersionChar
-    partStartsWithDigit part = case Text.uncons part of
-                                 Just (c, _) -> isDigit c
-                                 Nothing -> False -- Empty Text
+    partStartsWithDigitOrVariable part =
+      case Text.uncons part of
+        Just (c, _) -> isDigit c || isVariableStartChar c
+        Nothing -> False -- Empty Text
 
 isVersionChar :: Char -> Bool
 isVersionChar c =
   isDigit c
     || isAsciiUpper c
     || isAsciiLower c
-    || c `elem` ['.', '~', '^', '_', ':', '+']
+    || c `elem` ['.', '~', '^', '_', ':', '+', '$', '{', '}']
+
+isVariableStartChar :: Char -> Bool
+isVariableStartChar c = c `elem` ['$']
 
 yumModules :: Shell.ParsedShell -> [Text.Text]
 yumModules args =

--- a/src/Hadolint/Rule/DL3041.hs
+++ b/src/Hadolint/Rule/DL3041.hs
@@ -62,7 +62,7 @@ isVersionChar c =
     || c `elem` ['.', '~', '^', '_', ':', '+', '$', '{', '}']
 
 isVariableStartChar :: Char -> Bool
-isVariableStartChar c = c `elem` ['$']
+isVariableStartChar c = c == '$'
 
 dnfModules :: Shell.ParsedShell -> [Text.Text]
 dnfModules args =

--- a/src/Hadolint/Rule/DL3041.hs
+++ b/src/Hadolint/Rule/DL3041.hs
@@ -45,20 +45,24 @@ packageVersionFixed package
 isVersionLike :: [Text.Text] -> Bool
 isVersionLike parts =
   case parts of
-    [] -> False  -- No parts after splitting by hyphen
-    _ -> all partIsValid parts && any partStartsWithDigit parts
+    [] -> False -- No parts after splitting by hyphen
+    _ -> all partIsValid parts && any partStartsWithDigitOrVariable parts
   where
     partIsValid = Text.all isVersionChar
-    partStartsWithDigit part = case Text.uncons part of
-                                 Just (c, _) -> isDigit c
-                                 Nothing -> False -- Empty Text
+    partStartsWithDigitOrVariable part =
+      case Text.uncons part of
+        Just (c, _) -> isDigit c || isVariableStartChar c
+        Nothing -> False -- Empty Text
 
 isVersionChar :: Char -> Bool
 isVersionChar c =
   isDigit c
     || isAsciiUpper c
     || isAsciiLower c
-    || c `elem` ['.', '~', '^', '_', ':', '+']
+    || c `elem` ['.', '~', '^', '_', ':', '+', '$', '{', '}']
+
+isVariableStartChar :: Char -> Bool
+isVariableStartChar c = c `elem` ['$']
 
 dnfModules :: Shell.ParsedShell -> [Text.Text]
 dnfModules args =

--- a/test/Hadolint/Rule/DL3033Spec.hs
+++ b/test/Hadolint/Rule/DL3033Spec.hs
@@ -41,3 +41,10 @@ spec = do
       ruleCatchesNot "DL3033" "RUN bash -c `# not even a yum command`"
       onBuildRuleCatchesNot "DL3033" "RUN yum module install -y tomcat:9 && yum clean all"
       onBuildRuleCatchesNot "DL3033" "RUN bash -c `# not even a yum command`"
+
+    it "ok with yum version pinning via shell variable" $ do
+      ruleCatchesNot "DL3033" "RUN yum install -y \"git-core-${GIT_VER}\" && yum clean all"
+      ruleCatchesNot "DL3033" "RUN yum install -y \"which-${WHICH_VERSION}\" && yum clean all"
+      ruleCatchesNot "DL3033" "RUN yum install -y \"rpm-sign-${VERSION}\" && yum clean all"
+      ruleCatchesNot "DL3033" "RUN yum install -y tomcat-$VERSION && yum clean all"
+      onBuildRuleCatchesNot "DL3033" "RUN yum install -y \"git-core-${GIT_VER}\" && yum clean all"

--- a/test/Hadolint/Rule/DL3041Spec.hs
+++ b/test/Hadolint/Rule/DL3041Spec.hs
@@ -72,3 +72,10 @@ spec = do
       ruleCatchesNot "DL3041" "RUN dnf group install -y \"Development Tools\" && dnf clean all"
       ruleCatchesNot "DL3041" "RUN microdnf group install -y \"Development Tools\" && microdnf clean all"
       onBuildRuleCatchesNot "DL3041" "RUN dnf -y group install \"Development Tools\""
+
+    it "ok with dnf version pinning via shell variable" $ do
+      ruleCatchesNot "DL3041" "RUN dnf install -y \"git-core-${GIT_VER}\" && dnf clean all"
+      ruleCatchesNot "DL3041" "RUN dnf install -y \"rpm-sign-${VERSION}\" && dnf clean all"
+      ruleCatchesNot "DL3041" "RUN dnf install -y tomcat-$VERSION && dnf clean all"
+      ruleCatchesNot "DL3041" "RUN microdnf install -y \"git-core-${GIT_VER}\" && microdnf clean all"
+      onBuildRuleCatchesNot "DL3041" "RUN dnf install -y \"git-core-${GIT_VER}\" && dnf clean all"


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

### What I did

Added support for variable expansion via `$VAR` and `${VAR}` in the package parsing, like `git-${GIT_VERSION}`. This assumes that variable holds a version, which is the most common use-case:

```dockerfile
ARG GIT_VER=2.51.0-2.fc42
RUN dnf install -y "git-core-${GIT_VER}"
```

### How I did it

It is currently required for one of the parts of the package specifier to start with a digit, I have added `$` to the condition.

### How to verify it

See unit tests, verified on our dockerfiles as well.

Fixes #1143, #1136
