### PR TITLE
Add JUnit output formatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,9 +169,9 @@ Available options:
   --file-path-in-report FILEPATHINREPORT
                            The file path referenced in the generated report.
                            This only applies for the 'checkstyle', 'codeclimate',
-                           'sonarqube' and 'gitlab_codeclimate' formats and is
-                           useful when running Hadolint with Docker to set the
-                           correct file path.
+                           'sonarqube', 'junit' and 'gitlab_codeclimate' formats
+                           and is useful when running Hadolint with Docker to set
+                           the correct file path.
   --no-fail                Don't exit with a failure status code when any rule
                            is violated
   --no-color               Don't colorize output
@@ -179,7 +179,7 @@ Available options:
                            stderr
   -f,--format ARG          The output format for the results [tty | json |
                            checkstyle | codeclimate | gitlab_codeclimate | gnu |
-                           codacy | sonarqube | sarif] (default: tty)
+                           codacy | sonarqube | sarif | junit] (default: tty)
   --error RULECODE         Make the rule `RULECODE` have the level `error`
   --warning RULECODE       Make the rule `RULECODE` have the level `warning`
   --info RULECODE          Make the rule `RULECODE` have the level `info`
@@ -223,7 +223,7 @@ In windows, the `%LOCALAPPDATA%` environment variable is used instead of
 
 ```yaml
 failure-threshold: string               # name of threshold level (error | warning | info | style | ignore | none)
-format: string                          # Output format (tty | json | checkstyle | codeclimate | gitlab_codeclimate | gnu | codacy)
+format: string                          # Output format (tty | json | checkstyle | codeclimate | gitlab_codeclimate | gnu | codacy | sonarqube | sarif | junit)
 ignored: [string]                       # list of rules
 label-schema:                           # See Linting Labels below for specific label-schema details
   author: string                        # Your name
@@ -322,7 +322,7 @@ variables.
 NO_COLOR=1                               # Set or unset. See https://no-color.org
 HADOLINT_NOFAIL=1                        # Truthy value e.g. 1, true or yes
 HADOLINT_VERBOSE=1                       # Truthy value e.g. 1, true or yes
-HADOLINT_FORMAT=json                     # Output format (tty | json | checkstyle | codeclimate | gitlab_codeclimate | gnu | codacy | sarif )
+HADOLINT_FORMAT=json                     # Output format (tty | json | checkstyle | codeclimate | gitlab_codeclimate | gnu | codacy | sarif | junit )
 HADOLINT_FAILURE_THRESHOLD=info          # threshold level (error | warning | info | style | ignore | none)
 HADOLINT_OVERRIDE_ERROR=DL3010,DL3020    # comma separated list of rule codes
 HADOLINT_OVERRIDE_WARNING=DL3010,DL3020  # comma separated list of rule codes

--- a/hadolint.cabal
+++ b/hadolint.cabal
@@ -33,6 +33,7 @@ library
     Hadolint.Formatter.Codeclimate
     Hadolint.Formatter.Format
     Hadolint.Formatter.Gnu
+    Hadolint.Formatter.JUnit
     Hadolint.Formatter.Json
     Hadolint.Formatter.Sarif
     Hadolint.Formatter.SonarQube
@@ -245,6 +246,7 @@ test-suite hadolint-unit-tests
     Hadolint.Config.SpecHook
     Hadolint.Formatter.GnuSpec
     Hadolint.Formatter.ParseErrorSpec
+    Hadolint.Formatter.JUnitSpec
     Hadolint.Formatter.SarifSpec
     Hadolint.Formatter.SonarQubeSpec
     Hadolint.Formatter.TTYSpec
@@ -362,5 +364,7 @@ test-suite hadolint-unit-tests
     , silently
     , split
     , text
+    , time
+    , xml-conduit
 
   default-language:   GHC2021

--- a/src/Hadolint/Config/Commandline.hs
+++ b/src/Hadolint/Config/Commandline.hs
@@ -76,9 +76,9 @@ parseCommandline =
                 <> metavar "FILEPATHINREPORT"
                 <> help "The file path referenced in the generated report.\
                         \ This only applies for the 'checkstyle', 'codeclimate',\
-                        \ 'sonarqube' and 'gitlab_codeclimate' formats and is\
-                        \ useful when running Hadolint with Docker to set the\
-                        \ correct file path."
+                        \ 'sonarqube', 'junit' and 'gitlab_codeclimate' formats \
+                        \ and is useful when running Hadolint with Docker to set \
+                        \ the correct file path."
             )
         )
 
@@ -139,7 +139,7 @@ parseCommandline =
               <> help
                 "The output format for the results [tty | json | checkstyle |\
                 \ codeclimate | gitlab_codeclimate | gnu | codacy | sonarqube |\
-                \ sarif] (default: tty)"
+                \ sarif | junit] (default: tty)"
               <> completeWith
                   [ "tty",
                     "json",
@@ -148,7 +148,8 @@ parseCommandline =
                     "gitlab_codeclimate",
                     "codacy",
                     "sonarqube",
-                    "sarif"
+                    "sarif",
+                    "junit"
                   ]
           )
 

--- a/src/Hadolint/Formatter.hs
+++ b/src/Hadolint/Formatter.hs
@@ -13,6 +13,7 @@ import qualified Hadolint.Formatter.Checkstyle as FormatCheckstyle
 import qualified Hadolint.Formatter.Codacy as FormatCodacy
 import qualified Hadolint.Formatter.Codeclimate as FormatCodeclimate
 import qualified Hadolint.Formatter.Gnu as FormatGnu
+import qualified Hadolint.Formatter.JUnit as FormatJUnit
 import qualified Hadolint.Formatter.Json as FormatJson
 import qualified Hadolint.Formatter.Sarif as FormatSarif
 import qualified Hadolint.Formatter.SonarQube as FormatSonarQube
@@ -33,6 +34,7 @@ printResults format nocolor filePathInReport allResults =
     CodeclimateJson -> FormatCodeclimate.printResults allResults filePathInReport
     GitLabCodeclimateJson -> FormatCodeclimate.printGitLabResults allResults filePathInReport
     Gnu -> FormatGnu.printResults allResults
+    JUnit -> FormatJUnit.printResults allResults filePathInReport
     Json -> FormatJson.printResults allResults
     Sarif -> FormatSarif.printResults allResults
     SonarQube -> FormatSonarQube.printResults allResults filePathInReport

--- a/src/Hadolint/Formatter/Format.hs
+++ b/src/Hadolint/Formatter/Format.hs
@@ -28,27 +28,29 @@ import qualified Data.Text as Text
 import qualified Hadolint.Rule
 
 data OutputFormat
-  = Json
-  | SonarQube
-  | TTY
+  = Checkstyle
+  | Codacy
   | CodeclimateJson
   | GitLabCodeclimateJson
   | Gnu
-  | Checkstyle
-  | Codacy
+  | JUnit
+  | Json
   | Sarif
+  | SonarQube
+  | TTY
   deriving (Eq, Show)
 
 instance Pretty OutputFormat where
-  pretty Json = "json"
-  pretty SonarQube = "sonarqube"
-  pretty TTY = "tty"
+  pretty Checkstyle = "checkstyle"
+  pretty Codacy = "codacy"
   pretty CodeclimateJson = "codeclimate"
   pretty GitLabCodeclimateJson = "gitlab_codeclimate"
   pretty Gnu = "gnu"
-  pretty Checkstyle = "checkstyle"
-  pretty Codacy = "codacy"
+  pretty JUnit = "junit"
+  pretty Json = "json"
   pretty Sarif = "sarif"
+  pretty SonarQube = "sonarqube"
+  pretty TTY = "tty"
 
 instance Semigroup OutputFormat where
   _ <> f = f
@@ -73,15 +75,16 @@ instance Default OutputFormat where
   def = TTY
 
 readMaybeOutputFormat :: Text -> Maybe OutputFormat
-readMaybeOutputFormat "json" = Just Json
-readMaybeOutputFormat "sonarqube" = Just SonarQube
-readMaybeOutputFormat "tty" = Just TTY
+readMaybeOutputFormat "checkstyle" = Just Checkstyle
+readMaybeOutputFormat "codacy" = Just Codacy
 readMaybeOutputFormat "codeclimate" = Just CodeclimateJson
 readMaybeOutputFormat "gitlab_codeclimate" = Just GitLabCodeclimateJson
 readMaybeOutputFormat "gnu" = Just Gnu
-readMaybeOutputFormat "checkstyle" = Just Checkstyle
-readMaybeOutputFormat "codacy" = Just Codacy
+readMaybeOutputFormat "junit" = Just JUnit
+readMaybeOutputFormat "json" = Just Json
 readMaybeOutputFormat "sarif" = Just Sarif
+readMaybeOutputFormat "sonarqube" = Just SonarQube
+readMaybeOutputFormat "tty" = Just TTY
 readMaybeOutputFormat _ = Nothing
 
 

--- a/src/Hadolint/Formatter/JUnit.hs
+++ b/src/Hadolint/Formatter/JUnit.hs
@@ -1,0 +1,164 @@
+module Hadolint.Formatter.JUnit ( printResults ) where
+
+
+import qualified Data.ByteString.Lazy.Char8 as B
+import Data.Foldable
+import Data.Maybe
+import qualified Data.Map as Map
+import qualified Data.Text as Text
+import qualified Data.Time as Time
+import Hadolint.Formatter.Format
+  ( Result (..),
+    errorBundlePretty,
+    errorPosition,
+    severityText,
+  )
+import Hadolint.Rule (CheckFailure (..), RuleCode (..))
+import Hadolint.Meta (getShortVersion)
+import Text.Megaparsec (TraversableStream)
+import Text.Megaparsec.Error
+  ( ParseErrorBundle,
+    ShowErrorComponent,
+  )
+import Text.Megaparsec.Pos (sourceColumn, sourceLine, unPos)
+import Text.Megaparsec.Stream (VisualStream)
+import qualified Text.XML as XML
+
+
+providerName :: Text.Text
+providerName = "Hadolint " <> Text.pack getShortVersion
+
+providerID :: Text.Text
+providerID = "hadolint"
+
+
+printResults ::
+  (Foldable f, VisualStream s, TraversableStream s, ShowErrorComponent e) =>
+  f (Result s e) -> Maybe FilePath -> IO ()
+printResults results maybeFilepath = do
+  time <- Time.getCurrentTime
+  B.putStr $ XML.renderLBS settings $ document time
+
+  where
+    settings = XML.def
+
+    document :: Time.UTCTime -> XML.Document
+    document t =
+      XML.Document
+        { documentPrologue = XML.Prologue [] Nothing [],
+          documentRoot = root t,
+          documentEpilogue = []
+
+        }
+
+    root :: Time.UTCTime -> XML.Element
+    root t =
+      XML.Element
+        { elementName = "testsuites",
+          elementAttributes =
+            Map.fromList
+              [ ("id", runID t),
+                ("name", runName t),
+                ("time", "0.001")
+              ],
+          elementNodes = fmap ( `renderResult` maybeFilepath ) ( toList results )
+        }
+
+    runID :: Time.UTCTime -> Text.Text
+    runID t =
+      Text.pack $ Time.formatTime Time.defaultTimeLocale "%Y%m%d_%H%M%S" t
+
+    runName :: Time.UTCTime -> Text.Text
+    runName t =
+      Text.pack $ Time.formatTime Time.defaultTimeLocale "Hadolint run at %Y-%m-%d %H:%M:%S" t
+
+renderResult ::
+  (VisualStream s, TraversableStream s, ShowErrorComponent e) =>
+  Result s e -> Maybe FilePath -> XML.Node
+renderResult (Result filename errors checks) maybeFilepath =
+  XML.NodeElement XML.Element
+    { elementName = "testsuite",
+      elementAttributes =
+        Map.fromList
+          [ ("id", providerID),
+            ("name", providerName),
+            ("time", "0.001"),
+            ("failures", Text.pack $ show $ length findings),
+            ("errors", Text.pack $ show parseErrors)
+          ],
+      elementNodes = findings
+    }
+  where
+    findings = toList ( errorNodes <> checkNodes )
+    parseErrors = length errorNodes
+    errorNodes = fmap ( `errorToNode` file ) errors
+    checkNodes = fmap ( `checkToNode` file ) checks
+    file = if null maybeFilepath then filename else Text.pack $ fromMaybe "" maybeFilepath
+
+errorToNode ::
+  (VisualStream s, TraversableStream s, ShowErrorComponent e) =>
+  ParseErrorBundle s e -> Text.Text -> XML.Node
+errorToNode err filename =
+  XML.NodeElement XML.Element
+    { elementName = "testcase",
+      elementAttributes =
+        Map.fromList
+          [ ("id", providerID <> ".error"),
+            ("name", "DL1000"),
+            ("time", "0.001")
+          ],
+      elementNodes =
+        [ XML.NodeElement XML.Element
+            { elementName = "failure",
+              elementAttributes =
+                Map.fromList
+                  [ ("type", "error"),
+                    ("message", "parse error at line " <> line <> ", column " <> column)
+                  ],
+              elementNodes =
+                [ XML.NodeContent $
+                    Text.unlines
+                      [ "Parse Error in " <> filename,
+                        "Line: " <> line,
+                        "Column: " <> column,
+                        "Parse Error: " <> Text.pack ( errorBundlePretty err )
+                      ]
+                ]
+            }
+        ]
+    }
+  where
+    line = Text.pack ( show $ unPos $ sourceLine $ errorPosition err )
+    column = Text.pack ( show $ unPos $ sourceColumn $ errorPosition err )
+
+checkToNode :: CheckFailure -> Text.Text -> XML.Node
+checkToNode CheckFailure {..} filename =
+  XML.NodeElement XML.Element
+    { elementName = "testcase",
+      elementAttributes =
+        Map.fromList
+          [ ("id", providerID <> ".rule." <> unRuleCode code),
+            ("time", "0.001")
+          ],
+      elementNodes =
+        [ XML.NodeElement XML.Element
+            { elementName = "failure",
+              elementAttributes =
+                Map.fromList
+                  [ ("type", severityText severity),
+                    ("message", message),
+                    ("id", unRuleCode code)
+                  ],
+              elementNodes =
+                [ XML.NodeContent $
+                    Text.unlines
+                      [ "File: " <> filename,
+                        "Line: " <> Text.pack ( show line ),
+                        "Category: Hadolint - Dockerfile Static Analysis",
+                        severityText severity <> ": " <> message
+                      ]
+                ]
+            }
+        ]
+    }
+

--- a/test/Hadolint/Formatter/JUnitSpec.hs
+++ b/test/Hadolint/Formatter/JUnitSpec.hs
@@ -1,0 +1,231 @@
+module Hadolint.Formatter.JUnitSpec ( spec ) where
+
+import Helpers
+import Hadolint
+  ( CheckFailure (..),
+    DLSeverity (..),
+    OutputFormat (..),
+    getShortVersion,
+  )
+import Test.Hspec
+import qualified Data.Map as Map
+import qualified Data.Text as Text
+import qualified Data.Time as Time
+import qualified Text.XML as XML
+
+
+spec :: SpecWith ()
+spec = do
+  time <- runIO Time.getCurrentTime
+
+  let runID = Text.pack $ Time.formatTime Time.defaultTimeLocale "%Y%m%d_%H%M%S" time
+  let runName = Text.pack $ Time.formatTime Time.defaultTimeLocale "Hadolint run at %Y-%m-%d %H:%M:%S" time
+  let providerName = Text.pack $ "Hadolint " <> getShortVersion
+
+  let ?noColor = True
+
+  describe "Formatter: JUnit" $ do
+    it "print empty results" $ do
+      let checkFails = []
+          expectation =
+            XML.Document
+              { documentPrologue = XML.Prologue [] Nothing [],
+                documentRoot =
+                  XML.Element
+                    { elementName = "testsuites",
+                      elementAttributes =
+                        Map.fromList
+                          [ ("id", runID),
+                            ("name", runName),
+                            ("time", "0.001")
+                          ],
+                      elementNodes =
+                        [ XML.NodeElement XML.Element
+                            { elementName = "testsuite",
+                              elementAttributes =
+                                Map.fromList
+                                  [ ("id", "hadolint"),
+                                    ("name", providerName),
+                                    ("time", "0.001"),
+                                    ("failures", "0"),
+                                    ("errors", "0")
+                                  ],
+                              elementNodes = []
+                            }
+                        ]
+                    },
+                documentEpilogue = []
+              }
+      assertFormatterXML JUnit checkFails expectation
+
+    it "print one failed rule" $ do
+      let checkFails =
+            [ CheckFailure
+                { code = "DL2001",
+                  severity = DLWarningC,
+                  message = "test",
+                  line = 1
+                }
+            ]
+          expectation =
+            XML.Document
+              { documentPrologue = XML.Prologue [] Nothing [],
+                documentRoot =
+                  XML.Element
+                    { elementName = "testsuites",
+                      elementAttributes =
+                        Map.fromList
+                          [ ("id", runID),
+                            ("name", runName),
+                            ("time", "0.001")
+                          ],
+                      elementNodes =
+                        [ XML.NodeElement XML.Element
+                            { elementName = "testsuite",
+                              elementAttributes =
+                                Map.fromList
+                                  [ ("id", "hadolint"),
+                                    ("name", providerName),
+                                    ("time", "0.001"),
+                                    ("failures", "1"),
+                                    ("errors", "0")
+                                  ],
+                              elementNodes =
+                                [ XML.NodeElement XML.Element
+                                    { elementName = "testcase",
+                                      elementAttributes =
+                                        Map.fromList
+                                          [ ("id", "hadolint.rule.DL2001"),
+                                            ("time", "0.001")
+                                          ],
+                                      elementNodes =
+                                        [ XML.NodeElement XML.Element
+                                            { elementName = "failure",
+                                              elementAttributes =
+                                                Map.fromList
+                                                  [ ("type", "warning"),
+                                                    ("message", "test"),
+                                                    ("id", "DL2001")
+                                                  ],
+                                              elementNodes =
+                                                [ XML.NodeContent $
+                                                    Text.unlines
+                                                      [ "File: <string>",
+                                                        "Line: 1",
+                                                        "Category: Hadolint - Dockerfile Static Analysis",
+                                                        "warning: test"
+                                                      ]
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    },
+                documentEpilogue = []
+              }
+      assertFormatterXML JUnit checkFails expectation
+
+    it "print multiple failed rules" $ do
+      let checkFails =
+            [ CheckFailure
+                { code = "DL2001",
+                  severity = DLWarningC,
+                  message = "test",
+                  line = 1
+                },
+              CheckFailure
+                { code = "DL2003",
+                  severity = DLInfoC,
+                  message = "test 2",
+                  line = 3
+                }
+            ]
+          expectation =
+            XML.Document
+              { documentPrologue = XML.Prologue [] Nothing [],
+                documentRoot =
+                  XML.Element
+                    { elementName = "testsuites",
+                      elementAttributes =
+                        Map.fromList
+                          [ ("id", runID),
+                            ("name", runName),
+                            ("time", "0.001")
+                          ],
+                      elementNodes =
+                        [ XML.NodeElement XML.Element
+                            { elementName = "testsuite",
+                              elementAttributes =
+                                Map.fromList
+                                  [ ("id", "hadolint"),
+                                    ("name", "Hadolint " <> Text.pack getShortVersion),
+                                    ("time", "0.001"),
+                                    ("failures", "2"),
+                                    ("errors", "0")
+                                  ],
+                              elementNodes =
+                                [ XML.NodeElement XML.Element
+                                    { elementName = "testcase",
+                                      elementAttributes =
+                                        Map.fromList
+                                          [ ("id", "hadolint.rule.DL2001"),
+                                            ("time", "0.001")
+                                          ],
+                                      elementNodes =
+                                        [ XML.NodeElement XML.Element
+                                            { elementName = "failure",
+                                              elementAttributes =
+                                                Map.fromList
+                                                  [ ("type", "warning"),
+                                                    ("message", "test"),
+                                                    ("id", "DL2001")
+                                                  ],
+                                              elementNodes =
+                                                [ XML.NodeContent $
+                                                    Text.unlines
+                                                      [ "File: <string>",
+                                                        "Line: 1",
+                                                        "Category: Hadolint - Dockerfile Static Analysis",
+                                                        "warning: test"
+                                                      ]
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                  XML.NodeElement XML.Element
+                                    { elementName = "testcase",
+                                      elementAttributes =
+                                        Map.fromList
+                                          [ ("id", "hadolint.rule.DL2003"),
+                                            ("time", "0.001")
+                                          ],
+                                      elementNodes =
+                                        [ XML.NodeElement XML.Element
+                                            { elementName = "failure",
+                                              elementAttributes =
+                                                Map.fromList
+                                                  [ ("type", "info"),
+                                                    ("message", "test 2"),
+                                                    ("id", "DL2003")
+                                                  ],
+                                              elementNodes =
+                                                [ XML.NodeContent $
+                                                    Text.unlines
+                                                      [ "File: <string>",
+                                                        "Line: 3",
+                                                        "Category: Hadolint - Dockerfile Static Analysis",
+                                                        "info: test 2"
+                                                      ]
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    },
+                documentEpilogue = []
+              }
+      assertFormatterXML JUnit checkFails expectation

--- a/test/Helpers.hs
+++ b/test/Helpers.hs
@@ -17,6 +17,7 @@ import qualified Data.List.NonEmpty as NonEmpty
 import qualified Data.Sequence as Seq
 import qualified Data.Text as Text
 import qualified Hadolint.Process
+import qualified Text.XML as XML
 
 
 assertChecks ::
@@ -151,3 +152,16 @@ assertFormatterJson formatter failures expectation = do
   (cap, _) <- capture
                 (printResults formatter ?noColor (Just "<string>") results)
   decode (BSC.pack cap) `shouldBe` Just expectation
+
+assertFormatterXML
+  :: (HasCallStack, ?noColor :: Bool) =>
+  OutputFormat ->
+  [CheckFailure] ->
+  XML.Document ->
+  Assertion
+assertFormatterXML formatter failures expectation = do
+  let results =
+        NonEmpty.fromList [ Result "<string>" mempty (Seq.fromList failures) ]
+  (cap, _) <- capture
+                (printResults formatter ?noColor (Just "<string>") results)
+  XML.parseLBS_ XML.def (BSC.pack cap) `shouldBe` expectation


### PR DESCRIPTION
### What I did

Add output formatter for JUnit report format. This report format is popular and well integrated with several CI solutions (e.g. Jenkins).

JUnit XML schema, fields and their values are analogue to https://www.ibm.com/docs/en/developer-for-zos/17.0.x?topic=formats-junit-xml-format

Example:
<img width="1819" height="368" alt="Screenshot at 2026-05-13 22-19-21" src="https://github.com/user-attachments/assets/9f8b8f58-8687-44ff-9a87-e978fda3c168" />

related-to: hadolint/hadolint#1191
related-to: hadolint/hadolint#837