### PR TITLE
Fix DL3013 false positive on pip --root-user-action flag

### DIFF
--- a/src/Hadolint/Rule/DL3013.hs
+++ b/src/Hadolint/Rule/DL3013.hs
@@ -83,6 +83,7 @@ packages cmd =
           "python",
           "python-version",
           "root",
+          "root-user-action",
           "src",
           "t",
           "target",

--- a/src/Hadolint/Shell.hs
+++ b/src/Hadolint/Shell.hs
@@ -219,7 +219,10 @@ hasArg arg Command {arguments} = not $ null [a | CmdPart a _ <- arguments, a == 
 dropFlagArg :: [Text.Text] -> Command -> Command
 dropFlagArg flagsToDrop Command {name, arguments, flags} = Command name filteredArgs flags
   where
-    idsToDrop = Set.fromList [getValueId fId arguments | CmdPart f fId <- flags, f `elem` flagsToDrop]
+    idsToDrop =
+      Set.fromList
+        [getValueId fId arguments | CmdPart f fId <- flags, f `elem` flagsToDrop, not (hasInlineValue fId)]
+    hasInlineValue fId = or ["=" `Text.isInfixOf` a | CmdPart a aId <- arguments, aId == fId]
     filteredArgs = [arg | arg@(CmdPart _ aId) <- arguments, not (aId `Set.member` idsToDrop)]
 
 -- | given a flag and a command, return list of arguments for that particular

--- a/test/Hadolint/Rule/DL3013Spec.hs
+++ b/test/Hadolint/Rule/DL3013Spec.hs
@@ -174,3 +174,9 @@ spec = do
     it "pipx install --python argument is not a package" $ do
       ruleCatchesNot "DL3013" "RUN pipx install --python \"$(which python)\" \"poetry==1.8.5\""
       onBuildRuleCatchesNot "DL3013" "RUN pipx install --python \"$(which python)\" \"poetry==1.8.5\""
+    it "pip install --root-user-action argument is not a package" $ do
+      ruleCatchesNot "DL3013" "RUN pip install --no-cache-dir --root-user-action ignore poetry==1.8.5"
+      onBuildRuleCatchesNot "DL3013" "RUN pip install --no-cache-dir --root-user-action ignore poetry==1.8.5"
+    it "pip install flag=value still checks the package" $ do
+      ruleCatches "DL3013" "RUN pip install --root-user-action=ignore mypkg"
+      onBuildRuleCatches "DL3013" "RUN pip install --root-user-action=ignore mypkg"

--- a/test/Hadolint/ShellSpec.hs
+++ b/test/Hadolint/ShellSpec.hs
@@ -51,3 +51,8 @@ spec =
                         [ CmdPart "loglevel" 1]
        in do
         dropFlagArg ["loglevel"] cmd `shouldBe` res
+  --
+    it "dropFlagArg keeps the next argument when the flag value is inline" $ do
+      let cmds = presentCommands (parseShell "npm --loglevel=info install bla@1.0.0")
+      cmds `shouldNotBe` []
+      map (dropFlagArg ["loglevel"]) cmds `shouldBe` cmds


### PR DESCRIPTION
### What I did

DL3013 fires on `RUN pip install --no-cache-dir --root-user-action ignore poetry==1.8.5`. It reads `ignore`, the value of `--root-user-action`, as a package with no version pin. `poetry` is already pinned.

### How I did it

Added `--root-user-action` to the list of value-taking flags the rule drops. On its own that broke the `=` form, where `dropFlagArg` dropped the package instead of the attached value. Now `dropFlagArg` keeps the next argument when the value is attached with `=`.

### How to verify it

`cabal test`

fixes #1064
