### PR TITLE
Fix DL3018 for apk ~ pins

### DIFF
--- a/src/Hadolint/Rule/DL3018.hs
+++ b/src/Hadolint/Rule/DL3018.hs
@@ -1,11 +1,10 @@
 module Hadolint.Rule.DL3018 (rule) where
 
-import qualified Data.Text as Text
+import Data.Text qualified as Text
 import Hadolint.Rule
 import Hadolint.Shell (ParsedShell)
-import qualified Hadolint.Shell as Shell
+import Hadolint.Shell qualified as Shell
 import Language.Docker.Syntax
-
 
 rule :: Rule ParsedShell
 rule = dl3018 <> onbuild dl3018
@@ -24,22 +23,22 @@ dl3018 = simpleRule code severity message check
         ( \as ->
             and
               [ versionFixed p || packageFile p
-                | p <- apkAddPackages as
+              | p <- apkAddPackages as
               ]
         )
         args
     check _ = True
-    versionFixed package = "=" `Text.isInfixOf` package
+    versionFixed package = any (`Text.isInfixOf` package) ["=", "~"]
     packageFile package = ".apk" `Text.isSuffixOf` package
 {-# INLINEABLE dl3018 #-}
 
 apkAddPackages :: ParsedShell -> [Text.Text]
 apkAddPackages args =
   [ arg
-    | cmd <- Shell.presentCommands args,
-      Shell.cmdHasArgs "apk" ["add"] cmd,
-      arg <- Shell.getArgsNoFlags (dropTarget cmd),
-      arg /= "add"
+  | cmd <- Shell.presentCommands args,
+    Shell.cmdHasArgs "apk" ["add"] cmd,
+    arg <- Shell.getArgsNoFlags (dropTarget cmd),
+    arg /= "add"
   ]
   where
     dropTarget = Shell.dropFlagArg ["t", "virtual", "repository", "X"]

--- a/test/Hadolint/Rule/DL3018Spec.hs
+++ b/test/Hadolint/Rule/DL3018Spec.hs
@@ -5,7 +5,6 @@ import Data.Text as Text
 import Helpers
 import Test.Hspec
 
-
 spec :: SpecWith ()
 spec = do
   let ?config = def
@@ -17,6 +16,9 @@ spec = do
     it "apk add no version pinning single" $ do
       ruleCatchesNot "DL3018" "RUN apk add flex=2.6.4-r1"
       onBuildRuleCatchesNot "DL3018" "RUN apk add flex=2.6.4-r1"
+    it "apk add tilde version pinning single" $ do
+      ruleCatchesNot "DL3018" "RUN apk add --no-cache git~2.52.0"
+      onBuildRuleCatchesNot "DL3018" "RUN apk add --no-cache git~2.52.0"
     it "apk add version pinned chained" $
       let dockerFile =
             [ "RUN apk add --no-cache flex=2.6.4-r1 \\",

--- a/test/Hadolint/Rule/DL3018Spec.hs
+++ b/test/Hadolint/Rule/DL3018Spec.hs
@@ -16,9 +16,17 @@ spec = do
     it "apk add no version pinning single" $ do
       ruleCatchesNot "DL3018" "RUN apk add flex=2.6.4-r1"
       onBuildRuleCatchesNot "DL3018" "RUN apk add flex=2.6.4-r1"
+
     it "apk add tilde version pinning single" $ do
       ruleCatchesNot "DL3018" "RUN apk add --no-cache git~2.52.0"
       onBuildRuleCatchesNot "DL3018" "RUN apk add --no-cache git~2.52.0"
+
+    it "apk add ~= and =~ version pinning" $ do
+      ruleCatchesNot "DL3018" "RUN apk add --no-cache git~=2.52"
+      ruleCatchesNot "DL3018" "RUN apk add --no-cache git=~2.52"
+      onBuildRuleCatchesNot "DL3018" "RUN apk add --no-cache git~=2.52"
+      onBuildRuleCatchesNot "DL3018" "RUN apk add --no-cache git=~2.52"
+
     it "apk add version pinned chained" $
       let dockerFile =
             [ "RUN apk add --no-cache flex=2.6.4-r1 \\",


### PR DESCRIPTION
### What I did

Fix DL3018 so `apk add` with `~` version constraints (e.g. `git~2.52.0`) is treated as pinned and no longer triggers the rule. Added regression coverage.

### How I did it

Extended the DL3018 “version fixed” check to recognize `~` in package tokens, and added a spec verifying `apk add --no-cache git~2.52.0` does not trigger.

### How to verify it

- `cabal test`

fixes #1165