### PR TITLE
Add DL4007 rule to detect COPY . . in Dockerfiles

### DIFF
--- a/hadolint.cabal
+++ b/hadolint.cabal
@@ -320,6 +320,7 @@ test-suite hadolint-unit-tests
     Hadolint.Rule.DL4004Spec
     Hadolint.Rule.DL4005Spec
     Hadolint.Rule.DL4006Spec
+    Hadolint.Rule.DL4007Spec
     Hadolint.Rule.ShellcheckSpec
     Hadolint.ShellSpec
     Helpers

--- a/src/Hadolint/Process.hs
+++ b/src/Hadolint/Process.hs
@@ -77,6 +77,7 @@ import qualified Hadolint.Rule.DL4003
 import qualified Hadolint.Rule.DL4004
 import qualified Hadolint.Rule.DL4005
 import qualified Hadolint.Rule.DL4006
+import qualified Hadolint.Rule.DL4007
 import qualified Hadolint.Rule.Shellcheck
 import qualified Hadolint.Shell as Shell
 
@@ -201,4 +202,5 @@ failures Configuration {allowedRegistries, labelSchema, strictLabels} =
     <> Hadolint.Rule.DL4004.rule
     <> Hadolint.Rule.DL4005.rule
     <> Hadolint.Rule.DL4006.rule
+    <> Hadolint.Rule.DL4007.rule
     <> Hadolint.Rule.Shellcheck.rule

--- a/src/Hadolint/Rule/DL4007.hs
+++ b/src/Hadolint/Rule/DL4007.hs
@@ -1,0 +1,25 @@
+module Hadolint.Rule.DL4007 (rule) where
+
+import qualified Data.Text as Text
+import Hadolint.Rule
+import Language.Docker.Syntax
+
+rule :: Rule args
+rule = simpleRule code severity message check
+  where
+    code = "DL4007"
+    severity = DLWarningC
+    message =
+      "COPY with '.' as source can leak sensitive files like .git, .env, or \
+      \local configs into your image. Prefer copying only the files you actually need."
+
+    check (Copy (CopyArgs sources _) _)
+      | any isDotSource sources = False
+      | otherwise = True
+    check _ = True
+
+    isDotSource src =
+      let raw = unSourcePath src
+          unquoted = Text.dropAround (== '"') . Text.dropAround (== '\'') $ raw
+      in unquoted == "." || unquoted == "./"
+{-# INLINEABLE rule #-}

--- a/test/Hadolint/Rule/DL4007Spec.hs
+++ b/test/Hadolint/Rule/DL4007Spec.hs
@@ -1,0 +1,55 @@
+module Hadolint.Rule.DL4007Spec (spec) where
+
+import Data.Default
+import Data.Text as Text
+import Helpers
+import Test.Hspec
+
+
+spec :: SpecWith ()
+spec = do
+  let ?config = def
+
+  describe "DL4007 - COPY with dot as source" $ do
+    it "warns on COPY . ." $
+      let dockerFile =
+            [ "FROM scratch",
+              "COPY . ."
+            ]
+       in ruleCatches "DL4007" $ Text.unlines dockerFile
+
+    it "warns on COPY . /app" $
+      let dockerFile =
+            [ "FROM scratch",
+              "COPY . /app"
+            ]
+       in ruleCatches "DL4007" $ Text.unlines dockerFile
+
+    it "warns on COPY './' /app" $
+      let dockerFile =
+            [ "FROM scratch",
+              "COPY './' /app"
+            ]
+       in ruleCatches "DL4007" $ Text.unlines dockerFile
+
+    it "does not warn on COPY src/ ." $
+      let dockerFile =
+            [ "FROM scratch",
+              "COPY src/ ."
+            ]
+       in ruleCatchesNot "DL4007" $ Text.unlines dockerFile
+
+    it "does not warn on specific COPY" $
+      let dockerFile =
+            [ "FROM scratch",
+              "COPY package.json yarn.lock /app/"
+            ]
+       in ruleCatchesNot "DL4007" $ Text.unlines dockerFile
+
+    it "warns on COPY . . even after FROM alias" $
+      let dockerFile =
+            [ "FROM node:18 as build",
+              "COPY . .",
+              "RUN echo hello"
+            ]
+       in ruleCatches "DL4007" $ Text.unlines dockerFile


### PR DESCRIPTION
Was reading through the hadolint issue tracker and spotted #1199. Seems like a straightforward rule to add so figured I'd take a crack at it.

Using `COPY . .` in Dockerfiles can leak stuff like .git, .env, and local configs into your image. This adds DL4007 to detect when the source is just "." or "./" and warn about it.

The check handles quoted variants too like `COPY './' /app`.

Not sure if the message text is the happiest wording — happy to tweak it if you have suggestions.

Should fix #1199.