### PR TITLE
Ignore dnf group install from DL3041

### DIFF
--- a/src/Hadolint/Rule/DL3041.hs
+++ b/src/Hadolint/Rule/DL3041.hs
@@ -30,7 +30,7 @@ dnfPackages :: Shell.ParsedShell -> [Text.Text]
 dnfPackages args =
     [ arg
       | cmd <- Shell.presentCommands args,
-        not (Shell.cmdsHaveArgs dnfCmds ["module"] cmd),
+        not (Shell.cmdsHaveArgs dnfCmds ["module", "group"] cmd),
         arg <- installFilter cmd
     ]
 

--- a/test/Hadolint/Rule/DL3041Spec.hs
+++ b/test/Hadolint/Rule/DL3041Spec.hs
@@ -65,3 +65,10 @@ spec = do
       onBuildRuleCatchesNot "DL3041" "RUN dnf module install -y tomcat:9 && dnf clean all"
       onBuildRuleCatchesNot "DL3041" "RUN microdnf module install -y tomcat:9 && microdnf clean all"
       onBuildRuleCatchesNot "DL3041" "RUN notdnf module install tomcat"
+
+    it "ok with dnf group install" $ do
+      ruleCatchesNot "DL3041" "RUN dnf -y group install \"Development Tools\""
+      ruleCatchesNot "DL3041" "RUN dnf -y --setopt=group_package_types=\"mandatory\" group install \"Development Tools\""
+      ruleCatchesNot "DL3041" "RUN dnf group install -y \"Development Tools\" && dnf clean all"
+      ruleCatchesNot "DL3041" "RUN microdnf group install -y \"Development Tools\" && microdnf clean all"
+      onBuildRuleCatchesNot "DL3041" "RUN dnf -y group install \"Development Tools\""


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

### What I did

`dnf` allows to install groups of packages with `dnf group install`, which do not include version information. This leads to a false positive for

```dockerfile
RUN dnf -y group install "Development Tools" && dnf clean all
```

### How I did it

When `group` is found in the command line, `dnfPackages` list will not be populated with the rest of the arguments.

### How to verify it

See unit tests.