### PR TITLE
Fix: propagating shell options across build stages

### DIFF
--- a/src/Hadolint/Rule/Shellcheck.hs
+++ b/src/Hadolint/Rule/Shellcheck.hs
@@ -1,5 +1,6 @@
 module Hadolint.Rule.Shellcheck (rule) where
 
+import qualified Data.Map as Map
 import qualified Data.Set as Set
 import qualified Data.Text as Text
 import Hadolint.Rule
@@ -13,7 +14,10 @@ import qualified ShellCheck.Interface
 data Acc
   = Acc
       { opts :: Shell.ShellOpts,
-        defaultOpts :: Shell.ShellOpts
+        defaultOpts :: Shell.ShellOpts,
+        stageIdx :: Int,
+        stageOpts :: Map.Map Int Shell.ShellOpts,
+        stages :: Map.Map Int Text.Text
       }
   | Empty
 
@@ -25,7 +29,7 @@ rule = scrule <> onbuild scrule
 scrule :: Rule Shell.ParsedShell
 scrule = customRule check (emptyState Empty)
   where
-    check _ st (From _) = st |> modify newStage
+    check _ st (From bi) = st |> modify (newStage bi)
     check _ st (Arg name _) = st |> modify (addVars [name])
     check _ st (Env pairs) = st |> modify (addVars (map fst pairs))
     check _ st (Shell args) =
@@ -46,81 +50,142 @@ scrule = customRule check (emptyState Empty)
     check _ st _ = st
 {-# INLINEABLE scrule #-}
 
-newStage :: Acc -> Acc
-newStage Empty =
+newStage :: BaseImage -> Acc -> Acc
+newStage BaseImage {..} Empty =
   Acc
     { opts = Shell.defaultShellOpts,
-      defaultOpts = Shell.defaultShellOpts
+      defaultOpts = Shell.defaultShellOpts,
+      stageIdx = 0,
+      stageOpts = Map.singleton 0 Shell.defaultShellOpts,
+      stages = fromAlias alias
     }
-newStage Acc {..} =
-  Acc
-    { opts = defaultOpts,
-      defaultOpts
-    }
+  where
+    fromAlias Nothing = Map.empty
+    fromAlias (Just a) = Map.singleton 0 (unImageAlias a)
+newStage BaseImage {..} Acc {..} =
+  if Map.null (Map.filter (== (imageName image)) stages)
+  then
+    Acc
+      { opts = defaultOpts,
+        defaultOpts,
+        stageIdx = stageIdx + 1,
+        stageOpts = Map.insert (stageIdx + 1) defaultOpts stageOpts,
+        stages = fromAlias (stageIdx + 1) alias
+      }
+  else do
+  let idx = getIdx getList
+      theOpts = toOpts ( Map.lookup idx stageOpts )
+   in
+      Acc
+        { opts = theOpts,
+          defaultOpts,
+          stageIdx = stageIdx + 1,
+          stageOpts = Map.insert (stageIdx + 1) theOpts stageOpts,
+          stages = fromAlias (stageIdx + 1) alias
+        }
+  where
+    fromAlias _ Nothing = stages
+    fromAlias idx (Just a) = Map.insert idx (unImageAlias a) stages
+
+    getIdx [] = 0
+    getIdx [(k, _)] = k
+    getIdx ((k, _):_:_) = k
+
+    getList = Map.toList (Map.filter (== (imageName image)) stages)
+
+    toOpts Nothing = defaultOpts
+    toOpts (Just o) = o
 
 addVars :: [Text.Text] -> Acc -> Acc
-addVars vars Empty =
-  Acc
-    { opts =
+addVars vars Empty = do
+  let opts =
         Shell.ShellOpts
           { shellName = Shell.shellName Shell.defaultShellOpts,
             envVars = Shell.envVars Shell.defaultShellOpts <> Set.fromList vars
-          },
-      defaultOpts = Shell.defaultShellOpts
-    }
-addVars vars Acc {..} =
-  Acc
-    { opts =
+          }
+   in
+    Acc
+      {
+        opts,
+        defaultOpts = Shell.defaultShellOpts,
+        stageIdx = 0,
+        stageOpts = Map.singleton 0 opts,
+        stages = Map.empty
+      }
+addVars vars Acc {..} = do
+  let newOpts =
         Shell.ShellOpts
-          { shellName = Shell.shellName opts,
+          { shellName = Shell.shellName Shell.defaultShellOpts,
             envVars = Shell.envVars opts <> Set.fromList vars
-          },
-      defaultOpts
-    }
+          }
+   in
+    Acc
+      { opts = newOpts,
+        defaultOpts,
+        stageIdx,
+        stageOpts = Map.update (\_ -> Just newOpts) stageIdx stageOpts,
+        stages
+      }
 
 setShell :: Text.Text -> Acc -> Acc
-setShell sh Empty =
-  Acc
-    { opts =
-        Shell.ShellOpts
-          { shellName = sh,
-            envVars = Shell.envVars Shell.defaultShellOpts
-          },
-      defaultOpts = Shell.defaultShellOpts
-    }
-setShell sh Acc {..} =
-  Acc
-    { opts =
-        Shell.ShellOpts
-          { shellName = sh,
-            envVars = Shell.envVars opts
-          },
-      defaultOpts
-    }
-
-shellPragma :: Text.Text -> Acc -> Acc
-shellPragma sh Empty =
-  Acc
-    { opts =
-        Shell.ShellOpts
-          { shellName = sh,
-            envVars = Shell.envVars Shell.defaultShellOpts
-          },
-      defaultOpts =
+setShell sh Empty = do
+  let opts =
         Shell.ShellOpts
           { shellName = sh,
             envVars = Shell.envVars Shell.defaultShellOpts
           }
-    }
-shellPragma sh Acc {..} =
-  Acc
-    { opts =
+   in
+    Acc
+      { opts,
+        defaultOpts = Shell.defaultShellOpts,
+        stageIdx = 0,
+        stageOpts = Map.singleton 0 opts,
+        stages = Map.empty
+      }
+setShell sh Acc {..} = do
+  let newOpts =
         Shell.ShellOpts
           { shellName = sh,
             envVars = Shell.envVars opts
-          },
-      defaultOpts
-    }
+          }
+   in
+    Acc
+      { opts = newOpts,
+        defaultOpts,
+        stageIdx,
+        stageOpts = Map.update (\_ -> Just newOpts) stageIdx stageOpts,
+        stages
+      }
+
+shellPragma :: Text.Text -> Acc -> Acc
+shellPragma sh Empty = do
+  let newOpts =
+        Shell.ShellOpts
+          { shellName = sh,
+            envVars = Shell.envVars Shell.defaultShellOpts
+          }
+   in
+    Acc
+      { opts = newOpts,
+        defaultOpts = newOpts,
+        stageIdx = 0,
+        stageOpts = Map.singleton 0 newOpts,
+        stages = Map.empty
+      }
+shellPragma sh Acc {..} = do
+  let newOpts =
+        Shell.ShellOpts
+          { shellName = sh,
+            envVars = Shell.envVars opts
+          }
+   in
+    Acc
+      { opts = newOpts,
+        defaultOpts,
+        stageIdx,
+        stageOpts = Map.update (\_ -> Just newOpts) stageIdx stageOpts,
+        stages
+      }
 
 -- | Converts ShellCheck errors into our own errors type
 toFailure :: Linenumber ->

--- a/test/Hadolint/Rule/ShellcheckSpec.hs
+++ b/test/Hadolint/Rule/ShellcheckSpec.hs
@@ -169,3 +169,53 @@ spec = do
        in do
             assertChecks dockerFile passesShellcheck
             assertOnBuildChecks dockerFile passesShellcheck
+
+    it "SHELL instructions are propagated in multi-stage builds 1" $
+      let dockerfile =
+            Text.unlines
+              [ "FROM ubuntu:24.04 AS base",
+                "SHELL [\"/bin/bash\", \"-e\", \"-o\", \"pipefail\", \"-c\"]",
+                "",
+                "FROM base",
+                "RUN source /etc/os-release"
+              ]
+       in do
+            assertChecks dockerfile passesShellcheck
+
+    it "SHELL instructions are propagated only propagated if referencing earlier stage" $
+      let dockerfile =
+            Text.unlines
+              [ "FROM ubuntu:24.04 AS base",
+                "SHELL [\"/bin/bash\", \"-e\", \"-o\", \"pipefail\", \"-c\"]",
+                "",
+                "FROM ubuntu:24.04",
+                "RUN source /etc/os-release"
+              ]
+       in do
+            assertChecks dockerfile failsShellcheck
+
+    it "SHELL instructions are propagated in multi-stage builds 2" $
+      let dockerfile =
+            Text.unlines
+              [ "FROM something AS nothing",
+                "FROM ubuntu:24.04 AS base",
+                "SHELL [\"/bin/bash\", \"-e\", \"-o\", \"pipefail\", \"-c\"]",
+                "FROM nothing",
+                "FROM base",
+                "RUN source /etc/os-release"
+              ]
+       in do
+            assertChecks dockerfile passesShellcheck
+
+    it "SHELL instructions are propagated in multi-stage builds 3" $
+      let dockerfile =
+            Text.unlines
+              [ "FROM ubuntu:24.04 AS base",
+                "SHELL [\"/bin/bash\", \"-e\", \"-o\", \"pipefail\", \"-c\"]",
+                "FROM base AS next",
+                "RUN foobar && barfoo | tee logfile",
+                "FROM next",
+                "RUN source /etc/os-release"
+              ]
+       in do
+            assertChecks dockerfile passesShellcheck


### PR DESCRIPTION
### What I did

Fix propagating shell options, set by SHELL instructions, in multi-stage builds.

### How I did it

Track shell options set by the SHELL instruction in a map with stage indices as keys. Also track the stage names/aliases by index and the current stage index.
This allows Hadolint to figure out which shell options/environment variables are set at the end of each build stage. In multi-stage builds, when a later stage extends an earlier stage, the previously set shell options and environment variables can then be applied correctly before calling into Shellcheck.
This avoids some false-positives, e.g. when a base stage sets shell options with the SHELL instruction and a later stage builds upon this base stage, assuming these shell options are applied.

related-to: hadolint/hadolint#1174

### How to verify it

This should no longer produce a false-positive SC3046:
```Dockerfile
FROM ubuntu:24.04 AS stage
SHELL ["/bin/bash", "-e", "-o", "pipefail", "-c"]

FROM stage AS test
RUN source /etc/os-release
```