### PR TITLE
Fix DL3013 false positive on pipx --python flag

### DIFF
--- a/src/Hadolint/Rule/DL3013.hs
+++ b/src/Hadolint/Rule/DL3013.hs
@@ -80,6 +80,7 @@ packages cmd =
           "prefix",
           "progress-bar",
           "proxy",
+          "python",
           "python-version",
           "root",
           "src",

--- a/test/Hadolint/Rule/DL3013Spec.hs
+++ b/test/Hadolint/Rule/DL3013Spec.hs
@@ -168,3 +168,9 @@ spec = do
     it "pipenv is not pip" $ do
       ruleCatchesNot "DL3013" "RUN pipenv install black"
       onBuildRuleCatchesNot "DL3013" "RUN pipenv install black"
+    it "pipx version not pinned" $ do
+      ruleCatches "DL3013" "RUN pipx install black"
+      onBuildRuleCatches "DL3013" "RUN pipx install black"
+    it "pipx install --python argument is not a package" $ do
+      ruleCatchesNot "DL3013" "RUN pipx install --python \"$(which python)\" \"poetry==1.8.5\""
+      onBuildRuleCatchesNot "DL3013" "RUN pipx install --python \"$(which python)\" \"poetry==1.8.5\""


### PR DESCRIPTION
### What I did

DL3013 reports a missing version pin for `RUN pipx install --python "$(which python)" "poetry==1.8.5"`, because it reads the argument of the `--python` flag as a package. `poetry` itself is pinned.

### How I did it

Added `--python` to the list of flags whose argument DL3013 drops before it builds the package list. DL3013 still applies to `pipx install`, the same as `pip install`.

### How to verify it

`cabal test`

fixes #1067
