### PR TITLE
Automatically update image digest in pre-commit hook when a new image is pushed

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
     inputs:
       release_version:
-        description: 'The version number for the release'
+        description: "The version number for the release"
         required: true
 
 jobs:
@@ -36,7 +36,6 @@ jobs:
             ghc: 9.10.2
 
     steps:
-
       - name: Workaround to make checkout work on Alpine arm64
         run: |
           sed -i "/^ID=/s/alpine/NotpineForGHA/" /etc/os-release
@@ -282,13 +281,12 @@ jobs:
           - hadolint/hadolint
           - ghcr.io/hadolint/hadolint
     permissions:
-      contents: read
+      contents: write
       packages: write
       attestations: write
       id-token: write
 
     steps:
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -308,13 +306,14 @@ jobs:
       - name: Set target and tag
         id: build-opts
         run: |
-            if [[ $GITHUB_REF == refs/tags/* ]] ; then
-              echo "tag=${GITHUB_REF/refs\/tags\/v/}" >> $GITHUB_OUTPUT
-            else
-              echo "tag=${{ github.event.inputs.release_version }}" >> $GITHUB_OUTPUT
-            fi
+          if [[ $GITHUB_REF == refs/tags/* ]] ; then
+            echo "tag=${GITHUB_REF/refs\/tags\/v/}" >> $GITHUB_OUTPUT
+          else
+            echo "tag=${{ github.event.inputs.release_version }}" >> $GITHUB_OUTPUT
+          fi
 
       - name: Push scratch image
+        id: scratch-manifest
         run: |
           docker pull --platform linux/amd64 ${{ matrix.registry }}:${{github.sha}}-amd64
           docker pull --platform linux/arm64 ${{ matrix.registry }}:${{github.sha}}-arm64
@@ -330,6 +329,25 @@ jobs:
             --tag ${{ matrix.registry }}:v${{ steps.build-opts.outputs.tag }} \
             ${{ matrix.registry }}:${{github.sha}}-amd64 \
             ${{ matrix.registry }}:${{github.sha}}-arm64
+
+          # Manifest-only registry read (no image layer pull) for pre-commit pin on GHCR.
+          if [[ "${{ matrix.registry }}" == "ghcr.io/hadolint/hadolint" ]]; then
+            set -euo pipefail
+            VERSION="${{ steps.build-opts.outputs.tag }}"
+            IMAGE="${{ matrix.registry }}:v${VERSION}"
+            DIGEST="$(
+              docker buildx imagetools inspect "$IMAGE" --format '{{json .}}' | jq -r '.manifest.digest // empty'
+            )"
+            if [[ -z "$DIGEST" ]]; then
+              DIGEST="$(docker buildx imagetools inspect "$IMAGE" | awk '/^Digest:/ {print $2; exit}')"
+            fi
+            if [[ ! "$DIGEST" =~ ^sha256:[a-f0-9]{64}$ ]]; then
+              echo "Failed to resolve digest for $IMAGE (got: ${DIGEST:-empty})" >&2
+              exit 1
+            fi
+            echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
+            echo "Pinned image reference: ${IMAGE}@${DIGEST}"
+          fi
 
       - name: Push alpine image
         run: |
@@ -365,6 +383,49 @@ jobs:
             ${{ matrix.registry }}:${{github.sha}}-debian-amd64 \
             ${{ matrix.registry }}:${{github.sha}}-debian-arm64
 
+      - name: Check out master (pre-commit hook pin)
+        if: matrix.registry == 'ghcr.io/hadolint/hadolint'
+        uses: actions/checkout@v6
+        with:
+          ref: master
+          fetch-depth: 1
+
+      - name: Update pre-commit hook with pinned image
+        if: matrix.registry == 'ghcr.io/hadolint/hadolint'
+        env:
+          VERSION: ${{ steps.build-opts.outputs.tag }}
+          DIGEST: ${{ steps.scratch-manifest.outputs.digest }}
+        run: |
+          python3 <<'PY'
+          import os
+          import re
+          from pathlib import Path
+
+          ver = os.environ["VERSION"]
+          digest = os.environ["DIGEST"]
+          path = Path(".pre-commit-hooks.yaml")
+          text = path.read_text()
+          pattern = r"^(\s*entry:\s)ghcr\.io/hadolint/hadolint\S*(\s+hadolint)\s*$"
+
+          def repl(m):
+              return f"{m.group(1)}ghcr.io/hadolint/hadolint:v{ver}@{digest}{m.group(2)}"
+
+          new_text, n = re.subn(pattern, repl, text, count=1, flags=re.MULTILINE)
+          if n != 1:
+              raise SystemExit(
+                  f"Expected to update one ghcr.io/hadolint pre-commit entry, matched {n}"
+              )
+          path.write_text(new_text)
+          PY
+
+      - name: Commit pre-commit hook pin
+        if: matrix.registry == 'ghcr.io/hadolint/hadolint'
+        uses: EndBug/add-and-commit@v9
+        with:
+          add: ".pre-commit-hooks.yaml"
+          message: "chore: pin hadolint-docker pre-commit image to v${{ steps.build-opts.outputs.tag }}"
+          default_author: github_actions
+
   release:
     if: github.event_name != 'workflow_dispatch'
     needs:
@@ -375,7 +436,6 @@ jobs:
     name: Create GitHub Release
     runs-on: ubuntu-latest
     steps:
-
       - name: Check out
         uses: actions/checkout@v6
 

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -4,7 +4,7 @@
   description: Runs hadolint Docker image to lint Dockerfiles
   language: docker_image
   types: ["dockerfile"]
-  entry: ghcr.io/hadolint/hadolint hadolint
+  entry: ghcr.io/hadolint/hadolint:v2.14.0@sha256:27086352fd5e1907ea2b934eb1023f217c5ae087992eb59fde121dce9c9ff21e hadolint
 - id: hadolint
   name: Lint Dockerfiles
   description: Runs hadolint to lint Dockerfiles

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -2,11 +2,6 @@
 
 Only `master` branch is used for releases.
 
-1.  Update _hadolint-docker_ entry version in the
-    [.pre-commit-hooks.yaml](../.pre-commit-hooks.yaml) file.
-    Use the new version you're going to release.
-    And push to master.
-
 1.  Create branch to update release number in `package.yaml` and
     [integration](INTEGRATION.md) guide and merge it when it pass CI.
 
@@ -26,6 +21,12 @@ Only `master` branch is used for releases.
     binaries to GitHub release draft with the same name as is the name
     of the tag (created in step 1).
     ![draft_binaries](https://user-images.githubusercontent.com/18702153/32983247-7692d528-cc89-11e7-9340-2af1434a6bdf.png)
+
+    Tag creation also triggers the GitHub Actions **Release** workflow, which
+    publishes Docker images and automatically pins the _hadolint-docker_ hook in
+    [.pre-commit-hooks.yaml](../.pre-commit-hooks.yaml) to
+    `ghcr.io/hadolint/hadolint:v<version>@sha256:<digest>` (commit to `master`).
+    No manual edit is required for the Docker image reference.
 
 1.  Edit release notes, mention all new features and important fixes and
     publish it.


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

closes #1176

### What I did

- **Immediate fix:** Pinned the existing `hadolint-docker` pre-commit hook in `.pre-commit-hooks.yaml` to the **current latest released** scratch image on GHCR using the **version tag and digest** (e.g. `ghcr.io/hadolint/hadolint:v2.14.0@sha256:… hadolint`), so consumers get a reproducible image reference without relying on an unpinned tag.
- **Ongoing maintenance:** Extended the GitHub Actions **Release** workflow so each release (tag or manual dispatch) republishes the scratch image, reads that release’s **`v<version>`** manifest digest from GHCR, rewrites the same hook line, and commits the update to `master` when it changes.

### How I did it

- Release workflow (`docker-release`, GHCR matrix only): after `docker buildx imagetools create` tags `v<version>`, resolve the index digest via `docker buildx imagetools inspect` (manifest-only read), then update `.pre-commit-hooks.yaml` and commit with `EndBug/add-and-commit`.
- Documented the behavior in `docs/RELEASE.md`.

### How to verify it

- **Pin commit:** Open `.pre-commit-hooks.yaml` and confirm `hadolint-docker`’s `entry` is `ghcr.io/hadolint/hadolint:v<semver>@sha256:<64-hex> hadolint` matching [the latest GitHub release](https://github.com/hadolint/hadolint/releases/latest) tag and the digest for that tag on `ghcr.io/hadolint/hadolint` (e.g. `docker buildx imagetools inspect ghcr.io/hadolint/hadolint:<tag> --format '{{json .}}' | jq -r '.manifest.digest'`).
- **Automation:** In `.github/workflows/release.yml`, confirm the GHCR `scratch-manifest` step inspects `ghcr.io/hadolint/hadolint:v${{ steps.build-opts.outputs.tag }}` and that the “Update pre-commit hook” step writes `v{ver}@{digest}` for `hadolint-docker`.
- **Optional:** On a fork with registry secrets, run **Release** (or review a past run) and confirm a follow-up commit updates `.pre-commit-hooks.yaml` only when the digest changes; locally, `pre-commit try-repo . --all-files` with `hadolint-docker` can sanity-check the hook still runs.