### PR TITLE
DL3065: New Rule: No FROM with $TARGETPLATFORM

### DIFF
--- a/hadolint.cabal
+++ b/hadolint.cabal
@@ -103,6 +103,7 @@ library
     Hadolint.Rule.DL3061
     Hadolint.Rule.DL3062
     Hadolint.Rule.DL3063
+    Hadolint.Rule.DL3065
     Hadolint.Rule.DL4000
     Hadolint.Rule.DL4001
     Hadolint.Rule.DL4003
@@ -310,6 +311,7 @@ test-suite hadolint-unit-tests
     Hadolint.Rule.DL3061Spec
     Hadolint.Rule.DL3062Spec
     Hadolint.Rule.DL3063Spec
+    Hadolint.Rule.DL3065Spec
     Hadolint.Rule.DL4000Spec
     Hadolint.Rule.DL4001Spec
     Hadolint.Rule.DL4003Spec

--- a/src/Hadolint/Process.hs
+++ b/src/Hadolint/Process.hs
@@ -70,6 +70,7 @@ import qualified Hadolint.Rule.DL3060
 import qualified Hadolint.Rule.DL3061
 import qualified Hadolint.Rule.DL3062
 import qualified Hadolint.Rule.DL3063
+import qualified Hadolint.Rule.DL3065
 import qualified Hadolint.Rule.DL4000
 import qualified Hadolint.Rule.DL4001
 import qualified Hadolint.Rule.DL4003
@@ -176,6 +177,7 @@ failures Configuration {allowedRegistries, labelSchema, strictLabels} =
     <> Hadolint.Rule.DL3061.rule
     <> Hadolint.Rule.DL3062.rule
     <> Hadolint.Rule.DL3063.rule
+    <> Hadolint.Rule.DL3065.rule
     <> Hadolint.Rule.DL4000.rule
     <> Hadolint.Rule.DL4001.rule
     <> Hadolint.Rule.DL4003.rule

--- a/src/Hadolint/Rule/DL3065.hs
+++ b/src/Hadolint/Rule/DL3065.hs
@@ -1,0 +1,18 @@
+module Hadolint.Rule.DL3065 (rule) where
+
+import Hadolint.Rule
+import Language.Docker.Syntax
+
+rule :: Rule args
+rule = simpleRule code severity message check
+  where
+    code = "DL3065"
+    severity = DLWarningC
+    message =
+      "Setting `FROM --platform` to predefined `$TARGETPLATFORM` in is\
+      \ redundant as this is the default behavior"
+
+    check (From (BaseImage _ _ _ _ (Just platform))) =
+      platform /= "$TARGETPLATFORM" && platform /= "${TARGETPLATFORM}"
+    check _ = True
+{-# INLINEABLE rule #-}

--- a/test/Hadolint/Rule/DL3065Spec.hs
+++ b/test/Hadolint/Rule/DL3065Spec.hs
@@ -1,0 +1,25 @@
+module Hadolint.Rule.DL3065Spec (spec) where
+
+import Data.Default
+import Helpers
+import Test.Hspec
+
+
+spec :: SpecWith ()
+spec = do
+  let ?config = def
+  let rule = "DL3065"
+
+  describe "DL3065 - Setting `FROM --platform` to predefined `$TARGETPLATFORM` in is redundant as this is the default behavior" $ do
+
+    it "ok: FROM no --platform" $ do
+      ruleCatchesNot rule "FROM alpine:3.24"
+
+    it "ok: FROM --platform not $TARGETPLATFORM" $ do
+      ruleCatchesNot rule "FROM --platform=$FOOBAR alpine:3.24"
+      ruleCatchesNot rule "FROM --platform=foobar alpine:3.24"
+      ruleCatchesNot rule "FROM --platform=foobar/arm64 alpine:3.24"
+
+    it "not ok: FROM --platform=$TARGETPLATFORM" $ do
+      ruleCatches rule "FROM --platform=$TARGETPLATFORM alpine:3.24"
+      ruleCatches rule "FROM --platform=${TARGETPLATFORM} alpine:3.24"


### PR DESCRIPTION

### What I did

New rule: DL3065 - Don't use `FROM` with `--platform=$TARGETPLATFORM` FROM --platform=$TARGETPLATFORM is default behavior and shouldn't be used explictly.

The `--platform` argument to the `FROM` instruction primarily serves the purpose to be able to force a build stage to be the same platform as $BUILDPLATFORM for cross compiling.
It's unnecessary to set it to $TARGETPLATFORM.

This new rule implements one of Docker's build checks.
See also:
https://docs.docker.com/reference/build-checks/redundant-target-platform
https://docs.docker.com/reference/dockerfile/#from

### How I did it

The rule simply checks the platform text whether it's equal to either of `$TARGETPLATFORM` or `${TARGETPLATFORM}`.

### How to verify it

This should trigger the new rule and produce a warning:
```dockerfile
FROM --platform=$TARGETPLATFORM alpine:3.24
[...]
```

This should be fine:
```dockerfile
FROM --platform=$BUILDPLATFORM alpine:3.24
[...]
```

This should also not trigger DL3065:
```dockerfile
FROM --platform=linux/arm64 alpine:3.24
[...]
```