### PR TITLE
Automatically update Third party licenses

### DIFF
--- a/.github/workflows/thirdparty.yaml
+++ b/.github/workflows/thirdparty.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+  workflow_dispatch:
 
 jobs:
   third_party_notices_update:
@@ -20,11 +21,15 @@ jobs:
         with:
           ghc-version: 9.10.2
 
-      - name: Update ThirdPartyNotices.txt
+      - name: Install cabal-plan
         run: |
           cabal update
-          cabal install licensor --constraint 'licensor >= 0.4 && <0.5'
-          /home/runner/.cabal/bin/licensor --silent > ThirdPartyNotices.txt
+          cabal install cabal-plan --flags='exe license-report'
+
+      - name: Update ThirdpartyNotices.txt
+        run: |
+          /home/runner/.cabal/bin/cabal-plan license-report exe:hadolint \
+            > ThirdPartyNotices.txt
 
       - name: Commit ThirdPartyNotices.txt
         uses: EndBug/add-and-commit@v9


### PR DESCRIPTION
Automatically update thirdparty licenses list using `cabal-plan` utility.