### PR TITLE
SonarQube Formatter: Support --file-path-in-report

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,8 @@ Available options:
   -c,--config FILENAME     Path to the configuration file
   --file-path-in-report FILEPATHINREPORT
                            The file path referenced in the generated report.
-                           This only applies for the 'checkstyle', 'codeclimate', and 'gitlab_codeclimate' formats and is
+                           This only applies for the 'checkstyle', 'codeclimate',
+                           'sonarqube' and 'gitlab_codeclimate' formats and is
                            useful when running Hadolint with Docker to set the
                            correct file path.
   --no-fail                Don't exit with a failure status code when any rule

--- a/src/Hadolint/Config/Commandline.hs
+++ b/src/Hadolint/Config/Commandline.hs
@@ -76,7 +76,7 @@ parseCommandline =
                 <> metavar "FILEPATHINREPORT"
                 <> help "The file path referenced in the generated report.\
                         \ This only applies for the 'checkstyle', 'codeclimate',\
-                        \ and 'gitlab_codeclimate' formats and is\
+                        \ 'sonarqube' and 'gitlab_codeclimate' formats and is\
                         \ useful when running Hadolint with Docker to set the\
                         \ correct file path."
             )

--- a/src/Hadolint/Formatter.hs
+++ b/src/Hadolint/Formatter.hs
@@ -35,5 +35,5 @@ printResults format nocolor filePathInReport allResults =
     Gnu -> FormatGnu.printResults allResults
     Json -> FormatJson.printResults allResults
     Sarif -> FormatSarif.printResults allResults
-    SonarQube -> FormatSonarQube.printResults allResults
+    SonarQube -> FormatSonarQube.printResults allResults filePathInReport
     TTY -> FormatTTY.printResults allResults nocolor


### PR DESCRIPTION
Add support for --file-path-in-report flag for SonarQube formatter. This config option lets users set a custom filepath, replacing the real filepath of the Dockerfile in the generated output. This can be used e.g. to hide sensitive file paths when the report is shared with external parties.

related-to: hadolint/hadolint#1150

<img width="1775" height="410" alt="Screenshot at 2025-12-11 15-21-54" src="https://github.com/user-attachments/assets/5d009d7f-7007-41c7-8336-e620baa0e01a" />
