### PR TITLE
Fix DL3016 false positive on npm --registry flag

### DIFF
--- a/src/Hadolint/Rule/DL3016.hs
+++ b/src/Hadolint/Rule/DL3016.hs
@@ -81,7 +81,7 @@ stripInstallPrefix cmd = dropWhile (== "install") (dropWhile (/= "install") cmd)
 
 
 ignoreFlags :: [Text.Text]
-ignoreFlags = ["loglevel"]
+ignoreFlags = ["loglevel", "registry"]
 
 gitPrefixes :: [Text.Text]
 gitPrefixes = ["git://", "git+ssh://", "git+http://", "git+https://"]

--- a/test/Hadolint/Rule/DL3016Spec.hs
+++ b/test/Hadolint/Rule/DL3016Spec.hs
@@ -122,3 +122,12 @@ spec = do
     it "don't fire on loglevel flag" $ do
       ruleCatchesNot "DL3016" "RUN npm install --loglevel verbose sax@0.1.1"
       onBuildRuleCatchesNot "DL3016" "RUN npm install --loglevel verbose sax@0.1.1"
+    it "don't fire on registry flag" $ do
+      ruleCatchesNot "DL3016" "RUN npm install --registry https://example.com sax@0.1.1"
+      onBuildRuleCatchesNot "DL3016" "RUN npm install --registry https://example.com sax@0.1.1"
+    it "version not pinned with --registry flag" $ do
+      ruleCatches "DL3016" "RUN npm install --registry https://example.com express"
+      onBuildRuleCatches "DL3016" "RUN npm install --registry https://example.com express"
+    it "version not pinned with --registry=value form" $ do
+      ruleCatches "DL3016" "RUN npm install --registry=https://example.com express"
+      onBuildRuleCatches "DL3016" "RUN npm install --registry=https://example.com express"


### PR DESCRIPTION
### What I did

DL3016 reports a missing version pin for `RUN npm install --registry https://example.com sax@0.1.1`, because it reads the argument of the `--registry` flag as a package. `sax` itself is pinned.

### How I did it

Added `--registry` to the list of flags whose argument DL3016 drops before it builds the package list, the same way `--loglevel` is already handled. The `=` form was already covered by `dropFlagArg`.

### How to verify it

`cabal test`

fixes #975
