### PR TITLE
DL3025: Trigger on HEALTHCHECK instructions too

### DIFF
--- a/src/Hadolint/Rule/DL3025.hs
+++ b/src/Hadolint/Rule/DL3025.hs
@@ -12,5 +12,6 @@ rule = simpleRule code severity message check
 
     check (Cmd (ArgumentsText _)) = False
     check (Entrypoint (ArgumentsText _)) = False
+    check (Healthcheck (Check (CheckArgs (ArgumentsText _) _ _ _ _ _))) = False
     check _ = True
 {-# INLINEABLE rule #-}

--- a/test/Hadolint/Rule/DL3025Spec.hs
+++ b/test/Hadolint/Rule/DL3025Spec.hs
@@ -11,24 +11,28 @@ spec = do
   let ?config = def
 
   describe "DL3025 - Use arguments JSON notation for `CMD` and `ENTRYPOINT` arguments" $ do
+
     it "warn on ENTRYPOINT" $
       let dockerFile =
             [ "FROM node as foo",
               "ENTRYPOINT something"
             ]
        in ruleCatches "DL3025" $ Text.unlines dockerFile
+
     it "don't warn on ENTRYPOINT json notation" $
       let dockerFile =
             [ "FROM scratch as build",
               "ENTRYPOINT [\"foo\", \"bar\"]"
             ]
        in ruleCatchesNot "DL3025" $ Text.unlines dockerFile
+
     it "warn on CMD" $
       let dockerFile =
             [ "FROM node as foo",
               "CMD something"
             ]
        in ruleCatches "DL3025" $ Text.unlines dockerFile
+
     it "don't warn on CMD json notation" $
       let dockerFile =
             [ "FROM scratch as build",
@@ -36,6 +40,14 @@ spec = do
               "CMD [ \"foo\", \"bar\" ]"
             ]
        in ruleCatchesNot "DL3025" $ Text.unlines dockerFile
+
+    it "warn on HEALTHCHECK CMD shell notation" $
+      let df = Text.unlines [ "HEALTHCHECK CMD foobar" ]
+       in ruleCatches "DL3025" df
+
+    it "don't warn on HEALTHCHECK CMD json notation" $
+      let df = Text.unlines [ "HEALTHCHECK CMD [ \"foobar\" ]" ]
+       in ruleCatchesNot "DL3025" df
 
     -- regression: deal with broken long strings in exec format
     it "don't warn on CMD JSON notation with broken long strings" $


### PR DESCRIPTION
### What I did

Make DL3025 trigger on HEALTHCHECK instructions too. In some containers based on Distroless or Scratch images, there is no shell, but that doesn't necessarily mean that there can't be a HEALTHCHECK instruction.
To avoid the overhead of a shell, HEALTHCHECK instructions should utilize the JSON notation to directly execute the command without the implicit shell.

related-to: hadolint/hadolint#1208

### How to verify it

This is now ok and won't trigger rule DL3025:
```dockerfile
FROM scratch

HEALTHCHECK CMD [ "foobar" ]
```

This will trigger a warning for rule DL3025:
```dockerfile
FROM scratch

HEALTHCHECK CMD foobar
```