### PR TITLE
Add pyproject and hook to auto download github releases

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -5,9 +5,17 @@
   language: docker_image
   types: ["dockerfile"]
   entry: ghcr.io/hadolint/hadolint hadolint
+
 - id: hadolint
   name: Lint Dockerfiles
   description: Runs hadolint to lint Dockerfiles
   language: system
+  types: ["dockerfile"]
+  entry: hadolint
+
+- id: hadolint-github
+  name: Lint Dockerfiles
+  description: Runs hadolint to lint Dockerfiles. Downloads Github release
+  language: python
   types: ["dockerfile"]
   entry: hadolint

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,8 +3,6 @@ requires = ["release-gitter[builder]"]
 build-backend = "pseudo_builder"
 
 [tool.release-gitter]
-# If you're running a fork and need to download from the
-# upstream release, uncomment this line
-# git-url = "https://github.com/hadolint/hadolint"
+git-url = "https://github.com/hadolint/hadolint"
 format = "hadolint-{system}-{arch}"
 exec = "mv {} hadolint && chmod +x hadolint"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,10 @@
+[build-system]
+requires = ["release-gitter[builder]"]
+build-backend = "pseudo_builder"
+
+[tool.release-gitter]
+# If you're running a fork and need to download from the
+# upstream release, uncomment this line
+# git-url = "https://github.com/hadolint/hadolint"
+format = "hadolint-{system}-{arch}"
+exec = "mv {} hadolint && chmod +x hadolint"


### PR DESCRIPTION
Fixes #886

### What I did
I've added a `pyproject.toml` and a new hook that will allow `pre-commit` to install `hadolint` binaries using pip. I've done something similar for [StyLua](https://github.com/JohnnyMorganz/StyLua).

### How I did it
I had to make an update to `release-gitter` to add version parsing from `*.cabal` files, but with that

### How to verify it
I added a test to `release-gitter` that runs off my fork that validate this.

I also tested by adding the following to a repo of mine with pre-commit:

```yaml
  - repo: https://github.com/hadolint/hadolint
    rev: refs/pull/1152/head
    hooks:
      - id: hadolint-github
```

It successfully downloaded and ran the checks.