### PR TITLE
DL3041: Accept package versions in environment variables

### DIFF
--- a/src/Hadolint/Rule/DL3033.hs
+++ b/src/Hadolint/Rule/DL3033.hs
@@ -1,5 +1,8 @@
 module Hadolint.Rule.DL3033 (rule) where
 
+import qualified Data.Map as Map
+import qualified Data.Maybe as Maybe
+import qualified Data.Set as Set
 import qualified Data.Text as Text
 import Hadolint.Rule
 import qualified Hadolint.Shell as Shell
@@ -7,22 +10,37 @@ import Language.Docker.Syntax
 import Data.Char (isDigit, isAsciiUpper, isAsciiLower)
 
 
+data Acc
+  = Acc { stageIdx :: Int,
+          stageAliases :: Map.Map Int Text.Text,
+          envs :: Map.Map Int (Set.Set Text.Text),
+          args :: Set.Set Text.Text
+        }
+  | Empty
+  deriving (Show)
+
+
 rule :: Rule Shell.ParsedShell
 rule = dl3033 <> onbuild dl3033
 {-# INLINEABLE rule #-}
 
 dl3033 :: Rule Shell.ParsedShell
-dl3033 = simpleRule code severity message check
+dl3033 = customRule check (emptyState Empty)
   where
     code = "DL3033"
     severity = DLWarningC
     message = "Specify version with `yum install -y <package>-<version>`."
 
-    check (Run (RunArgs args _)) =
-      foldArguments (all packageVersionFixed . yumPackages) args
-        && foldArguments (all moduleVersionFixed . yumModules) args
-    check _ = True
+    check line st (Run (RunArgs a _))
+      | foldArguments (all ( packageVersionFixed ( state st ) ) . yumPackages) a
+          && foldArguments (all moduleVersionFixed . yumModules) a = st
+      | otherwise = st |> addFail CheckFailure {..}
+    check _ st (Env pairs) = st |> modify (registerEnvs pairs)
+    check _ st (Arg arg _) = st |> modify (registerArg arg)
+    check _ st (From bi) = st |> modify (newStage bi)
+    check _ st _ = st
 {-# INLINEABLE dl3033 #-}
+
 
 yumPackages :: Shell.ParsedShell -> [Text.Text]
 yumPackages args =
@@ -32,13 +50,26 @@ yumPackages args =
       arg <- installFilter cmd
   ]
 
-packageVersionFixed :: Text.Text -> Bool
-packageVersionFixed package
+packageVersionFixed :: Acc -> Text.Text -> Bool
+packageVersionFixed acc package
   | length parts <= 1 = False  -- No dashes, definitively no version
   | ".rpm" `Text.isSuffixOf` package = True  -- rpm files always have a version
+  | "$" `Text.isInfixOf` package = envDefined acc package
   | otherwise = isVersionLike $ drop 1 parts
   where
     parts = Text.splitOn "-" package
+
+envDefined :: Acc -> Text.Text -> Bool
+envDefined Empty _ = False
+envDefined (Acc stageIdx _ envs args) package =
+  any (`varInText` package) (thisStage envs)
+    || any (`varInText` package) args
+  where
+    thisStage envsMap = Maybe.fromMaybe Set.empty $ Map.lookup stageIdx envsMap
+
+varInText :: Text.Text -> Text.Text -> Bool
+varInText var txt =
+  ( Text.pack "${" <> var <> Text.pack "}" ) `Text.isInfixOf` txt
 
 isVersionLike :: [Text.Text] -> Bool
 isVersionLike parts =
@@ -46,7 +77,7 @@ isVersionLike parts =
     [] -> False  -- No parts after splitting by hyphen
     _ -> all partIsValid parts && any partStartsWithDigit parts
   where
-    partIsValid part = Text.all isVersionChar part
+    partIsValid = Text.all isVersionChar
     partStartsWithDigit part = case Text.uncons part of
                                  Just (c, _) -> isDigit c
                                  Nothing -> False -- Empty Text
@@ -77,3 +108,74 @@ installFilter cmd =
       arg /= "install",
       arg /= "module"
   ]
+
+registerEnvs :: Pairs -> Acc -> Acc
+registerEnvs pairs Empty =
+  Acc
+    { stageIdx = 0,
+      stageAliases = Map.singleton 0 (Text.pack ""),
+      envs = Map.singleton 0 (Set.fromList (map fst pairs)),
+      args = Set.empty
+    }
+registerEnvs pairs (Acc stageIdx stageAliases envs args) =
+  Acc
+    { stageIdx,
+      stageAliases,
+      envs = Map.adjust stageEnvs stageIdx envs,
+      args
+    }
+  where
+    stageEnvs = Set.union (Set.fromList (map fst pairs))
+
+registerArg :: Text.Text -> Acc -> Acc
+registerArg arg Empty =
+  Acc
+    { stageIdx = 0,
+      stageAliases = Map.singleton 0 (Text.pack ""),
+      envs = Map.singleton 0 Set.empty,
+      args = Set.singleton arg
+    }
+registerArg arg (Acc stageIdx stageAliases envs args) =
+  Acc
+    { stageIdx,
+      stageAliases,
+      envs,
+      args = Set.insert arg args
+    }
+
+newStage :: BaseImage -> Acc -> Acc
+newStage (BaseImage _ _ _ Nothing _) Empty =
+  Acc
+    { stageIdx = 1,
+      stageAliases = Map.singleton 1 (Text.pack ""),
+      envs = Map.singleton 1 Set.empty,
+      args = Set.empty
+    }
+newStage (BaseImage _ _ _ (Just alias) _) Empty =
+  Acc
+    { stageIdx = 1,
+      stageAliases = Map.singleton 1 (unImageAlias alias),
+      envs = Map.singleton 1 Set.empty,
+      args = Set.empty
+    }
+newStage (BaseImage image _ _ alias _) (Acc stageIdx stageAliases envs args) =
+  Acc
+    { stageIdx = stageIdx + 1,
+      stageAliases = Map.insert (stageIdx + 1) (als alias) stageAliases,
+      envs = Map.insert (stageIdx + 1) (stageEnvs stageIdxOfAlias) envs,
+      args
+    }
+  where
+    als :: Maybe ImageAlias -> Text.Text
+    als Nothing = Text.pack ""
+    als (Just a) = unImageAlias a
+
+    stageIdxOfAlias :: Int
+    stageIdxOfAlias = do
+      let l = Map.toList (Map.filter (== imageName image) stageAliases)
+       in case l of
+            [] -> stageIdx + 1
+            x:_ -> fst x
+
+    stageEnvs :: Int -> Set.Set Text.Text
+    stageEnvs idx = Maybe.fromMaybe Set.empty $ Map.lookup idx envs

--- a/src/Hadolint/Rule/DL3041.hs
+++ b/src/Hadolint/Rule/DL3041.hs
@@ -1,26 +1,38 @@
 module Hadolint.Rule.DL3041 (rule) where
 
+import qualified Data.Set as Set
 import qualified Data.Text as Text
 import Hadolint.Rule
 import qualified Hadolint.Shell as Shell
 import Language.Docker.Syntax
 import Data.Char (isDigit, isAsciiUpper, isAsciiLower)
 
+data Acc
+  = Acc { envs :: Set.Set Text.Text,
+          args :: Set.Set Text.Text
+        }
+  | Empty
+  deriving (Show)
+
 rule :: Rule Shell.ParsedShell
 rule = dl3041 <> onbuild dl3041
 {-# INLINEABLE rule #-}
 
 dl3041 :: Rule Shell.ParsedShell
-dl3041 = simpleRule code severity message check
+dl3041 = customRule check (emptyState Empty)
   where
     code = "DL3041"
     severity = DLWarningC
     message = "Specify version with `dnf install -y <package>-<version>`."
 
-    check (Run (RunArgs args _)) =
-      foldArguments (all packageVersionFixed . dnfPackages) args
-        && foldArguments (all moduleVersionFixed . dnfModules) args
-    check _ = True
+    check line st (Run (RunArgs a _))
+      | foldArguments (all ( packageVersionFixed ( state st ) ) . dnfPackages) a
+          && foldArguments (all moduleVersionFixed . dnfModules) a = st
+      | otherwise = st |> addFail CheckFailure {..}
+    check _ st (Env pairs) = st |> modify (registerEnvs pairs)
+    check _ st (Arg arg _) = st |> modify (registerArg arg)
+    check _ st (From _) = st |> modify (resetEnv)
+    check _ st _ = st
 {-# INLINEABLE dl3041 #-}
 
 dnfCmds :: [Text.Text]
@@ -34,13 +46,24 @@ dnfPackages args =
         arg <- installFilter cmd
     ]
 
-packageVersionFixed :: Text.Text -> Bool
-packageVersionFixed package
+packageVersionFixed :: Acc -> Text.Text -> Bool
+packageVersionFixed acc package
   | length parts <= 1 = False  -- No dashes, definitively no version
   | ".rpm" `Text.isSuffixOf` package = True  -- rpm files always have a version
+  | "$" `Text.isInfixOf` package = envDefined acc package
   | otherwise = isVersionLike $ drop 1 parts
   where
     parts = Text.splitOn "-" package
+
+envDefined :: Acc -> Text.Text -> Bool
+envDefined Empty _ = False
+envDefined (Acc envs args) package =
+  any (\v -> varInText v package) envs
+    || any (`varInText` package) args
+
+varInText :: Text.Text -> Text.Text -> Bool
+varInText var txt =
+  ( Text.pack "${" <> var <> Text.pack "}" ) `Text.isInfixOf` txt
 
 isVersionLike :: [Text.Text] -> Bool
 isVersionLike parts =
@@ -79,3 +102,35 @@ installFilter cmd =
       arg /= "install",
       arg /= "module"
   ]
+
+registerEnvs :: Pairs -> Acc -> Acc
+registerEnvs pairs Empty =
+  Acc
+    { envs = Set.fromList (map fst pairs),
+      args = Set.empty
+    }
+registerEnvs pairs (Acc envs args) =
+  Acc
+    { envs = Set.union (Set.fromList (map fst pairs)) envs,
+      args
+    }
+
+registerArg :: Text.Text -> Acc -> Acc
+registerArg arg Empty =
+  Acc
+    { envs = Set.empty,
+      args = Set.singleton arg
+    }
+registerArg arg (Acc envs args) =
+  Acc
+    { envs,
+      args = Set.insert arg args
+    }
+
+resetEnv :: Acc -> Acc
+resetEnv Empty = Empty
+resetEnv (Acc _ args) =
+  Acc
+    { envs = Set.empty,
+      args = args
+    }

--- a/src/Hadolint/Rule/DL3041.hs
+++ b/src/Hadolint/Rule/DL3041.hs
@@ -1,5 +1,7 @@
 module Hadolint.Rule.DL3041 (rule) where
 
+import qualified Data.Map as Map
+import qualified Data.Maybe as Maybe
 import qualified Data.Set as Set
 import qualified Data.Text as Text
 import Hadolint.Rule
@@ -8,7 +10,9 @@ import Language.Docker.Syntax
 import Data.Char (isDigit, isAsciiUpper, isAsciiLower)
 
 data Acc
-  = Acc { envs :: Set.Set Text.Text,
+  = Acc { stageIdx :: Int,
+          stageAliases :: Map.Map Int Text.Text,
+          envs :: Map.Map Int (Set.Set Text.Text),
           args :: Set.Set Text.Text
         }
   | Empty
@@ -31,7 +35,7 @@ dl3041 = customRule check (emptyState Empty)
       | otherwise = st |> addFail CheckFailure {..}
     check _ st (Env pairs) = st |> modify (registerEnvs pairs)
     check _ st (Arg arg _) = st |> modify (registerArg arg)
-    check _ st (From _) = st |> modify (resetEnv)
+    check _ st (From bi) = st |> modify (newStage bi)
     check _ st _ = st
 {-# INLINEABLE dl3041 #-}
 
@@ -57,9 +61,11 @@ packageVersionFixed acc package
 
 envDefined :: Acc -> Text.Text -> Bool
 envDefined Empty _ = False
-envDefined (Acc envs args) package =
-  any (\v -> varInText v package) envs
+envDefined (Acc stageIdx _ envs args) package =
+  any (`varInText` package) (thisStage envs)
     || any (`varInText` package) args
+  where
+    thisStage envsMap = Maybe.fromMaybe Set.empty $ Map.lookup stageIdx envsMap
 
 varInText :: Text.Text -> Text.Text -> Bool
 varInText var txt =
@@ -106,31 +112,70 @@ installFilter cmd =
 registerEnvs :: Pairs -> Acc -> Acc
 registerEnvs pairs Empty =
   Acc
-    { envs = Set.fromList (map fst pairs),
+    { stageIdx = 0,
+      stageAliases = Map.singleton 0 (Text.pack ""),
+      envs = Map.singleton 0 (Set.fromList (map fst pairs)),
       args = Set.empty
     }
-registerEnvs pairs (Acc envs args) =
+registerEnvs pairs (Acc stageIdx stageAliases envs args) =
   Acc
-    { envs = Set.union (Set.fromList (map fst pairs)) envs,
+    { stageIdx,
+      stageAliases,
+      envs = Map.adjust stageEnvs stageIdx envs,
       args
     }
+  where
+    stageEnvs es = Set.union (Set.fromList (map fst pairs)) es
 
 registerArg :: Text.Text -> Acc -> Acc
 registerArg arg Empty =
   Acc
-    { envs = Set.empty,
+    { stageIdx = 0,
+      stageAliases = Map.singleton 0 (Text.pack ""),
+      envs = Map.singleton 0 Set.empty,
       args = Set.singleton arg
     }
-registerArg arg (Acc envs args) =
+registerArg arg (Acc stageIdx stageAliases envs args) =
   Acc
-    { envs,
+    { stageIdx,
+      stageAliases,
+      envs,
       args = Set.insert arg args
     }
 
-resetEnv :: Acc -> Acc
-resetEnv Empty = Empty
-resetEnv (Acc _ args) =
+newStage :: BaseImage -> Acc -> Acc
+newStage (BaseImage _ _ _ Nothing _) Empty =
   Acc
-    { envs = Set.empty,
-      args = args
+    { stageIdx = 1,
+      stageAliases = Map.singleton 1 (Text.pack ""),
+      envs = Map.singleton 1 Set.empty,
+      args = Set.empty
     }
+newStage (BaseImage _ _ _ (Just alias) _) Empty =
+  Acc
+    { stageIdx = 1,
+      stageAliases = Map.singleton 1 (unImageAlias alias),
+      envs = Map.singleton 1 Set.empty,
+      args = Set.empty
+    }
+newStage (BaseImage image _ _ alias _) (Acc stageIdx stageAliases envs args) =
+  Acc
+    { stageIdx = stageIdx + 1,
+      stageAliases = Map.insert (stageIdx + 1) (als alias) stageAliases,
+      envs = Map.insert (stageIdx + 1) (stageEnvs stageIdxOfAlias) envs,
+      args
+    }
+  where
+    als :: Maybe ImageAlias -> Text.Text
+    als Nothing = Text.pack ""
+    als (Just a) = unImageAlias a
+
+    stageIdxOfAlias :: Int
+    stageIdxOfAlias = do
+      let l = Map.toList (Map.filter (== imageName image) stageAliases)
+       in case l of
+            [] -> stageIdx + 1
+            x:_ -> fst x
+
+    stageEnvs :: Int -> Set.Set Text.Text
+    stageEnvs idx = Maybe.fromMaybe Set.empty $ Map.lookup idx envs

--- a/src/Hadolint/Rule/DL3041.hs
+++ b/src/Hadolint/Rule/DL3041.hs
@@ -9,6 +9,7 @@ import qualified Hadolint.Shell as Shell
 import Language.Docker.Syntax
 import Data.Char (isDigit, isAsciiUpper, isAsciiLower)
 
+
 data Acc
   = Acc { stageIdx :: Int,
           stageAliases :: Map.Map Int Text.Text,
@@ -17,6 +18,7 @@ data Acc
         }
   | Empty
   deriving (Show)
+
 
 rule :: Rule Shell.ParsedShell
 rule = dl3041 <> onbuild dl3041
@@ -38,6 +40,7 @@ dl3041 = customRule check (emptyState Empty)
     check _ st (From bi) = st |> modify (newStage bi)
     check _ st _ = st
 {-# INLINEABLE dl3041 #-}
+
 
 dnfCmds :: [Text.Text]
 dnfCmds = ["dnf", "microdnf"]
@@ -77,7 +80,7 @@ isVersionLike parts =
     [] -> False  -- No parts after splitting by hyphen
     _ -> all partIsValid parts && any partStartsWithDigit parts
   where
-    partIsValid part = Text.all isVersionChar part
+    partIsValid = Text.all isVersionChar
     partStartsWithDigit part = case Text.uncons part of
                                  Just (c, _) -> isDigit c
                                  Nothing -> False -- Empty Text
@@ -125,7 +128,7 @@ registerEnvs pairs (Acc stageIdx stageAliases envs args) =
       args
     }
   where
-    stageEnvs es = Set.union (Set.fromList (map fst pairs)) es
+    stageEnvs = Set.union (Set.fromList (map fst pairs))
 
 registerArg :: Text.Text -> Acc -> Acc
 registerArg arg Empty =

--- a/src/Hadolint/Shell.hs
+++ b/src/Hadolint/Shell.hs
@@ -7,7 +7,29 @@ import Data.Maybe (fromMaybe, listToMaybe, mapMaybe)
 import qualified Data.Set as Set
 import Data.Text (Text)
 import qualified Data.Text as Text
-import ShellCheck.AST (Id (..), Token (..), pattern T_Pipe, pattern T_SimpleCommand)
+import ShellCheck.AST
+  ( Id (..),
+    Token (..),
+    pattern T_Pipe,
+    pattern T_SimpleCommand,
+    pattern T_NormalWord,
+    pattern T_DoubleQuoted,
+    pattern T_SingleQuoted,
+    pattern T_DollarBraced,
+    pattern T_DollarArithmetic,
+    pattern T_DollarExpansion,
+    pattern T_Backticked,
+    pattern T_Glob,
+    pattern T_Pipeline,
+    pattern T_Literal,
+    pattern T_ParamSubSpecialChar,
+    pattern T_SimpleCommand,
+    pattern T_Redirecting,
+    pattern T_DollarSingleQuoted,
+    pattern T_Annotation,
+    pattern TA_Sequence,
+    pattern TA_Expansion,
+  )
 import qualified ShellCheck.AST
 import qualified ShellCheck.ASTLib
 import ShellCheck.Checker (checkScript)
@@ -32,6 +54,9 @@ data ParsedShell = ParsedShell
     parsed :: ParseResult,
     presentCommands :: [Command]
   }
+
+instance Show (ParsedShell) where
+  show p = show (presentCommands p)
 
 data ShellOpts = ShellOpts
   { shellName :: Text.Text,
@@ -182,10 +207,32 @@ extractAllArgs (T_SimpleCommand _ _ (_ : allArgs)) = map mkPart allArgs
   where
     mkPart token =
       CmdPart
-        (Text.concat . fmap Text.pack $ ShellCheck.ASTLib.oversimplify token)
+        (Text.concat . fmap Text.pack $ simplify token)
         (mkId (ShellCheck.AST.getId token))
     mkId (Id i) = i
 extractAllArgs _ = []
+
+-- Modified version of ShellCheck.ASTLib.oversimplify
+-- This version keeps variable names
+simplify token =
+  case token of
+    (T_NormalWord _ l) -> [concat (concatMap simplify l)]
+    (T_DoubleQuoted _ l) -> [concat (concatMap simplify l)]
+    (T_SingleQuoted _ s) -> [s]
+    (T_DollarBraced _ _ t) -> ["${" ++ (concat $ simplify t) ++ "}"]
+    (T_DollarArithmetic _ _) -> ["${VAR}"]
+    (T_DollarExpansion _ t) -> ["${" ++ (concat $ concatMap simplify t) ++ "}"]
+    (T_Backticked _ _) -> ["${VAR}"]
+    (T_Glob _ s) -> [s]
+    (T_Pipeline _ _ [x]) -> simplify x
+    (T_Literal _ x) -> [x]
+    (T_ParamSubSpecialChar _ x) -> [x]
+    (T_SimpleCommand _ vars words) -> concatMap simplify words
+    (T_Redirecting _ _ foo) -> simplify foo
+    (T_DollarSingleQuoted _ s) -> [s]
+    (T_Annotation _ _ s) -> simplify s
+    (TA_Sequence _ [TA_Expansion _ v]) -> concatMap simplify v
+    _ -> []
 
 getArgs :: Command -> [Text.Text]
 getArgs cmd = map arg (arguments cmd)

--- a/src/Hadolint/Shell.hs
+++ b/src/Hadolint/Shell.hs
@@ -55,7 +55,7 @@ data ParsedShell = ParsedShell
     presentCommands :: [Command]
   }
 
-instance Show (ParsedShell) where
+instance Show ParsedShell where
   show p = show (presentCommands p)
 
 data ShellOpts = ShellOpts
@@ -214,20 +214,21 @@ extractAllArgs _ = []
 
 -- Modified version of ShellCheck.ASTLib.oversimplify
 -- This version keeps variable names
+simplify :: Token -> [String]
 simplify token =
   case token of
     (T_NormalWord _ l) -> [concat (concatMap simplify l)]
     (T_DoubleQuoted _ l) -> [concat (concatMap simplify l)]
     (T_SingleQuoted _ s) -> [s]
-    (T_DollarBraced _ _ t) -> ["${" ++ (concat $ simplify t) ++ "}"]
+    (T_DollarBraced _ _ t) -> ["${" ++ concat ( simplify t ) ++ "}"]
     (T_DollarArithmetic _ _) -> ["${VAR}"]
-    (T_DollarExpansion _ t) -> ["${" ++ (concat $ concatMap simplify t) ++ "}"]
+    (T_DollarExpansion _ t) -> ["${" ++ concat ( concatMap simplify t ) ++ "}"]
     (T_Backticked _ _) -> ["${VAR}"]
     (T_Glob _ s) -> [s]
     (T_Pipeline _ _ [x]) -> simplify x
     (T_Literal _ x) -> [x]
     (T_ParamSubSpecialChar _ x) -> [x]
-    (T_SimpleCommand _ vars words) -> concatMap simplify words
+    (T_SimpleCommand _ _ wds) -> concatMap simplify wds
     (T_Redirecting _ _ foo) -> simplify foo
     (T_DollarSingleQuoted _ s) -> [s]
     (T_Annotation _ _ s) -> simplify s

--- a/test/Hadolint/Rule/DL3033Spec.hs
+++ b/test/Hadolint/Rule/DL3033Spec.hs
@@ -1,5 +1,6 @@
 module Hadolint.Rule.DL3033Spec (spec) where
 
+import qualified Data.Text as Text
 import Data.Default
 import Helpers
 import Test.Hspec
@@ -41,3 +42,65 @@ spec = do
       ruleCatchesNot "DL3033" "RUN bash -c `# not even a yum command`"
       onBuildRuleCatchesNot "DL3033" "RUN yum module install -y tomcat:9 && yum clean all"
       onBuildRuleCatchesNot "DL3033" "RUN bash -c `# not even a yum command`"
+
+    -- this is important e.g. when using renovatebot
+    it "ok with version as variable - braced" $ do
+      let
+        rule = "DL3033"
+        snippet =
+          Text.unlines
+            [ "ENV version=2.51.0-2.fc42",
+              "RUN yum -y install git-core-${version}"
+            ]
+       in do
+        ruleCatchesNot rule snippet
+
+    it "ok with version as arg - unbraced" $ do
+      let
+        rule = "DL3033"
+        snippet =
+          Text.unlines
+            [ "ARG version=2.51.0-2.fc42",
+              "RUN yum -y install git-core-$version"
+            ]
+       in do
+        ruleCatchesNot rule snippet
+
+    it "ok with version as arg - different stages" $ do
+      let
+        rule = "DL3033"
+        snippet =
+          Text.unlines
+            [ "FROM fedora:fc42 AS build",
+              "ARG version=2.51.0-2.fc42",
+              "FROM fedora:fc42",
+              "RUN yum -y install git-core-${version}"
+            ]
+       in do
+        ruleCatchesNot rule snippet
+
+    it "ok with version as env - different stages, reused stage" $ do
+      let
+        rule = "DL3033"
+        snippet =
+          Text.unlines
+            [ "FROM fedora:fc42 AS build",
+              "ENV version=2.51.0-2.fc42",
+              "FROM build",
+              "RUN yum -y install git-core-${version}"
+            ]
+       in do
+        ruleCatchesNot rule snippet
+
+    it "not ok with version as variable - different stages, new stage" $ do
+      let
+        rule = "DL3033"
+        snippet =
+          Text.unlines
+            [ "FROM fedora:fc42 AS build",
+              "ENV version=2.51.0-2.fc42",
+              "FROM fedora:fc42",
+              "RUN yum -y install git-core-${version}"
+            ]
+       in do
+        ruleCatches rule snippet

--- a/test/Hadolint/Rule/DL3041Spec.hs
+++ b/test/Hadolint/Rule/DL3041Spec.hs
@@ -92,7 +92,7 @@ spec = do
         snippet =
           Text.unlines
             [ "ARG version=2.51.0-2.fc42",
-              "RUN dnf -y install git-core-${version}"
+              "RUN dnf -y install git-core-$version"
             ]
        in do
         ruleCatchesNot rule snippet
@@ -110,7 +110,20 @@ spec = do
        in do
         ruleCatchesNot rule snippet
 
-    it "not ok with version as variable - different stages" $ do
+    it "ok with version as env - different stages, reused stage" $ do
+      let
+        rule = "DL3041"
+        snippet =
+          Text.unlines
+            [ "FROM fedora:fc42 AS build",
+              "ENV version=2.51.0-2.fc42",
+              "FROM build",
+              "RUN dnf -y install git-core-${version}"
+            ]
+       in do
+        ruleCatchesNot rule snippet
+
+    it "not ok with version as variable - different stages, new stage" $ do
       let
         rule = "DL3041"
         snippet =

--- a/test/Hadolint/Rule/DL3041Spec.hs
+++ b/test/Hadolint/Rule/DL3041Spec.hs
@@ -1,5 +1,6 @@
 module Hadolint.Rule.DL3041Spec (spec) where
 
+import qualified Data.Text as Text
 import Data.Default
 import Helpers
 import Test.Hspec
@@ -72,3 +73,52 @@ spec = do
       ruleCatchesNot "DL3041" "RUN dnf group install -y \"Development Tools\" && dnf clean all"
       ruleCatchesNot "DL3041" "RUN microdnf group install -y \"Development Tools\" && microdnf clean all"
       onBuildRuleCatchesNot "DL3041" "RUN dnf -y group install \"Development Tools\""
+
+    -- this is important e.g. when using renovatebot
+    it "ok with version as variable - braced" $ do
+      let
+        rule = "DL3041"
+        snippet =
+          Text.unlines
+            [ "ENV version=2.51.0-2.fc42",
+              "RUN dnf -y install git-core-${version}"
+            ]
+       in do
+        ruleCatchesNot rule snippet
+
+    it "ok with version as arg - unbraced" $ do
+      let
+        rule = "DL3041"
+        snippet =
+          Text.unlines
+            [ "ARG version=2.51.0-2.fc42",
+              "RUN dnf -y install git-core-${version}"
+            ]
+       in do
+        ruleCatchesNot rule snippet
+
+    it "ok with version as arg - different stages" $ do
+      let
+        rule = "DL3041"
+        snippet =
+          Text.unlines
+            [ "FROM fedora:fc42 AS build",
+              "ARG version=2.51.0-2.fc42",
+              "FROM fedora:fc42",
+              "RUN dnf -y install git-core-${version}"
+            ]
+       in do
+        ruleCatchesNot rule snippet
+
+    it "not ok with version as variable - different stages" $ do
+      let
+        rule = "DL3041"
+        snippet =
+          Text.unlines
+            [ "FROM fedora:fc42 AS build",
+              "ENV version=2.51.0-2.fc42",
+              "FROM fedora:fc42",
+              "RUN dnf -y install git-core-${version}"
+            ]
+       in do
+        ruleCatches rule snippet


### PR DESCRIPTION
### What I did

DL3041 nudges users to use version pinning with `dnf`. A popular way to deal with this is to inject the package versions as `ARG`s or `ENV`s and keep them up to date with renovate bot or similar dependency automation software.
This PR expands the capabilities of DL3041 such that packages whose versions are specified in variables no longer trigger the rule, as long as the variable has been defined previously in an `ARG` or `ENV` statement.

related-to: hadolint/hadolint#1136

### How I did it

The rule now keeps track of which environment variables have been defined by an `ARG` or `ENV` instruction. If a package name contains a `$` character, the rule expects the package name to contain a shell variable and tries to look up this variable in set of defined variables. If the variable exists, DL3041 is not triggered.

### How to verify it

Tests are included.

This Dockerfile and similar constructions should no longer emit a warning:
```dockerfile
ARG GIT_VER=2.51.0-2.fc42
FROM fedora:foobar
RUN dnf install -y "git-core-${GIT_VER}"
```