### PR TITLE
Bump upload/download artifacts action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,6 @@ jobs:
         - /:/host
         - /opt:/opt:rw,rshared
         - /opt:/__e/node24:ro,rshared
-        - /opt:/__e/node20:ro,rshared
     strategy:
       fail-fast: false
       matrix:
@@ -104,7 +103,7 @@ jobs:
         shell: bash
 
       - name: Upload Artifact
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: hadolint-${{ matrix.target }}
           path: ~/.local/bin/hadolint
@@ -149,7 +148,7 @@ jobs:
             --ghc-options="-fPIC"
 
       - name: Upload Artifact
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: hadolint-${{ matrix.target }}
           path: ./dist/hadolint
@@ -191,7 +190,7 @@ jobs:
             --installdir=dist
 
       - name: Upload Artifact
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: hadolint-${{ matrix.target }}
           path: dist\hadolint.exe
@@ -219,7 +218,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Download Artifact
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v7
         with:
           name: hadolint-linux-${{matrix.target}}
           path: ${{matrix.target}}
@@ -381,31 +380,31 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Download Linux x86
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v7
         with:
           name: hadolint-linux-amd64
           path: artifacts/hadolint-linux-x86_64
 
       - name: Download Linux arm64
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v7
         with:
           name: hadolint-linux-arm64
           path: artifacts/hadolint-linux-arm64
 
       - name: Download Macos x86
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v7
         with:
           name: hadolint-macos-x86_64
           path: artifacts/hadolint-macos-x86_64
 
       - name: Download Macos arm
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v7
         with:
           name: hadolint-macos-arm64
           path: artifacts/hadolint-macos-arm64
 
       - name: Download Windows x86
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v7
         with:
           name: hadolint-windows-x86_64
           path: artifacts/hadolint-windows-x86_64


### PR DESCRIPTION
Bump upload/download artifacts action versions. Remove Node20 mount as it's no longer needed
