### PR TITLE
Shellcheck: fix false-positives with exec notation

### DIFF
--- a/src/Hadolint/Rule/Shellcheck.hs
+++ b/src/Hadolint/Rule/Shellcheck.hs
@@ -38,16 +38,18 @@ scrule = customRule check (emptyState Empty)
       case Hadolint.Pragma.parseShell com of
         Just sh -> st |> modify (shellPragma sh)
         _ -> st
-    check line st (Run (RunArgs args _)) = getFailures (state st) |> foldr addFail st
-      where
-        getFailures Empty = foldArguments (runShellCheck Shell.defaultShellOpts) args
-        getFailures s = foldArguments (runShellCheck (opts s)) args
-        runShellCheck options script =
-          Set.fromList
-            [ toFailure line c
-              | c <- Shell.shellcheck options script
-            ]
+    check line st (Run (RunArgs args@(ArgumentsText _) _)) = getFailures line args (state st) |> foldr addFail st
+    check _ st (Run (RunArgs (ArgumentsList _) _)) = st
     check _ st _ = st
+
+    getFailures line args Empty = foldArguments (runShellCheck line Shell.defaultShellOpts) args
+    getFailures line args s = foldArguments (runShellCheck line (opts s)) args
+
+    runShellCheck line options script =
+      Set.fromList
+        [ toFailure line c
+          | c <- Shell.shellcheck options script
+        ]
 {-# INLINEABLE scrule #-}
 
 newStage :: BaseImage -> Acc -> Acc

--- a/test/Hadolint/Rule/ShellcheckSpec.hs
+++ b/test/Hadolint/Rule/ShellcheckSpec.hs
@@ -11,12 +11,18 @@ spec = do
   let ?config = def
 
   describe "Shellcheck" $ do
+
     it "runs shellcheck on RUN instructions" $ do
       assertChecks "RUN echo $MISSING_QUOTES" failsShellcheck
       assertOnBuildChecks "RUN echo $MISSING_QUOTES" failsShellcheck
+
     it "not warns on valid scripts" $ do
       assertChecks "RUN echo foo" passesShellcheck
       assertOnBuildChecks "RUN echo foo" passesShellcheck
+
+    it "no warnings on exec notations" $ do
+      assertChecks "RUN [\"foobar\", \"$f\"]" passesShellcheck
+      assertOnBuildChecks "RUN [\"foobar\", \"$f\"]" passesShellcheck
 
     it "Does not complain on default env vars" $
       let dockerFile =


### PR DESCRIPTION
### What I did

Fix false positive Shellcheck warnings when using exec-notation with `RUN` instructions.
`RUN` instructions can be written in the exec-form where commands and their arguments are expressed as JSON-style arrays. In this case, there is no command shell like Bash, the commands are executed directly.
This means that Shellcheck's warnings would always be false-positives, since they relate only to the behavior of Bash-like command shells.

related-to: hadolint/hadolint#418

### How I did it

The type-information for the arguments of the `RUN` instruction will be `ArgumentsList ...` if and only if the instruction was in exec-form. Otherwise (in shell-form or with a heredoc), it will be a `ArgumentsText ...`.
Running shellcheck only when the type of the arguments of the `RUN` instruction is an `ArgumentsText` will disable Shellcheck when the instruction is written in exec-form.

### How to verify it

This used to generate an info-level warning `SC2086` ("Double quote to prevent globbing and word splitting."). However with this change, it should no longer generate that warning.


```dockerfile
FROM debian:foobar

RUN ["foobar", "$f"]
```

This dockerfile should (rightfully) still get the warning `SC2086`, since the `$f` argument to the foobar command would be expanded by the shell:
```dockerfile
FROM debian:foobar

RUN foobar $f
```