### PR TITLE
DL3063: New rule, stage name reserved word

### DIFF
--- a/hadolint.cabal
+++ b/hadolint.cabal
@@ -102,6 +102,7 @@ library
     Hadolint.Rule.DL3060
     Hadolint.Rule.DL3061
     Hadolint.Rule.DL3062
+    Hadolint.Rule.DL3063
     Hadolint.Rule.DL4000
     Hadolint.Rule.DL4001
     Hadolint.Rule.DL4003
@@ -308,6 +309,7 @@ test-suite hadolint-unit-tests
     Hadolint.Rule.DL3060Spec
     Hadolint.Rule.DL3061Spec
     Hadolint.Rule.DL3062Spec
+    Hadolint.Rule.DL3063Spec
     Hadolint.Rule.DL4000Spec
     Hadolint.Rule.DL4001Spec
     Hadolint.Rule.DL4003Spec

--- a/src/Hadolint/Process.hs
+++ b/src/Hadolint/Process.hs
@@ -69,6 +69,7 @@ import qualified Hadolint.Rule.DL3059
 import qualified Hadolint.Rule.DL3060
 import qualified Hadolint.Rule.DL3061
 import qualified Hadolint.Rule.DL3062
+import qualified Hadolint.Rule.DL3063
 import qualified Hadolint.Rule.DL4000
 import qualified Hadolint.Rule.DL4001
 import qualified Hadolint.Rule.DL4003
@@ -174,6 +175,7 @@ failures Configuration {allowedRegistries, labelSchema, strictLabels} =
     <> Hadolint.Rule.DL3060.rule
     <> Hadolint.Rule.DL3061.rule
     <> Hadolint.Rule.DL3062.rule
+    <> Hadolint.Rule.DL3063.rule
     <> Hadolint.Rule.DL4000.rule
     <> Hadolint.Rule.DL4001.rule
     <> Hadolint.Rule.DL4003.rule

--- a/src/Hadolint/Rule/DL3024.hs
+++ b/src/Hadolint/Rule/DL3024.hs
@@ -11,10 +11,8 @@ rule = customRule check (emptyState Set.empty)
     severity = DLErrorC
     message = "FROM aliases (stage names) must be unique"
 
-    check line st (From BaseImage {alias = Just (ImageAlias als)}) =
-      let newState = st |> modify (Set.insert als)
-       in if Set.member als (state st)
-            then newState |> addFail CheckFailure {..}
-            else newState
+    check line st (From BaseImage {alias = Just (ImageAlias als)})
+      | Set.member als (state st) = st |> addFail CheckFailure {..}
+      | otherwise = st |> modify (Set.insert als)
     check _ st _ = st
 {-# INLINEABLE rule #-}

--- a/src/Hadolint/Rule/DL3063.hs
+++ b/src/Hadolint/Rule/DL3063.hs
@@ -1,0 +1,18 @@
+module Hadolint.Rule.DL3063 (rule) where
+
+import Hadolint.Rule
+import qualified Hadolint.Shell as Shell
+import Language.Docker.Syntax
+
+rule :: Rule Shell.ParsedShell
+rule = simpleRule code severity message check
+  where
+    code = "DL3063"
+    severity = DLWarningC
+    message = "stage name should not be a reserved word"
+
+    check (From BaseImage {alias = Just (ImageAlias als)})
+      | als `elem` ["scratch", "context"] = False
+      | otherwise = True
+    check _ = True
+{-# INLINEABLE rule #-}

--- a/test/Hadolint/Rule/DL3063Spec.hs
+++ b/test/Hadolint/Rule/DL3063Spec.hs
@@ -1,0 +1,18 @@
+module Hadolint.Rule.DL3063Spec (spec) where
+
+import Data.Default
+import Helpers
+import Test.Hspec
+
+
+spec :: SpecWith ()
+spec = do
+  let ?config = def
+
+  describe "DL3063 - Stage name is a reserved word" $ do
+    it "not ok: stage name `scratch`" $
+      ruleCatches "DL3063" "FROM foo:bar AS scratch"
+    it "not ok: stage name `context`" $
+      ruleCatches "DL3063" "FROM foo:bar AS context"
+    it "ok: stage name `foobar`" $
+      ruleCatchesNot "DL3063" "FROM foo:bar AS foobar"


### PR DESCRIPTION
### What I did

Add new rule DL3063: stage names (aliases) can not be one of the reserved words: context, scratch.
This is documented by upstream Docker:
https://docs.docker.com/reference/build-checks/reserved-stage-name/

Additionally, simplify implementation of DL3024

### How to verify it

The following examples should produce a warning:
```Dockerfile
FROM debian:bullseye AS context
```

```Dockerfile
FROM debian:bullseye AS scratch
```