### PR TITLE
Checkstyle: Output file node on empty result

### DIFF
--- a/src/Hadolint/Formatter/Checkstyle.hs
+++ b/src/Hadolint/Formatter/Checkstyle.hs
@@ -4,7 +4,6 @@ where
 import qualified Data.ByteString.Lazy.Char8 as B
 import Data.Foldable
 import qualified Data.Map as Map
-import qualified Data.Maybe as Maybe
 import qualified Data.Text as Text
 import Hadolint.Formatter.Format
   ( Result (..),
@@ -66,14 +65,14 @@ renderNodes (Result _ errors checks) =
 toFile ::
   (VisualStream s, TraversableStream s, ShowErrorComponent e) =>
   Result s e -> Maybe FilePath -> XML.Node
-toFile results filePathInReport =
+toFile result filePathInReport =
   XML.NodeElement XML.Element
     { elementName = "file",
       elementAttributes = Map.fromList [("name", filepath)],
-      elementNodes = renderNodes results
+      elementNodes = renderNodes result
     }
   where
-    filepath = if null filePathInReport then filename results else getFilePath filePathInReport
+    filepath = if null filePathInReport then filename result else getFilePath filePathInReport
     filename Result {fileName=fn} = fn
 
 renderResults ::
@@ -82,11 +81,8 @@ renderResults ::
 renderResults results filePathInReport = XML.Element
   { elementName = "checkstyle",
     elementAttributes = Map.fromList [("version", "4.3")],
-    elementNodes = Maybe.mapMaybe maybeFile ( toList results )
+    elementNodes = fmap (`toFile` filePathInReport) ( toList results )
   }
-  where
-    maybeFile r = if isEmpty r then Nothing else Just $ toFile r filePathInReport
-    isEmpty Result {errors=e, checks=c} = null e && null c
 
 printResults ::
   (Foldable f, VisualStream s, TraversableStream s, ShowErrorComponent e) =>
@@ -104,7 +100,4 @@ printResults results filePathInReport =
 
 getFilePath :: Maybe FilePath -> Text.Text
 getFilePath Nothing = ""
-getFilePath (Just filePath) = toText [filePath]
-
-toText :: [FilePath] -> Text.Text
-toText = foldMap Text.pack
+getFilePath (Just filePath) = Text.pack filePath

--- a/src/Hadolint/Lint.hs
+++ b/src/Hadolint/Lint.hs
@@ -6,10 +6,9 @@ module Hadolint.Lint
   )
 where
 
-import Data.Sequence (Seq)
 import Data.Text (Text)
 import Hadolint.Config.Configuration (Configuration (..))
-import Hadolint.Rule (RuleCode, DLSeverity (..), CheckFailure (..))
+import Hadolint.Rule (RuleCode, DLSeverity (..), CheckFailure (..), Failures)
 import Language.Docker.Parser (DockerfileError, Error)
 import Language.Docker.Syntax (Dockerfile)
 import qualified Control.Parallel.Strategies as Parallel
@@ -57,7 +56,7 @@ lint config parsedFiles = gather results `Parallel.using` parallelRun
       ]
     parallelRun = Parallel.parList Parallel.rseq
 
-analyze :: Configuration -> Dockerfile -> Seq Hadolint.Rule.CheckFailure
+analyze :: Configuration -> Dockerfile -> Failures
 analyze config dockerfile = fixer process
   where
     fixer = fixSeverity config
@@ -65,8 +64,8 @@ analyze config dockerfile = fixer process
 
 fixSeverity ::
   Configuration ->
-  Seq CheckFailure ->
-  Seq CheckFailure
+  Failures ->
+  Failures
 fixSeverity Configuration {..} =
   Seq.filter ignoredRules . Seq.mapWithIndex (const correctSeverity)
   where


### PR DESCRIPTION
### What I did

Make the checkstyle formatter output a file-node even if the linting results for that file are empty.
This ensures that the structure of the XML document does not hide the fact that the linter ran on files when the result is clean.

related-to: hadolint/hadolint#986

### How to verify it

Before:

<img width="639" height="141" alt="Screenshot at 2026-06-08 17-45-16" src="https://github.com/user-attachments/assets/352d1609-210b-4d58-9b02-409c12f3478d" />

After:

<img width="1621" height="181" alt="Screenshot at 2026-06-08 17-46-06" src="https://github.com/user-attachments/assets/7723f206-88ca-4c20-a9f7-3c710beee800" />

