### PR TITLE
fix: fix hlint warnings

### DIFF
--- a/app/embedded.hs
+++ b/app/embedded.hs
@@ -47,7 +47,7 @@ setup = do
   js_addEventListener lintInput (toJSString "click") lintInputCallback
 
   versionOutput <- js_document_getElementById (toJSString "version")
-  js_setText versionOutput $ toJSString $ Hadolint.getVersion
+  js_setText versionOutput $ toJSString Hadolint.getVersion
 
 foreign export javascript "lint" lint :: IO ()
 lint :: IO ()

--- a/src/Hadolint/Formatter/Codeclimate.hs
+++ b/src/Hadolint/Formatter/Codeclimate.hs
@@ -128,7 +128,7 @@ formatGitLabResult ::
   (VisualStream s, TraversableStream s, ShowErrorComponent e) =>
   Result s e -> Maybe FilePath ->
   Seq FingerprintIssue
-formatGitLabResult result filePathInReport = issueToFingerprintIssue <$> (formatResult result filePathInReport)
+formatGitLabResult result filePathInReport = issueToFingerprintIssue <$> formatResult result filePathInReport
 
 printResult :: (VisualStream s, TraversableStream s, ShowErrorComponent e) => Result s e -> Maybe FilePath -> IO ()
 printResult result filePathInReport = mapM_ output (formatResult result filePathInReport)

--- a/src/Hadolint/Formatter/TTY.hs
+++ b/src/Hadolint/Formatter/TTY.hs
@@ -44,8 +44,8 @@ printResults ::
 printResults results color = mapM_ printResult results
   where
     printResult Result {fileName, errors, checks} = printErrors errors >> printChecks fileName checks
-    printErrors errors = mapM_ (putStrLn . formatError) errors
-    printChecks fileName checks = mapM_ (putStrLn . Text.unpack . formatCheck color fileName) checks
+    printErrors = mapM_ (putStrLn . formatError)
+    printChecks fileName = mapM_ (putStrLn . Text.unpack . formatCheck color fileName)
 
 colorizedSeverity :: DLSeverity -> Text.Text
 colorizedSeverity s =

--- a/src/Hadolint/Rule/DL3033.hs
+++ b/src/Hadolint/Rule/DL3033.hs
@@ -46,7 +46,7 @@ isVersionLike parts =
     [] -> False  -- No parts after splitting by hyphen
     _ -> all partIsValid parts && any partStartsWithDigit parts
   where
-    partIsValid part = Text.all isVersionChar part
+    partIsValid = Text.all isVersionChar
     partStartsWithDigit part = case Text.uncons part of
                                  Just (c, _) -> isDigit c
                                  Nothing -> False -- Empty Text

--- a/src/Hadolint/Rule/DL3041.hs
+++ b/src/Hadolint/Rule/DL3041.hs
@@ -48,7 +48,7 @@ isVersionLike parts =
     [] -> False  -- No parts after splitting by hyphen
     _ -> all partIsValid parts && any partStartsWithDigit parts
   where
-    partIsValid part = Text.all isVersionChar part
+    partIsValid = Text.all isVersionChar
     partStartsWithDigit part = case Text.uncons part of
                                  Just (c, _) -> isDigit c
                                  Nothing -> False -- Empty Text

--- a/src/Hadolint/Rule/DL3047.hs
+++ b/src/Hadolint/Rule/DL3047.hs
@@ -24,7 +24,7 @@ dl3047 = simpleRule code severity message check
 
     forgotProgress cmd = isWget cmd && (not (hasProgressOption cmd) && not (hasSpecialFlags cmd))
     isWget (Shell.Command name _ _) = name == "wget"
-    hasProgressOption cmd = Shell.hasFlag "progress" cmd
+    hasProgressOption = Shell.hasFlag "progress"
 
     hasSpecialFlags cmd =
       hasQuietFlag cmd
@@ -32,9 +32,9 @@ dl3047 = simpleRule code severity message check
         || hasAppendOutputFlag cmd
         || hasNoVerboseFlag cmd
 
-    hasQuietFlag cmd = Shell.hasAnyFlag ["q", "quiet"] cmd
-    hasOutputFlag cmd = Shell.hasAnyFlag ["o", "output-file"] cmd
-    hasAppendOutputFlag cmd = Shell.hasAnyFlag ["a", "append-output"] cmd
+    hasQuietFlag = Shell.hasAnyFlag ["q", "quiet"]
+    hasOutputFlag = Shell.hasAnyFlag ["o", "output-file"]
+    hasAppendOutputFlag = Shell.hasAnyFlag ["a", "append-output"]
     hasNoVerboseFlag cmd =
       Shell.hasAnyFlag ["no-verbose"] cmd
         || Shell.cmdHasArgs "wget" ["-nv"] cmd

--- a/src/Hadolint/Rule/DL4006.hs
+++ b/src/Hadolint/Rule/DL4006.hs
@@ -21,13 +21,12 @@ rule = customRule check (emptyState False)
       | foldArguments isNonPosixShell args = st |> replaceWith True
       | otherwise = st |> replaceWith (foldArguments hasPipefailOption args)
     check line st@(State _ False) (Run (RunArgs args _))
-      | foldArguments hasPipes args = st |> addFail CheckFailure {..}
+      | foldArguments Shell.hasPipes args = st |> addFail CheckFailure {..}
       | otherwise = st
     check _ st _ = st
 
     isNonPosixShell (Shell.ParsedShell orig _ _) =
       any (`Text.isPrefixOf` orig) Shell.nonPosixShells
-    hasPipes script = Shell.hasPipes script
     hasPipefailOption script =
       not $
         null

--- a/src/Hadolint/Rule/Shellcheck.hs
+++ b/src/Hadolint/Rule/Shellcheck.hs
@@ -63,7 +63,7 @@ newStage BaseImage {..} Empty =
     fromAlias Nothing = Map.empty
     fromAlias (Just a) = Map.singleton 0 (unImageAlias a)
 newStage BaseImage {..} Acc {..} =
-  if Map.null (Map.filter (== (imageName image)) stages)
+  if Map.null (Map.filter (== imageName image) stages)
   then
     Acc
       { opts = defaultOpts,
@@ -91,7 +91,7 @@ newStage BaseImage {..} Acc {..} =
     getIdx [(k, _)] = k
     getIdx ((k, _):_:_) = k
 
-    getList = Map.toList (Map.filter (== (imageName image)) stages)
+    getList = Map.toList (Map.filter (== imageName image) stages)
 
     toOpts Nothing = defaultOpts
     toOpts (Just o) = o


### PR DESCRIPTION
### What I did

Fix a bunch of eta reduce, redundant brackets and other HLint warnings. Keep the code base and CI output clean.

### How to verify it

`cabal test` (i.e. the CI pipeline) should still pass.