### PR TITLE
DL3026: Warn on `COPY --from` untrusted registry

### DIFF
--- a/src/Hadolint/Rule/DL3026.hs
+++ b/src/Hadolint/Rule/DL3026.hs
@@ -1,7 +1,8 @@
 module Hadolint.Rule.DL3026 (rule) where
 
 import qualified Data.Set as Set
-import Data.Text (Text, pack, drop, dropEnd, isSuffixOf, isPrefixOf)
+import Data.String ( IsString(..) )
+import Data.Text (Text, pack, unpack, drop, dropEnd, isSuffixOf, isPrefixOf)
 import Hadolint.Rule
 import Language.Docker.Syntax
 
@@ -17,6 +18,11 @@ rule allowed = customRule check (emptyState Set.empty)
        in if doCheck (state st) image
             then newState
             else newState |> addFail CheckFailure {..}
+    check line st (Copy _ (CopyFlags _ _ _ (CopySource src) _)) =
+      let img = fromString ( Data.Text.unpack src )
+       in if doCheck (state st) img
+            then st
+            else st |> addFail CheckFailure {..}
     check _ st _ = st
 
     doCheck st img = Set.member (toImageAlias img) st || Set.null allowed || isAllowed img
@@ -29,13 +35,13 @@ rule allowed = customRule check (emptyState Set.empty)
         || isRegistryAllowed "hub.docker.com"
 
     isRegistryAllowed registry = any (\p -> matchRegistry (unRegistry p) registry) allowed
-
-    matchRegistry :: Text -> Text -> Bool
-    matchRegistry allow registry | allow == star = True
-                                 | star `isPrefixOf` allow = Data.Text.drop 1 allow `isSuffixOf` registry
-                                 | star `isSuffixOf` allow = Data.Text.dropEnd 1 allow `isPrefixOf` registry
-                                 | otherwise = registry == allow
-                                  where
-                                      star = pack "*"
-
 {-# INLINEABLE rule #-}
+
+matchRegistry :: Text -> Text -> Bool
+matchRegistry allow registry
+  | allow == star = True
+  | star `isPrefixOf` allow = Data.Text.drop 1 allow `isSuffixOf` registry
+  | star `isSuffixOf` allow = Data.Text.dropEnd 1 allow `isPrefixOf` registry
+  | otherwise = registry == allow
+  where
+      star = pack "*"

--- a/test/Hadolint/Rule/DL3026Spec.hs
+++ b/test/Hadolint/Rule/DL3026Spec.hs
@@ -42,7 +42,7 @@ spec = do
 
       ruleCatchesNot "DL3026" $ Text.unlines dockerFile
 
-    it "allows boths all forms of docker.io" $ do
+    it "allows all forms of docker.io" $ do
       let dockerFile =
             [ "FROM ubuntu:18.04 AS builder1",
               "FROM zemanlx/ubuntu:18.04 AS builder2",
@@ -86,3 +86,26 @@ spec = do
       let ?config = def { allowedRegistries = ["*"] }
 
       ruleCatchesNot "DL3026" $ Text.unlines dockerFile
+
+    it "does warn on copy from untrusted registry" $ do
+      let dockerfile =
+            Text.unlines
+              [ "COPY --from=untrusted.com/repo/image:tag /foo /bar" ]
+      let ?config = def { allowedRegistries = [ "trusted.com" ] }
+       in ruleCatches "DL3026" dockerfile
+
+    it "does not warn on copy from untrusted registry" $ do
+      let dockerfile =
+            Text.unlines
+              [ "COPY --from=trusted.com/repo/image:tag /foo /bar" ]
+      let ?config = def { allowedRegistries = [ "trusted.com" ] }
+       in ruleCatchesNot "DL3026" dockerfile
+
+    it "distrust all forms of docker.io if trusted registries are given" $ do
+      let dockerFile =
+            [ "FROM ubuntu:18.04 AS builder1",
+              "FROM zemanlx/ubuntu:18.04 AS builder2",
+              "FROM docker.io/zemanlx/ubuntu:18.04 AS builder3"
+            ]
+      let ?config = def { allowedRegistries = ["trusted.com"] }
+       in assertChecks ( Text.unlines dockerFile ) ( failsWith 3 "DL3026" )


### PR DESCRIPTION
### What I did

DL3026: Trigger warning if `COPY --from=` uses image from untrusted registry.
Rule DL3026 is useful for protecting against taking on code from untrusted sources. This change makes rule DL3026 aware of the possibility that untrusted code can be copied with the `COPY` instruction directly, not just with `FROM` instructions.

related-to: hadolint/hadolint#1108

### How to verify it

This dockerfile should trigger the rule DL3026 if Hadolint has been configured with a list of trusted registries:

```dockerfile
FROM scratch
COPY --from=untrusted.com/repo/image:tag /foo /bar
```