### PR TITLE
Add output to file/multiple files

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -35,8 +35,8 @@ exitProgram ::
   IO ()
 exitProgram conf res
   | noFail conf = exitSuccess
-  | CodeclimateJson == format conf = exitSuccess
-  | Codacy == format conf = exitSuccess
+  | CodeclimateJson `elem` formats conf = exitSuccess
+  | Codacy `elem` formats conf = exitSuccess
   | all (`noFailure` failureThreshold conf) res = exitSuccess
   | otherwise = exitFailure
 
@@ -49,7 +49,7 @@ runLint cmd conf = do
       filePathInReport = filePathInReportOption cmd
       destinations = output cmd
   res <- Hadolint.lintIO conf files
-  write destinations (format conf) (noColor conf) filePathInReport res
+  write destinations (formats conf) (noColor conf) filePathInReport res
   exitProgram conf res
 
 execute :: CommandlineConfig -> Configuration -> IO ()

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -2,7 +2,7 @@ module Main where
 
 import Control.Monad (when)
 import Data.Default
-import Hadolint (OutputFormat (..), printResults, DLSeverity (..))
+import Hadolint (OutputFormat (..), write, DLSeverity (..))
 import Hadolint.Config
 import Prettyprinter
 import qualified Data.List.NonEmpty as NonEmpty
@@ -47,8 +47,9 @@ runLint ::
 runLint cmd conf = do
   let files = NonEmpty.fromList $ dockerfiles cmd
       filePathInReport = filePathInReportOption cmd
+      destinations = output cmd
   res <- Hadolint.lintIO conf files
-  printResults (format conf) (noColor conf) filePathInReport res
+  write destinations (format conf) (noColor conf) filePathInReport res
   exitProgram conf res
 
 execute :: CommandlineConfig -> Configuration -> IO ()

--- a/src/Hadolint/Config/Commandline.hs
+++ b/src/Hadolint/Config/Commandline.hs
@@ -143,7 +143,7 @@ parseCommandline =
         )
 
     parseOutputFormat =
-      optional $
+      many $
         option
           ( maybeReader (readMaybeOutputFormat . pack) )
           ( long "format"

--- a/src/Hadolint/Config/Commandline.hs
+++ b/src/Hadolint/Config/Commandline.hs
@@ -44,6 +44,7 @@ data CommandlineConfig =
       configFile :: Maybe FilePath,
       dockerfiles :: [String],
       filePathInReportOption :: Maybe FilePath,
+      output :: [FilePath],
       configuration :: PartialConfiguration
     }
   deriving (Eq, Show)
@@ -55,6 +56,7 @@ parseCommandline =
     <*> parseConfigFile
     <*> parseFiles
     <*> parseFilePathInReportOption
+    <*> parseOutput
     <*> parseConfiguration
   where
     parseVersion = switch (long "version" <> short 'v' <> help "Show version")
@@ -79,6 +81,16 @@ parseCommandline =
                         \ 'sonarqube', 'junit' and 'gitlab_codeclimate' formats \
                         \ and is useful when running Hadolint with Docker to set \
                         \ the correct file path."
+            )
+        )
+
+    parseOutput =
+      many
+        ( strOption
+            ( short 'o'
+                <> long "output"
+                <> metavar "OUTPUT"
+                <> help "Output destination file"
             )
         )
 

--- a/src/Hadolint/Config/Configuration.hs
+++ b/src/Hadolint/Config/Configuration.hs
@@ -27,7 +27,7 @@ data Configuration =
     { noFail :: Bool,
       noColor :: Bool,
       verbose :: Bool,
-      format :: OutputFormat,
+      formats :: [OutputFormat],
       errorRules :: [RuleCode],
       warningRules :: [RuleCode],
       infoRules :: [RuleCode],
@@ -47,7 +47,7 @@ instance Default Configuration where
       False
       False
       False
-      def
+      mempty
       mempty
       mempty
       mempty
@@ -66,7 +66,7 @@ applyPartialConfiguration config partial =
     (fromMaybe (noFail config) (partialNoFail partial))
     (fromMaybe (noColor config) (partialNoColor partial))
     (fromMaybe (verbose config) (partialVerbose partial))
-    (fromMaybe (format config) (partialFormat partial))
+    (formats config <> partialFormats partial)
     (errorRules config <> partialErrorRules partial)
     (warningRules config <> partialWarningRules partial)
     (infoRules config <> partialInfoRules partial)
@@ -85,7 +85,7 @@ instance Pretty Configuration where
           [ "Configuration:",
             "no fail:" <+> pretty (noFail c),
             "no color:" <+> pretty (noColor c),
-            "output format:" <+> pretty (format c),
+            nest 2 ( "output format:\n" <> prettyPrintList pretty (formats c) ),
             "failure threshold:" <+> pretty (failureThreshold c),
             prettyPrintRulelist "error" (errorRules c),
             prettyPrintRulelist "warning" (warningRules c),
@@ -132,7 +132,7 @@ data PartialConfiguration =
     { partialNoFail :: Maybe Bool,
       partialNoColor :: Maybe Bool,
       partialVerbose :: Maybe Bool,
-      partialFormat :: Maybe OutputFormat,
+      partialFormats :: [OutputFormat],
       partialErrorRules :: [RuleCode],
       partialWarningRules :: [RuleCode],
       partialInfoRules :: [RuleCode],
@@ -192,7 +192,9 @@ instance Yaml.FromYAML PartialConfiguration where
     partialNoFail <- m .:? "no-fail" .!= Nothing
     partialNoColor <- m .:? "no-color" .!= Nothing
     partialVerbose <- m .:? "verbose" .!= Nothing
-    partialFormat <- m .:? "format"
+    partialFmt <- m .:? "format" .!= Nothing
+    partialFmts <- m .:? "formats" .!= mempty
+    let partialFormats = partialFmts <> listFromMaybe partialFmt
     override <- m .:? "override" .!= mempty
     ignored <- m .:? "ignored" .!= mempty
     trusted <- m .:? "trustedRegistries" .!= mempty
@@ -207,6 +209,10 @@ instance Yaml.FromYAML PartialConfiguration where
         partialAllowedRegistries = Set.fromList (coerce (trusted :: [Text]))
     partialFailureThreshold <- m .:? "failure-threshold"
     return PartialConfiguration {..}
+
+listFromMaybe :: Maybe a -> [a]
+listFromMaybe Nothing = []
+listFromMaybe (Just a) = [a]
 
 
 data OverrideConfig = OverrideConfig

--- a/src/Hadolint/Config/Environment.hs
+++ b/src/Hadolint/Config/Environment.hs
@@ -54,10 +54,18 @@ maybeTruthy name = do
 truthy :: String -> Bool
 truthy s = map toLower s `elem` ["1", "y", "on", "true", "yes"]
 
-getFormat :: IO (Maybe OutputFormat)
+getFormat :: IO [OutputFormat]
 getFormat = do
-  fmt <- lookupEnv "HADOLINT_FORMAT"
-  return $ (readMaybeOutputFormat . pack) =<< fmt
+  maybeString <- lookupEnv "HADOLINT_FORMAT"
+  case maybeString of
+    Nothing -> return []
+    Just s -> return $ flt $ map readMaybeOutputFormat $ splitOn "," (pack s)
+
+  where
+    flt :: [Maybe a] -> [a]
+    flt [] = []
+    flt (Nothing:xs) = flt xs
+    flt ((Just x):xs) = x:flt xs
 
 getOverrideList :: String -> IO [RuleCode]
 getOverrideList env = do

--- a/src/Hadolint/Formatter.hs
+++ b/src/Hadolint/Formatter.hs
@@ -44,17 +44,25 @@ hWrite handle format nocolor filePathInReport allResults =
 
 write :: Foldable f =>
   [FilePath] ->
-  OutputFormat ->
+  [OutputFormat] ->
   Bool ->
   Maybe FilePath ->
   f (Result Text DockerfileError) ->
   IO ()
-write [] format nocolor filePathInReport allResults =
-  hWrite stdout format nocolor filePathInReport allResults
-write paths format nocolor filePathInReport allResults =
-  mapM_ writePath paths
+write paths formats nocolor filePathInReport allResults =
+  mapM_ writePath ziplist
   where
-    writePath p =
-      case p == "-" of
-        True -> hWrite stdout format nocolor filePathInReport allResults
-        _ -> withFile p WriteMode (\h -> hWrite h format nocolor filePathInReport allResults)
+    ziplist = zipWithDef "-" TTY paths formats
+    writePath ( p, f ) =
+      if p == "-" then hWrite stdout f nocolor filePathInReport allResults
+      else withFile p WriteMode (\h -> hWrite h f nocolor filePathInReport allResults)
+
+
+zipWithDef :: FilePath -> OutputFormat -> [FilePath] -> [OutputFormat] -> [(FilePath, OutputFormat)]
+zipWithDef defP defF []     []     = [(defP, defF)]
+zipWithDef defP _    []     [f]    = [(defP, f)]
+zipWithDef _    defF [p]    []     = [(p, defF)]
+zipWithDef _    _    [p]    [f]    = [(p, f)]
+zipWithDef defP defF []     (f:fs) = (defP, f):zipWithDef defP defF [] fs
+zipWithDef defP defF (p:ps) []     = (p, defF):zipWithDef defP defF ps []
+zipWithDef defP defF (p:ps) (f:fs) = (p, f):zipWithDef defP defF ps fs

--- a/src/Hadolint/Formatter.hs
+++ b/src/Hadolint/Formatter.hs
@@ -1,7 +1,7 @@
 module Hadolint.Formatter
   ( OutputFormat (..),
     Result (..),
-    printResults,
+    write,
     readMaybeOutputFormat,
   )
 where
@@ -18,24 +18,43 @@ import qualified Hadolint.Formatter.Json as FormatJson
 import qualified Hadolint.Formatter.Sarif as FormatSarif
 import qualified Hadolint.Formatter.SonarQube as FormatSonarQube
 import qualified Hadolint.Formatter.TTY as FormatTTY
+import System.IO
 
 
-printResults ::
-  Foldable f =>
+hWrite :: Foldable f =>
+  Handle ->
   OutputFormat ->
   Bool ->
   Maybe FilePath ->
   f (Result Text DockerfileError) ->
   IO ()
-printResults format nocolor filePathInReport allResults =
+hWrite handle format nocolor filePathInReport allResults =
   case format of
-    Checkstyle -> FormatCheckstyle.printResults allResults filePathInReport
-    Codacy -> FormatCodacy.printResults allResults
-    CodeclimateJson -> FormatCodeclimate.printResults allResults filePathInReport
-    GitLabCodeclimateJson -> FormatCodeclimate.printGitLabResults allResults filePathInReport
-    Gnu -> FormatGnu.printResults allResults
-    JUnit -> FormatJUnit.printResults allResults filePathInReport
-    Json -> FormatJson.printResults allResults
-    Sarif -> FormatSarif.printResults allResults
-    SonarQube -> FormatSonarQube.printResults allResults filePathInReport
-    TTY -> FormatTTY.printResults allResults nocolor
+    Checkstyle -> FormatCheckstyle.hWrite handle allResults filePathInReport
+    Codacy -> FormatCodacy.hWrite handle allResults
+    CodeclimateJson -> FormatCodeclimate.hWrite handle allResults filePathInReport
+    GitLabCodeclimateJson -> FormatCodeclimate.hWriteGitLab handle allResults filePathInReport
+    Gnu -> FormatGnu.hWrite handle allResults
+    JUnit -> FormatJUnit.hWrite handle allResults filePathInReport
+    Json -> FormatJson.hWrite handle allResults
+    Sarif -> FormatSarif.hWrite handle allResults
+    SonarQube -> FormatSonarQube.hWrite handle allResults filePathInReport
+    TTY -> FormatTTY.hWrite handle allResults nocolor
+
+
+write :: Foldable f =>
+  [FilePath] ->
+  OutputFormat ->
+  Bool ->
+  Maybe FilePath ->
+  f (Result Text DockerfileError) ->
+  IO ()
+write [] format nocolor filePathInReport allResults =
+  hWrite stdout format nocolor filePathInReport allResults
+write paths format nocolor filePathInReport allResults =
+  mapM_ writePath paths
+  where
+    writePath p =
+      case p == "-" of
+        True -> hWrite stdout format nocolor filePathInReport allResults
+        _ -> withFile p WriteMode (\h -> hWrite h format nocolor filePathInReport allResults)

--- a/src/Hadolint/Formatter/Checkstyle.hs
+++ b/src/Hadolint/Formatter/Checkstyle.hs
@@ -1,4 +1,5 @@
-module Hadolint.Formatter.Checkstyle ( printResults )
+module Hadolint.Formatter.Checkstyle
+  ( hWrite )
 where
 
 import qualified Data.ByteString.Lazy.Char8 as B
@@ -13,6 +14,7 @@ import Hadolint.Formatter.Format
     severityText,
   )
 import Hadolint.Rule (CheckFailure (..), DLSeverity (..), RuleCode (..))
+import System.IO
 import Text.Megaparsec (TraversableStream)
 import Text.Megaparsec.Error
   ( ParseErrorBundle,
@@ -88,11 +90,11 @@ renderResults results filePathInReport = XML.Element
     maybeFile r = if isEmpty r then Nothing else Just $ toFile r filePathInReport
     isEmpty Result {errors=e, checks=c} = null e && null c
 
-printResults ::
+hWrite ::
   (Foldable f, VisualStream s, TraversableStream s, ShowErrorComponent e) =>
-  f (Result s e) -> Maybe FilePath -> IO ()
-printResults results filePathInReport =
-  B.putStr $ XML.renderLBS settings document
+  Handle -> f (Result s e) -> Maybe FilePath -> IO ()
+hWrite handle results filePathInReport =
+  B.hPutStr handle $ XML.renderLBS settings document
   where
     settings = XML.def -- use default render settings
     document =
@@ -101,6 +103,7 @@ printResults results filePathInReport =
           documentRoot = renderResults results filePathInReport,
           documentEpilogue = []
         }
+
 
 getFilePath :: Maybe FilePath -> Text.Text
 getFilePath Nothing = ""

--- a/src/Hadolint/Formatter/Codacy.hs
+++ b/src/Hadolint/Formatter/Codacy.hs
@@ -1,7 +1,5 @@
 module Hadolint.Formatter.Codacy
-  ( printResults,
-    formatResult,
-  )
+  ( hWrite )
 where
 
 import qualified Control.Foldl as Foldl
@@ -11,6 +9,7 @@ import Data.Sequence (Seq)
 import qualified Data.Text as Text
 import Hadolint.Formatter.Format (Result (..), errorPosition)
 import Hadolint.Rule (CheckFailure (..), RuleCode (..))
+import System.IO
 import Text.Megaparsec (TraversableStream)
 import Text.Megaparsec.Error
 import Text.Megaparsec.Pos (sourceLine, sourceName, unPos)
@@ -55,11 +54,10 @@ formatResult (Result filename errors checks) = allIssues
     errorMessages = fmap errorToIssue errors
     checkMessages = fmap (checkToIssue filename) checks
 
-printResults ::
+hWrite ::
   (Foldable f, VisualStream s, TraversableStream s, ShowErrorComponent e) =>
-  f (Result s e) ->
-  IO ()
-printResults results = mapM_ output flattened
+  Handle -> f (Result s e) -> IO ()
+hWrite handle results = mapM_ output flattened
   where
     flattened = Foldl.fold (Foldl.premap formatResult Foldl.mconcat) results
-    output value = B.putStrLn (encode value)
+    output value = B.hPutStr handle ( encode value )

--- a/src/Hadolint/Formatter/Codeclimate.hs
+++ b/src/Hadolint/Formatter/Codeclimate.hs
@@ -1,8 +1,6 @@
 module Hadolint.Formatter.Codeclimate
-  ( printResults,
-    printGitLabResults,
-    formatResult,
-    formatGitLabResult,
+  ( hWrite,
+    hWriteGitLab,
   )
 where
 
@@ -17,6 +15,7 @@ import qualified Data.Text as Text
 import GHC.Generics
 import Hadolint.Formatter.Format (Result (..), errorPosition)
 import Hadolint.Rule (CheckFailure (..), DLSeverity (..), RuleCode (..))
+import System.IO
 import Text.Megaparsec (TraversableStream)
 import Text.Megaparsec.Error
 import Text.Megaparsec.Pos (sourceColumn, sourceLine, sourceName, unPos)
@@ -130,23 +129,24 @@ formatGitLabResult ::
   Seq FingerprintIssue
 formatGitLabResult result filePathInReport = issueToFingerprintIssue <$> formatResult result filePathInReport
 
-printResult :: (VisualStream s, TraversableStream s, ShowErrorComponent e) => Result s e -> Maybe FilePath -> IO ()
-printResult result filePathInReport = mapM_ output (formatResult result filePathInReport)
+printResult :: (VisualStream s, TraversableStream s, ShowErrorComponent e) =>
+  Handle -> Result s e -> Maybe FilePath -> IO ()
+printResult handle result filePathInReport = mapM_ output (formatResult result filePathInReport)
   where
     output value = do
-      B.putStr (encode value)
-      B.putStr (B.singleton 0x00)
+      B.hPutStr handle (encode value)
+      B.hPutStr handle (B.singleton 0x00)
 
-printResults :: (VisualStream s, TraversableStream s, ShowErrorComponent e, Foldable f) => f (Result s e) -> Maybe FilePath -> IO ()
-printResults results filePathInReport = flattened
+hWrite :: (VisualStream s, TraversableStream s, ShowErrorComponent e, Foldable f) =>
+  Handle -> f (Result s e) -> Maybe FilePath -> IO ()
+hWrite handle results filePathInReport = flattened
   where
-    flattened = Foldl.fold (Foldl.premap printResult Foldl.mconcat) results filePathInReport
+    flattened = Foldl.fold (Foldl.premap ( printResult handle ) Foldl.mconcat) results filePathInReport
 
-printGitLabResults ::
+hWriteGitLab ::
   (Foldable f, VisualStream s, TraversableStream s, ShowErrorComponent e) =>
-  f (Result s e) -> Maybe FilePath ->
-  IO ()
-printGitLabResults results filePathInReport = B.putStr . encode $ flattened
+  Handle -> f (Result s e) -> Maybe FilePath -> IO ()
+hWriteGitLab handle results filePathInReport = B.hPutStr handle . encode $ flattened
   where
     flattened = Foldl.fold (Foldl.premap formatGitLabResult Foldl.mconcat) results filePathInReport
 

--- a/src/Hadolint/Formatter/Gnu.hs
+++ b/src/Hadolint/Formatter/Gnu.hs
@@ -3,51 +3,42 @@
 -- See https://www.gnu.org/prep/standards/html_node/Errors.html for reference.
 
 module Hadolint.Formatter.Gnu
-  ( printResults,
-  )
+  ( hWrite )
 where
 
 
-import Data.Text (Text, pack)
+import Data.Text (Text, pack, unpack)
 import Hadolint.Formatter.Format
 import Hadolint.Rule (CheckFailure (..), RuleCode (..))
+import System.IO
 import Text.Megaparsec (TraversableStream)
 import Text.Megaparsec.Error
 import Text.Megaparsec.Stream (VisualStream)
 import qualified Data.List.NonEmpty as NonEmpty
-import qualified Data.Text.IO as TextIO
 
-
-printResults ::
+hWrite ::
   (VisualStream s, TraversableStream s, ShowErrorComponent e, Foldable f) =>
-  f (Result s e) ->
-  IO ()
-printResults = mapM_ printResult
-
+  Handle -> f (Result s e) -> IO ()
+hWrite handle = mapM_ ( printResult handle )
 
 printResult ::
   (VisualStream s, TraversableStream s, ShowErrorComponent e) =>
-  Result s e ->
-  IO ()
-printResult (Result filename errors checks) =
-  printErrors errors >> printChecks filename checks
-
+  Handle -> Result s e -> IO ()
+printResult handle (Result filename errors checks) =
+  printErrors handle errors >> printChecks handle filename checks
 
 printErrors ::
   (VisualStream s, TraversableStream s, ShowErrorComponent e, Foldable f) =>
-  f (ParseErrorBundle s e) ->
-  IO ()
-printErrors = mapM_ (TextIO.putStrLn . formatError)
+  Handle -> f (ParseErrorBundle s e) -> IO ()
+printErrors handle = mapM_ ( hPutStrLn handle . unpack . formatError )
 
-
-printChecks :: (Foldable f) => Text -> f CheckFailure -> IO ()
-printChecks filename = mapM_ (TextIO.putStrLn . formatCheck filename)
+printChecks :: (Foldable f) => Handle -> Text -> f CheckFailure -> IO ()
+printChecks handle filename = mapM_ ( hPutStrLn handle . unpack . formatCheck filename )
 
 
 formatError ::
   (VisualStream s, TraversableStream s, ShowErrorComponent e) =>
-  ParseErrorBundle s e ->
-  Text
+  ParseErrorBundle s e -> Text
 formatError err@(ParseErrorBundle e _) =
   pack $
     "hadolint:"

--- a/src/Hadolint/Formatter/JUnit.hs
+++ b/src/Hadolint/Formatter/JUnit.hs
@@ -1,4 +1,4 @@
-module Hadolint.Formatter.JUnit ( printResults ) where
+module Hadolint.Formatter.JUnit ( hWrite ) where
 
 
 import qualified Data.ByteString.Lazy.Char8 as B
@@ -15,6 +15,7 @@ import Hadolint.Formatter.Format
   )
 import Hadolint.Rule (CheckFailure (..), RuleCode (..))
 import Hadolint.Meta (getShortVersion)
+import System.IO (Handle)
 import Text.Megaparsec (TraversableStream)
 import Text.Megaparsec.Error
   ( ParseErrorBundle,
@@ -32,12 +33,12 @@ providerID :: Text.Text
 providerID = "hadolint"
 
 
-printResults ::
+hWrite ::
   (Foldable f, VisualStream s, TraversableStream s, ShowErrorComponent e) =>
-  f (Result s e) -> Maybe FilePath -> IO ()
-printResults results maybeFilepath = do
+  Handle -> f (Result s e) -> Maybe FilePath -> IO ()
+hWrite handle results maybeFilepath = do
   time <- Time.getCurrentTime
-  B.putStr $ XML.renderLBS settings $ document time
+  B.hPutStr handle $ XML.renderLBS settings $ document time
 
   where
     settings = XML.def

--- a/src/Hadolint/Formatter/Json.hs
+++ b/src/Hadolint/Formatter/Json.hs
@@ -1,7 +1,5 @@
 module Hadolint.Formatter.Json
-  ( printResults,
-    formatResult,
-  )
+  ( hWrite )
 where
 
 import qualified Control.Foldl as Foldl
@@ -16,6 +14,7 @@ import Hadolint.Formatter.Format
     errorMessage
   )
 import Hadolint.Rule (CheckFailure (..), DLSeverity (..), unRuleCode)
+import System.IO
 import Text.Megaparsec (TraversableStream)
 import Text.Megaparsec.Error
 import Text.Megaparsec.Pos (sourceColumn, sourceLine, sourceName, unPos)
@@ -47,11 +46,10 @@ instance (VisualStream s, TraversableStream s, ShowErrorComponent e) => ToJSON (
     where
       pos = errorPosition err
 
-printResults ::
+hWrite ::
   (VisualStream s, TraversableStream s, ShowErrorComponent e, Foldable f) =>
-  f (Result s e) ->
-  IO ()
-printResults results = B.putStr . encode $ flattened
+  Handle -> f (Result s e) -> IO ()
+hWrite handle results = B.hPutStr handle . encode $ flattened
   where
     flattened = Foldl.fold (Foldl.premap formatResult Foldl.mconcat) results
 

--- a/src/Hadolint/Formatter/Sarif.hs
+++ b/src/Hadolint/Formatter/Sarif.hs
@@ -1,7 +1,5 @@
 module Hadolint.Formatter.Sarif
-  ( printResults,
-    formatResult,
-  )
+  ( hWrite )
 where
 
 import qualified Control.Foldl as Foldl
@@ -22,6 +20,7 @@ import Hadolint.Rule
     DLSeverity (..),
     unRuleCode,
   )
+import System.IO
 import Text.Megaparsec (TraversableStream)
 import Text.Megaparsec.Error
 import Text.Megaparsec.Pos
@@ -115,16 +114,15 @@ formatResult (Result filename errors checks) = allMessages
     checkMessages = fmap (SarifCheck filename) checks
     errorMessages = fmap SarifError errors
 
-printResults ::
+hWrite ::
   ( VisualStream s,
     TraversableStream s,
     ShowErrorComponent e,
     Foldable f
   ) =>
-  f (Result s e) ->
-  IO ()
-printResults results =
-  B.putStr . encode $
+  Handle -> f (Result s e) -> IO ()
+hWrite handle results =
+  B.hPutStr handle . encode $
     object
       [ ("version", "2.1.0"),
         "$schema"

--- a/src/Hadolint/Formatter/SonarQube.hs
+++ b/src/Hadolint/Formatter/SonarQube.hs
@@ -1,8 +1,6 @@
 module Hadolint.Formatter.SonarQube
-  ( formatResult,
-    printResults
-  )
-  where
+  ( hWrite )
+where
 
 import qualified Control.Foldl as Foldl
 import Data.Aeson hiding (Result)
@@ -19,6 +17,7 @@ import Hadolint.Rule
     DLSeverity (..),
     unRuleCode
   )
+import System.IO
 import Text.Megaparsec (TraversableStream)
 import Text.Megaparsec.Error
 import Text.Megaparsec.Pos
@@ -84,12 +83,15 @@ formatResult filePathInReport (Result filename errors checks) = allMessages
     checkMessages = fmap (SonarQubeCheck filepath) checks
     filepath = if null filePathInReport then filename else getFilePath filePathInReport
 
-printResults :: (VisualStream s,
-  TraversableStream s,
-  ShowErrorComponent e,
-  Foldable f) => f (Result s e) -> Maybe FilePath -> IO ()
-printResults results filePathInReport =
-  B.putStr . encode $ object [ "issues" .= flattened ]
+hWrite ::
+  ( VisualStream s,
+    TraversableStream s,
+    ShowErrorComponent e,
+    Foldable f
+  ) =>
+  Handle -> f (Result s e) -> Maybe FilePath -> IO ()
+hWrite handle results filePathInReport =
+  B.hPutStr handle . encode $ object [ "issues" .= flattened ]
   where
     flattened = Foldl.fold (Foldl.premap (formatResult filePathInReport) Foldl.mconcat) results
 

--- a/src/Hadolint/Formatter/TTY.hs
+++ b/src/Hadolint/Formatter/TTY.hs
@@ -1,10 +1,7 @@
-{-# LANGUAGE NamedFieldPuns #-}
-{-# LANGUAGE OverloadedStrings #-}
-
 module Hadolint.Formatter.TTY
-  ( printResults,
+  ( hWrite,
     formatCheck,
-    formatError,
+    formatError
   )
 where
 
@@ -14,6 +11,7 @@ import qualified Data.Text as Text
 import Hadolint.Formatter.Format
 import Hadolint.Rule (CheckFailure (..), DLSeverity (..), RuleCode (..))
 import Language.Docker.Syntax
+import System.IO (Handle, hPutStrLn)
 import Text.Megaparsec (TraversableStream)
 import Text.Megaparsec.Error
 import Text.Megaparsec.Stream (VisualStream)
@@ -36,16 +34,17 @@ formatCheck nocolor source CheckFailure {code, severity, line, message} =
 formatPos :: Filename -> Linenumber -> Text.Text
 formatPos source line = source <> ":" <> Text.pack (show line) <> " "
 
-printResults ::
+hWrite ::
   (VisualStream s, TraversableStream s, ShowErrorComponent e, Foldl.Foldable f) =>
+  Handle ->
   f (Result s e) ->
   Bool ->
   IO ()
-printResults results color = mapM_ printResult results
+hWrite handle results color = mapM_ writeResult results
   where
-    printResult Result {fileName, errors, checks} = printErrors errors >> printChecks fileName checks
-    printErrors = mapM_ (putStrLn . formatError)
-    printChecks fileName = mapM_ (putStrLn . Text.unpack . formatCheck color fileName)
+    writeResult Result {fileName, errors, checks} = writeErrors errors >> writeChecks fileName checks
+    writeErrors = mapM_ (hPutStrLn handle . formatError)
+    writeChecks fileName = mapM_ (hPutStrLn handle . Text.unpack . formatCheck color fileName)
 
 colorizedSeverity :: DLSeverity -> Text.Text
 colorizedSeverity s =

--- a/test/Hadolint/Config/CommandlineSpec.hs
+++ b/test/Hadolint/Config/CommandlineSpec.hs
@@ -168,23 +168,33 @@ spec = do
                                 []
                                 mempty { partialVerbose = Just True }
 
-      it "parse -f json" $ do
-        checkCommandline ["-f", "json"] $ CommandlineConfig
-                                False
-                                Nothing
-                                []
-                                Nothing
-                                []
-                                mempty { partialFormat = Just Json }
+      describe "parse format options" $ do
+        it "parse -f json" $ do
+          checkCommandline ["-f", "json"] $ CommandlineConfig
+                                  False
+                                  Nothing
+                                  []
+                                  Nothing
+                                  []
+                                  mempty { partialFormats = [Json] }
 
-      it "parse --format" $ do
-        checkCommandline ["--format", "sarif"] $ CommandlineConfig
-                                False
-                                Nothing
-                                []
-                                Nothing
-                                []
-                                mempty { partialFormat = Just Sarif }
+        it "parse --format" $ do
+          checkCommandline ["--format", "sarif"] $ CommandlineConfig
+                                  False
+                                  Nothing
+                                  []
+                                  Nothing
+                                  []
+                                  mempty { partialFormats = [Sarif] }
+
+        it "parse multiple --format" $ do
+          checkCommandline ["-f", "junit", "--format", "sarif"] $ CommandlineConfig
+                                  False
+                                  Nothing
+                                  []
+                                  Nothing
+                                  []
+                                  mempty { partialFormats = [JUnit, Sarif] }
 
     describe "parse severity overrides" $ do
       it "parse --error=DL3010" $ do

--- a/test/Hadolint/Config/CommandlineSpec.hs
+++ b/test/Hadolint/Config/CommandlineSpec.hs
@@ -23,6 +23,7 @@ spec = do
                               Nothing
                               []
                               Nothing
+                              []
                               mempty
 
     describe "parse version flag" $ do
@@ -32,6 +33,7 @@ spec = do
                                 Nothing
                                 []
                                 Nothing
+                                []
                                 mempty
 
       it "parse --version" $ do
@@ -40,6 +42,7 @@ spec = do
                                 Nothing
                                 []
                                 Nothing
+                                []
                                 mempty
 
     describe "parse config file option" $ do
@@ -49,6 +52,7 @@ spec = do
                                 (Just "hadolint.yaml")
                                 []
                                 Nothing
+                                []
                                 mempty
 
       it "parse --config hadolint.yaml" $ do
@@ -57,6 +61,7 @@ spec = do
                                 (Just "hadolint.yaml")
                                 []
                                 Nothing
+                                []
                                 mempty
 
     describe "parse file arguments" $ do
@@ -66,6 +71,7 @@ spec = do
                                 Nothing
                                 ["Dockerfile"]
                                 Nothing
+                                []
                                 mempty
 
       it "parse `Dockerfile1 Dockerfile2`" $ do
@@ -74,6 +80,7 @@ spec = do
                                 Nothing
                                 ["Dockerfile1", "Dockerfile2"]
                                 Nothing
+                                []
                                 mempty
 
       it "parse --file-path-in-report foobar/Dockerfile" $ do
@@ -84,17 +91,55 @@ spec = do
               Nothing
               []
               (Just "foobar/Dockerfile")
+              []
+              mempty
+          )
+
+      it "parse single output destination - short form" $ do
+        checkCommandline
+          ["-o", "report.log"]
+          ( CommandlineConfig
+              False
+              Nothing
+              []
+              Nothing
+              ["report.log"]
+              mempty
+          )
+
+      it "parse single output destination - long form" $ do
+        checkCommandline
+          ["--output", "report.log"]
+          ( CommandlineConfig
+              False
+              Nothing
+              []
+              Nothing
+              ["report.log"]
+              mempty
+          )
+
+      it "parse multiple output destinations" $ do
+        checkCommandline
+          ["--output", "report.log", "-o", "other-report.log"]
+          ( CommandlineConfig
+              False
+              Nothing
+              []
+              Nothing
+              ["report.log", "other-report.log"]
               mempty
           )
 
     describe "parse general configuration" $ do
       it "parse --no-fail" $ do
         checkCommandline ["--no-fail"] $ CommandlineConfig
-                                          False
-                                          Nothing
-                                          []
-                                          Nothing
-                                          mempty { partialNoFail = Just True }
+                                            False
+                                            Nothing
+                                            []
+                                            Nothing
+                                            []
+                                            mempty { partialNoFail = Just True }
 
       it "parse --no-color" $ do
         checkCommandline ["--no-color"] $ CommandlineConfig
@@ -102,6 +147,7 @@ spec = do
                                             Nothing
                                             []
                                             Nothing
+                                            []
                                             mempty { partialNoColor = Just True }
 
       it "parse -V" $ do
@@ -110,6 +156,7 @@ spec = do
                                 Nothing
                                 []
                                 Nothing
+                                []
                                 mempty { partialVerbose = Just True }
 
       it "parse --verbose" $ do
@@ -118,6 +165,7 @@ spec = do
                                 Nothing
                                 []
                                 Nothing
+                                []
                                 mempty { partialVerbose = Just True }
 
       it "parse -f json" $ do
@@ -126,6 +174,7 @@ spec = do
                                 Nothing
                                 []
                                 Nothing
+                                []
                                 mempty { partialFormat = Just Json }
 
       it "parse --format" $ do
@@ -134,6 +183,7 @@ spec = do
                                 Nothing
                                 []
                                 Nothing
+                                []
                                 mempty { partialFormat = Just Sarif }
 
     describe "parse severity overrides" $ do
@@ -143,6 +193,7 @@ spec = do
                                 Nothing
                                 []
                                 Nothing
+                                []
                                 mempty { partialErrorRules = ["DL3010"] }
 
       it "parse --error=DL3010 --error=DL3020" $ do
@@ -153,6 +204,7 @@ spec = do
               Nothing
               []
               Nothing
+              []
               mempty { partialErrorRules = ["DL3010", "DL3020"] }
           )
 
@@ -162,6 +214,7 @@ spec = do
                                 Nothing
                                 []
                                 Nothing
+                                []
                                 mempty { partialWarningRules = ["DL3010"] }
 
       it "parse --warning=DL3010 --warning=DL3020" $ do
@@ -172,6 +225,7 @@ spec = do
               Nothing
               []
               Nothing
+              []
               mempty { partialWarningRules = ["DL3010", "DL3020"] }
           )
 
@@ -181,6 +235,7 @@ spec = do
                                 Nothing
                                 []
                                 Nothing
+                                []
                                 mempty { partialInfoRules = ["DL3010"] }
 
       it "parse --info=DL3010 --info=DL3020" $ do
@@ -191,6 +246,7 @@ spec = do
               Nothing
               []
               Nothing
+              []
               mempty { partialInfoRules = ["DL3010", "DL3020"] }
           )
 
@@ -200,6 +256,7 @@ spec = do
                                 Nothing
                                 []
                                 Nothing
+                                []
                                 mempty { partialStyleRules = ["DL3010"] }
 
       it "parse --style=DL3010 --style=DL3020" $ do
@@ -210,6 +267,7 @@ spec = do
               Nothing
               []
               Nothing
+              []
               mempty { partialStyleRules = ["DL3010", "DL3020"] }
           )
 
@@ -219,6 +277,7 @@ spec = do
                                 Nothing
                                 []
                                 Nothing
+                                []
                                 mempty { partialIgnoreRules = ["DL3010"] }
 
       it "parse --ignore=DL3010 --ignore=DL3020" $ do
@@ -229,6 +288,7 @@ spec = do
               Nothing
               []
               Nothing
+              []
               mempty { partialIgnoreRules = ["DL3010", "DL3020"] }
           )
 
@@ -241,6 +301,7 @@ spec = do
               Nothing
               []
               Nothing
+              []
               mempty { partialAllowedRegistries = Set.fromList ["foobar.com"] }
           )
 
@@ -256,6 +317,7 @@ spec = do
               Nothing
               []
               Nothing
+              []
               mempty
                 { partialAllowedRegistries =
                     Set.fromList ["foobar.com", "barfoo.io"]
@@ -271,6 +333,7 @@ spec = do
               Nothing
               []
               Nothing
+              []
               mempty { partialLabelSchema = Map.fromList [("foo", Email)] }
           )
 
@@ -282,6 +345,7 @@ spec = do
               Nothing
               []
               Nothing
+              []
               mempty
                 { partialLabelSchema =
                     Map.fromList [("foo", Email), ("bar", RawText)]
@@ -297,6 +361,7 @@ spec = do
               Nothing
               []
               Nothing
+              []
               mempty { partialStrictLabels = Just True }
           )
 
@@ -309,6 +374,7 @@ spec = do
               Nothing
               []
               Nothing
+              []
               mempty { partialDisableIgnorePragma = Just True }
           )
 
@@ -319,6 +385,7 @@ spec = do
                                 Nothing
                                 []
                                 Nothing
+                                []
                                 mempty
                                   { partialFailureThreshold = Just DLWarningC }
 
@@ -328,6 +395,7 @@ spec = do
                                 Nothing
                                 []
                                 Nothing
+                                []
                                 mempty
                                   { partialFailureThreshold = Just DLStyleC }
 

--- a/test/Hadolint/Config/ConfigfileSpec.hs
+++ b/test/Hadolint/Config/ConfigfileSpec.hs
@@ -46,15 +46,24 @@ spec =
           conf = parseYaml yaml
       conf `shouldBe` Right mempty { partialVerbose = Just False }
 
-    it "parse `format: json`" $ do
-      let yaml = ["format: json"]
-          conf = parseYaml yaml
-      conf `shouldBe` Right mempty { partialFormat = Just Json }
+    describe "parse format options" $ do
+      it "parse `format: json`" $ do
+        let yaml = ["format: json"]
+            conf = parseYaml yaml
+        conf `shouldBe` Right mempty { partialFormats = [Json] }
 
-    it "parse `format: sarif`" $ do
-      let yaml = ["format: sarif"]
-          conf = parseYaml yaml
-      conf `shouldBe` Right mempty { partialFormat = Just Sarif }
+      it "parse `format: sarif`" $ do
+        let yaml = ["format: sarif"]
+            conf = parseYaml yaml
+        conf `shouldBe` Right mempty { partialFormats = [Sarif] }
+
+      it "parse multiple formats" $ do
+        let yaml = [ "formats:",
+                     "  - sarif",
+                     "  - json"
+                   ]
+            conf = parseYaml yaml
+        conf `shouldBe` Right mempty { partialFormats = [Sarif, Json] }
 
     it "parse override error rules" $ do
       let yaml = [ "override:",

--- a/test/Hadolint/Config/ConfigurationSpec.hs
+++ b/test/Hadolint/Config/ConfigurationSpec.hs
@@ -33,9 +33,9 @@ spec = do
         `shouldBe` def { verbose = True }
 
     it "override default with specific configuration: output-format json" $ do
-      let config = def { partialFormat = Just Json }
+      let config = def { partialFormats = [Json] }
       applyPartialConfiguration def config
-        `shouldBe` def { format = Json }
+        `shouldBe` def { formats = [Json] }
 
     it "override default with specific configuration: disable ignore pragma" $ do
       let config = def { partialDisableIgnorePragma = Just True }

--- a/test/Hadolint/Config/EnvironmentSpec.hs
+++ b/test/Hadolint/Config/EnvironmentSpec.hs
@@ -61,15 +61,26 @@ spec = do
         conf <- getConfigFromEnvironment
         conf `shouldBe` mempty { partialVerbose = Just False }
 
-    withJustEnv "HADOLINT_FORMAT" "json" $ do
-      it "parse HADOLINT_FORMAT=json" $ do
-        conf <- getConfigFromEnvironment
-        conf `shouldBe` mempty { partialFormat = Just Json }
+    describe "parse formats" $ do
+      withJustEnv "HADOLINT_FORMAT" "json" $ do
+        it "parse HADOLINT_FORMAT=json" $ do
+          conf <- getConfigFromEnvironment
+          conf `shouldBe` mempty { partialFormats = [Json] }
 
-    withJustEnv "HADOLINT_FORMAT" "sarif" $ do
-      it "parse HADOLINT_FORMAT=sarif" $ do
-        conf <- getConfigFromEnvironment
-        conf `shouldBe` mempty { partialFormat = Just Sarif }
+      withJustEnv "HADOLINT_FORMAT" "sarif" $ do
+        it "parse HADOLINT_FORMAT=sarif" $ do
+          conf <- getConfigFromEnvironment
+          conf `shouldBe` mempty { partialFormats = [Sarif] }
+
+      withJustEnv "HADOLINT_FORMAT" "sarif,json" $ do
+        it "parse HADOLINT_FORMAT=sarif,json" $ do
+          conf <- getConfigFromEnvironment
+          conf `shouldBe` mempty { partialFormats = [Sarif, Json] }
+
+      withJustEnv "HADOLINT_FORMAT" "junk,json" $ do
+        it "parse HADOLINT_FORMAT=junk,json" $ do
+          conf <- getConfigFromEnvironment
+          conf `shouldBe` mempty { partialFormats = [Json] }
 
     withJustEnv "HADOLINT_OVERRIDE_ERROR" "DL3010" $ do
       it "parse HADOLINT_OVERRIDE_ERROR=DL3010" $ do

--- a/test/Hadolint/Formatter/SonarQubeSpec.hs
+++ b/test/Hadolint/Formatter/SonarQubeSpec.hs
@@ -113,5 +113,5 @@ spec = do
                     ]
               ]
           expected = Object ["issues" .= Array [mkCustomIssue "path/to/custom/Dockerfile"]]
-      (cap, _) <- capture (write [] SonarQube ?noColor customPath results)
+      (cap, _) <- capture (write [] [SonarQube] ?noColor customPath results)
       decode (BSC.pack cap) `shouldBe` Just expected

--- a/test/Hadolint/Formatter/SonarQubeSpec.hs
+++ b/test/Hadolint/Formatter/SonarQubeSpec.hs
@@ -4,7 +4,7 @@ import Data.Aeson
 import qualified Data.ByteString.Lazy.Char8 as BSC
 import qualified Data.List.NonEmpty as NonEmpty
 import qualified Data.Sequence as Seq
-import Hadolint.Formatter (printResults)
+import Hadolint.Formatter (write)
 import Hadolint.Formatter.Format (Result (..))
 import Helpers
 import Hadolint
@@ -113,5 +113,5 @@ spec = do
                     ]
               ]
           expected = Object ["issues" .= Array [mkCustomIssue "path/to/custom/Dockerfile"]]
-      (cap, _) <- capture (printResults SonarQube ?noColor customPath results)
+      (cap, _) <- capture (write [] SonarQube ?noColor customPath results)
       decode (BSC.pack cap) `shouldBe` Just expected

--- a/test/Hadolint/Formatter/TTYSpec.hs
+++ b/test/Hadolint/Formatter/TTYSpec.hs
@@ -1,12 +1,9 @@
 module Hadolint.Formatter.TTYSpec (spec) where
 
 import Helpers
-import Data.List.NonEmpty as NonEmpty
-import Hadolint (OutputFormat (..), write)
-import Hadolint.Formatter.Format (Result (..))
+import Hadolint (OutputFormat (..))
 import Hadolint.Rule (CheckFailure (..), DLSeverity (..))
 import Test.Hspec
-import qualified Data.Sequence as Seq
 
 
 spec :: SpecWith ()
@@ -14,8 +11,9 @@ spec = do
   let ?noColor = True
   describe "Formatter: TTY" $ do
     it "print empty results" $ do
-      let results = NonEmpty.fromList [Result "<string>" mempty Seq.empty]
-      write [] TTY True (Just "<string>") results `shouldReturn` ()
+      let checkFails = []
+          expectation = unlines []
+      assertFormatter TTY checkFails expectation
 
     it "print some result: no colors" $ do
       let checkFails = [ CheckFailure

--- a/test/Hadolint/Formatter/TTYSpec.hs
+++ b/test/Hadolint/Formatter/TTYSpec.hs
@@ -2,7 +2,7 @@ module Hadolint.Formatter.TTYSpec (spec) where
 
 import Helpers
 import Data.List.NonEmpty as NonEmpty
-import Hadolint (OutputFormat (..), printResults)
+import Hadolint (OutputFormat (..), write)
 import Hadolint.Formatter.Format (Result (..))
 import Hadolint.Rule (CheckFailure (..), DLSeverity (..))
 import Test.Hspec
@@ -15,7 +15,7 @@ spec = do
   describe "Formatter: TTY" $ do
     it "print empty results" $ do
       let results = NonEmpty.fromList [Result "<string>" mempty Seq.empty]
-      printResults TTY True (Just "<string>") results `shouldReturn` ()
+      write [] TTY True (Just "<string>") results `shouldReturn` ()
 
     it "print some result: no colors" $ do
       let checkFails = [ CheckFailure

--- a/test/Helpers.hs
+++ b/test/Helpers.hs
@@ -3,7 +3,7 @@ module Helpers where
 import Control.Monad (unless, when)
 import qualified Data.ByteString.Lazy.Char8 as BSC
 import Data.Aeson hiding (Result)
-import Hadolint (Configuration (..), OutputFormat (..), printResults)
+import Hadolint (Configuration (..), OutputFormat (..), write)
 import Hadolint.Formatter.Format (Result (..))
 import Hadolint.Formatter.TTY (formatCheck)
 import Hadolint.Rule (CheckFailure (..), Failures, RuleCode (..))
@@ -137,7 +137,7 @@ assertFormatter formatter failures expectation = do
   let results =
         NonEmpty.fromList [Result "<string>" mempty (Seq.fromList failures)]
   (cap, _) <- capture
-                (printResults formatter ?noColor (Just "<string>") results)
+                (write [] formatter ?noColor (Just "<string>") results)
   cap `shouldBe` expectation
 
 assertFormatterJson
@@ -150,7 +150,7 @@ assertFormatterJson formatter failures expectation = do
   let results =
         NonEmpty.fromList [ Result "<string>" mempty (Seq.fromList failures) ]
   (cap, _) <- capture
-                (printResults formatter ?noColor (Just "<string>") results)
+                (write [] formatter ?noColor (Just "<string>") results)
   decode (BSC.pack cap) `shouldBe` Just expectation
 
 assertFormatterXML

--- a/test/Helpers.hs
+++ b/test/Helpers.hs
@@ -126,18 +126,17 @@ passesShellcheck checks =
   where
     matched = Seq.filter (\CheckFailure {code = RuleCode rc} -> "SC" `Text.isPrefixOf` rc) checks
 
-
 assertFormatter ::
   (HasCallStack, ?noColor :: Bool) =>
   OutputFormat ->
   [CheckFailure] ->
   String ->
   Assertion
-assertFormatter formatter failures expectation = do
+assertFormatter format failures expectation = do
   let results =
         NonEmpty.fromList [Result "<string>" mempty (Seq.fromList failures)]
   (cap, _) <- capture
-                (write [] formatter ?noColor (Just "<string>") results)
+                (write [] [format] ?noColor (Just "<string>") results)
   cap `shouldBe` expectation
 
 assertFormatterJson
@@ -146,11 +145,11 @@ assertFormatterJson
   [CheckFailure] ->
   Value ->
   Assertion
-assertFormatterJson formatter failures expectation = do
+assertFormatterJson format failures expectation = do
   let results =
         NonEmpty.fromList [ Result "<string>" mempty (Seq.fromList failures) ]
   (cap, _) <- capture
-                (write [] formatter ?noColor (Just "<string>") results)
+                (write [] [format] ?noColor (Just "<string>") results)
   decode (BSC.pack cap) `shouldBe` Just expectation
 
 assertFormatterXML
@@ -159,9 +158,9 @@ assertFormatterXML
   [CheckFailure] ->
   XML.Document ->
   Assertion
-assertFormatterXML formatter failures expectation = do
+assertFormatterXML format failures expectation = do
   let results =
         NonEmpty.fromList [ Result "<string>" mempty (Seq.fromList failures) ]
   (cap, _) <- capture
-                (printResults formatter ?noColor (Just "<string>") results)
+                (write [] [format] ?noColor (Just "<string>") results)
   XML.parseLBS_ XML.def (BSC.pack cap) `shouldBe` expectation


### PR DESCRIPTION
### What I did

Add command line option to write output directly to a file. This makes it possible to use Hadolint in scenarios where the output can not be redirected by a command shell or multiple output destinations are needed.

The new command line option is `-o` or `--output`. It can be given multiple times, in which case the result is written to all destinations.

The default behavior remains the same, Hadolint will still print the results on stdout by default.

The result can also be forced on stdout when using the special file name `-`, e.g.: `hadolint -o - `. This is usefule when writing the output to multiple destinations.

This changes the interfaces of the formatters. Instead of a `printResults` function, which always writes to stdout, the formatters now expose an `hWrite` function, which takes a file handle as additional argument.
This decouples the output destination from the formatters and lets Hadolint call the formatters multiple times to write to multiple output destinations.
It also lets Hadolint choose where to write the result based on command line options, rather than having the destination hard-coded in the formatters themselves.

Additionally, the `-f/--format` option is now accepted multiple times. Each format option will be applied to the corresponding output, i.e. the first format to the first output, the second format to the second output and so on.
Each `-f/--format` without a corresponding `-o/--output` option will be printed to the default destination: stdout. Each output without a corresponding `-f/--format` will be printed in the default format.
The formats can also be set via the config file with the new key `formats`, e.g.:
```yaml
formats:
  - json
  - sarif
```
Or via the environment variable `HADOLINT_FORMAT` as comma separated list.
The existing config file key `format` (without `s` at the end) is still valid and will be taken into account, i.e.
```yaml
format: tty
formats:
  - json
  - sarif
```
is the same as `-f tty -f json -f sarif`.

A practical example would be the following invocation, producing human readable output on the command line stdout as well as a machine readable report file:
```
hadolint -f junit -o report.xml -f tty Dockerfile
```

related-to: hadolint/hadolint#837