### PR TITLE
DL3018: Allow fuzzy version matching

### DIFF
--- a/src/Hadolint/Rule/DL3018.hs
+++ b/src/Hadolint/Rule/DL3018.hs
@@ -28,7 +28,7 @@ dl3018 = simpleRule code severity message check
         )
         args
     check _ = True
-    versionFixed package = any (`Text.isInfixOf` package) ["=", "~"]
+    versionFixed package = any (`Text.isInfixOf` package) ["=", "~", ">", "<"]
     packageFile package = ".apk" `Text.isSuffixOf` package
 {-# INLINEABLE dl3018 #-}
 

--- a/test/Hadolint/Rule/DL3018Spec.hs
+++ b/test/Hadolint/Rule/DL3018Spec.hs
@@ -35,6 +35,7 @@ spec = do
        in do
             ruleCatchesNot "DL3018" $ Text.unlines dockerFile
             onBuildRuleCatchesNot "DL3018" $ Text.unlines dockerFile
+
     it "apk add version pinned regression" $
       let dockerFile =
             [ "RUN apk add --no-cache \\",
@@ -46,6 +47,20 @@ spec = do
        in do
             ruleCatchesNot "DL3018" $ Text.unlines dockerFile
             onBuildRuleCatchesNot "DL3018" $ Text.unlines dockerFile
+
+    it "apk add version pinned with fuzzy versions" $
+      let dockerfile =
+            Text.unlines
+              [ "RUN apk add --no-cache \\",
+                "  \"flex>=2.6.1-r1\" \\",
+                "  \"libffi~3.2.1\" \\",
+                "  \"python3<3.6.12-r2\" \\",
+                "  \"libbz2=~1.0.6-r4\""
+              ]
+       in do
+            ruleCatchesNot "DL3018" dockerfile
+            onBuildRuleCatchesNot "DL3018" dockerfile
+
     it "apk add version pinned regression - one missed" $
       let dockerFile =
             [ "RUN apk add --no-cache \\",
@@ -57,6 +72,7 @@ spec = do
        in do
             ruleCatches "DL3018" $ Text.unlines dockerFile
             onBuildRuleCatches "DL3018" $ Text.unlines dockerFile
+
     it "apk add virtual package" $
       let dockerFile =
             [ "RUN apk add \\",
@@ -69,6 +85,7 @@ spec = do
        in do
             ruleCatchesNot "DL3018" $ Text.unlines dockerFile
             onBuildRuleCatchesNot "DL3018" $ Text.unlines dockerFile
+
     it "apk add with repository without equal sign" $
       let dockerFile =
             [ "RUN apk add --no-cache \\",
@@ -78,6 +95,7 @@ spec = do
        in do
             ruleCatchesNot "DL3018" $ Text.unlines dockerFile
             onBuildRuleCatchesNot "DL3018" $ Text.unlines dockerFile
+
     it "apk add with repository with equal sign" $
       let dockerFile =
             [ "RUN apk add --no-cache \\",
@@ -87,6 +105,7 @@ spec = do
        in do
             ruleCatchesNot "DL3018" $ Text.unlines dockerFile
             onBuildRuleCatchesNot "DL3018" $ Text.unlines dockerFile
+
     it "apk add with repository (-X) without equal sign" $
       let dockerFile =
             [ "RUN apk add --no-cache \\",


### PR DESCRIPTION
### What I did

Allow fuzzy version matching with `<`, `>`, `<=` and `>=` respectively in DL3018.

Alpine's APK package manager supports various syntaxes for fuzzy version matching or upper and lower bounds on package versions. This change relaxes DL3018 to recognize any form of such version matching.

Note, that users may need to escape the `<` or `>` characters to prevent them from being interpreted as shell redirections. This matches the commands actual behavior.

related-to: hadolint/hadolint#782

### How to verify it

Unit tests included.
The following example Dockerfile should no longer trigger DL3018:
```dockerfile
FROM alpine:3.24

RUN apk add --no-cache "flex>=2.6.1-r1"
```