### PR TITLE
Ignore Pragma: Add stage ignore pragma

### DIFF
--- a/src/Hadolint/Pragma.hs
+++ b/src/Hadolint/Pragma.hs
@@ -1,5 +1,6 @@
 module Hadolint.Pragma
   ( ignored,
+    stageIgnored,
     globalIgnored,
     parseIgnorePragma,
     parseShell
@@ -27,6 +28,19 @@ ignored = Foldl.Fold parse mempty id
         _ -> acc
     parse acc _ = acc
 
+stageIgnored :: Foldl.Fold (InstructionPos Text) (Map.IntMap (Set.Set RuleCode))
+stageIgnored = Foldl.Fold parse mempty id
+  where
+    parse acc InstructionPos { instruction = Comment comment, lineNumber = line } =
+      case parseStageIgnorePragma comment of
+        Just ignores@(_ : _) -> Map.insert (line + 1) ( Set.fromList . fmap RuleCode $ ignores ) acc
+        _ -> acc
+    parse acc InstructionPos { instruction = From _ , lineNumber = line } =
+      case Map.lookup line acc of
+        Just _ -> acc
+        _ -> Map.insert line mempty acc
+    parse acc _ = acc
+
 globalIgnored :: Foldl.Fold (InstructionPos Text) (Set.Set RuleCode)
 globalIgnored = Foldl.Fold parse mempty id
   where
@@ -39,17 +53,26 @@ globalIgnored = Foldl.Fold parse mempty id
 parseIgnorePragma :: Text -> Maybe [Text]
 parseIgnorePragma = Megaparsec.parseMaybe ignoreParser
 
+parseStageIgnorePragma :: Text -> Maybe [Text]
+parseStageIgnorePragma = Megaparsec.parseMaybe stageIgnoreParser
+
 parseGlobalIgnorePragma :: Text -> Maybe [Text]
 parseGlobalIgnorePragma = Megaparsec.parseMaybe globalIgnoreParser
 
 ignoreParser :: Megaparsec.Parsec Void Text [Text]
 ignoreParser = hadolintPragma >> ignore
 
+stageIgnoreParser :: Megaparsec.Parsec Void Text [Text]
+stageIgnoreParser = hadolintPragma >> stage >> ignore
+
 globalIgnoreParser :: Megaparsec.Parsec Void Text [Text]
 globalIgnoreParser = hadolintPragma >> global >> ignore
 
 hadolintPragma :: Megaparsec.Parsec Void Text Text
 hadolintPragma = spaces >> string "hadolint" >> spaces1
+
+stage :: Megaparsec.Parsec Void Text Text
+stage = string "stage" >> spaces1
 
 global :: Megaparsec.Parsec Void Text Text
 global = string "global" >> spaces1

--- a/src/Hadolint/Process.hs
+++ b/src/Hadolint/Process.hs
@@ -84,6 +84,8 @@ import qualified Hadolint.Shell as Shell
 data AnalisisResult = AnalisisResult
   { -- | The set of ignored rules per line
     ignored :: SMap.IntMap (Set.Set RuleCode),
+    -- | The set of ignored rules per build stage
+    stageIgnored :: SMap.IntMap (Set.Set RuleCode),
     -- | The set of globally ignored rules
     globalIgnored :: Set.Set RuleCode,
     -- | A set of failures collected for reach rule
@@ -97,10 +99,24 @@ run config dockerfile = Seq.filter shouldKeep failed
 
     shouldKeep CheckFailure {line, code}
       | disableIgnorePragma config = True
-      | code `Set.member` globalIgnored = False
-      | otherwise = Just True /= do
-          ignoreList <- SMap.lookup line ignored
-          return $ code `Set.member` ignoreList
+      | otherwise = not $
+          code `Set.member` Set.unions [ ignores line, stageIgnores line, globalIgnores ]
+
+    ignores :: Int -> Set.Set RuleCode
+    ignores line =
+      case SMap.lookup line ignored of
+        Just set -> set
+        _ -> Set.empty
+
+    stageIgnores :: Int -> Set.Set RuleCode
+    stageIgnores line = do
+      let ls = 0:[x | x <- SMap.keys stageIgnored, x < line]
+      case SMap.lookup (last ls) stageIgnored of
+        Just set -> set
+        _ -> Set.empty
+
+    globalIgnores :: Set.Set RuleCode
+    globalIgnores = globalIgnored
 
 analyze ::
   Configuration ->
@@ -108,6 +124,7 @@ analyze ::
 analyze config =
   AnalisisResult
     <$> Hadolint.Pragma.ignored
+    <*> Hadolint.Pragma.stageIgnored
     <*> Hadolint.Pragma.globalIgnored
     <*> Foldl.premap parseShell (failures config)
 

--- a/test/Hadolint/PragmaSpec.hs
+++ b/test/Hadolint/PragmaSpec.hs
@@ -62,6 +62,45 @@ spec = do
             ruleCatchesNot "DL3023" $ Text.unlines dockerFile
             ruleCatchesNot "DL3021" $ Text.unlines dockerFile
 
+  describe "Rules can be ignored per stage with stage ignore pragma" $ do
+    it "ignore single rule" $
+      let dockerfile =
+            [ "# hadolint stage ignore=DL3011",
+              "FROM ubuntu",
+              "EXPOSE 80000"
+            ]
+       in ruleCatchesNot "DL3011" $ Text.unlines dockerfile
+
+    it "stage ignore rule, but catch it in different stage 1" $
+      let dockerfile =
+            [ "# hadolint stage ignore=DL3011",
+              "FROM ubuntu",
+              "EXPOSE 80000",
+              "FROM ubuntu",
+              "EXPOSE 80000"
+            ]
+       in ruleCatches "DL3011" $ Text.unlines dockerfile
+
+    it "stage ignore rule, but catch it in different stage 2" $
+      let dockerfile =
+            [ "FROM ubuntu",
+              "EXPOSE 80000",
+              "# hadolint stage ignore=DL3011",
+              "FROM ubuntu",
+              "EXPOSE 80000"
+            ]
+       in ruleCatches "DL3011" $ Text.unlines dockerfile
+
+    it "ignore multiple rules" $
+      let dockerfile =
+            [ "# hadolint stage ignore=DL3011,DL3002",
+              "FROM ubuntu",
+              "USER root",
+              "EXPOSE 80000"
+            ]
+       in do
+            ruleCatchesNot "DL3012" $ Text.unlines dockerfile
+            ruleCatchesNot "DL3011" $ Text.unlines dockerfile
 
   describe "Rules can be ignored globally with global ignore pragma" $ do
 


### PR DESCRIPTION
### What I did

Add stage ignore pragma. This works like the global ignore pragma, but only applies to the stage immediately following the pragma comment. Stage ignore pragmas that aren't immediately followed by a FROM instruction will be silently ignored.

The finer granularity of this pragma comment allows certain rules to be ignored e.g. on build stages and then later applied to the final stages of the image.

related-to: hadolint/hadolint#1096

### How to verify it

The following dockerfile is an example of the properties of the stage ignore pragma

```dockerfile
FROM debian:foobar

EXPOSE 80000  # <-- this should give a warning

# hadolint stage ignore=DL3011
FROM debian:foobar

EXPOSE 80000  # <-- the warning here should be ignored, no output for this line

FROM debian:foobar

EXPOSE 80000  # <-- this should give a warning again
```
