### PR TITLE
DL3026: Disallow mounting from untrusted registies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,5 @@ devenv.local.nix
 .vim
 
 *.wasm
+
+hspec-discover.tix

--- a/src/Hadolint/Rule/DL3026.hs
+++ b/src/Hadolint/Rule/DL3026.hs
@@ -1,5 +1,6 @@
 module Hadolint.Rule.DL3026 (rule) where
 
+import qualified Data.Maybe as Maybe
 import qualified Data.Set as Set
 import Data.String ( IsString(..) )
 import Data.Text (Text, pack, unpack, drop, dropEnd, isSuffixOf, isPrefixOf)
@@ -23,7 +24,19 @@ rule allowed = customRule check (emptyState Set.empty)
        in if doCheck (state st) img
             then st
             else st |> addFail CheckFailure {..}
+    check line st (Run (RunArgs _ (RunFlags m _ _))) =
+       if null $ Set.filter (not . checkMount st) m
+         then st
+         else st |> addFail CheckFailure {..}
     check _ st _ = st
+
+    checkMount st (CacheMount (CacheOpts _ _ _ _ fi _ _ _ _)) =
+      let img = fromString $ unpack $ Maybe.fromMaybe "scratch" fi
+       in doCheck (state st) img
+    checkMount st (BindMount (BindOpts _ _ fi _ _)) =
+      let img = fromString $ unpack $ Maybe.fromMaybe "scratch" fi
+       in doCheck (state st) img
+    checkMount _ _ = True
 
     doCheck st img = Set.member (toImageAlias img) st || Set.null allowed || isAllowed img
 

--- a/test/Hadolint/Rule/DL3026Spec.hs
+++ b/test/Hadolint/Rule/DL3026Spec.hs
@@ -101,6 +101,34 @@ spec = do
       let ?config = def { allowedRegistries = [ "trusted.com" ] }
        in ruleCatchesNot "DL3026" dockerfile
 
+    it "warn on run with bind mount from untrusted registry" $ do
+      let dockerfile =
+            Text.unlines
+              [ "RUN --mount=type=bind,from=untrusted.com/repo/image:tag,target=/foo foobar" ]
+      let ?config = def { allowedRegistries = [ "trusted.com" ] }
+       in ruleCatches "DL3026" dockerfile
+
+    it "warn on run with cache mount from untrusted registry" $ do
+      let dockerfile =
+            Text.unlines
+              [ "RUN --mount=type=cache,from=untrusted.com/repo/image:tag,target=/foo foobar" ]
+      let ?config = def { allowedRegistries = [ "trusted.com" ] }
+       in ruleCatches "DL3026" dockerfile
+
+    it "don't warn on run with bind mount from trusted registry" $ do
+      let dockerfile =
+            Text.unlines
+              [ "RUN --mount=type=bind,from=trusted.com/repo/image:tag,target=/foo foobar" ]
+      let ?config = def { allowedRegistries = [ "trusted.com" ] }
+       in ruleCatchesNot "DL3026" dockerfile
+
+    it "don't warn on run with cache mount from trusted registry" $ do
+      let dockerfile =
+            Text.unlines
+              [ "RUN --mount=type=cache,from=trusted.com/repo/image:tag,target=/foo foobar" ]
+      let ?config = def { allowedRegistries = [ "trusted.com" ] }
+       in ruleCatchesNot "DL3026" dockerfile
+
     it "distrust all forms of docker.io if trusted registries are given" $ do
       let dockerFile =
             [ "FROM ubuntu:18.04 AS builder1",


### PR DESCRIPTION
### What I did

Disallow mount options for RUN instructions from untrusted registries. RUN instructions have the capability to have cache and bind mounts directly from another image. If the user has configured a whitelist of trusted registries it only makes sense to highlight the use of such mount options, if they mount from an image hosted not on a whitelisted registry.

related-to: hadolint/hadolint#1108

### How to verify it

If Hadolint is configured with e.g. the following:

```yaml
trustedRegistries:
  - trusted.com
  - docker.io
```

this Dockerfile should raise DL3026 on line 3:

```dockerfile
FROM debian:trixie

RUN --mount=type=bind,from=untrusted.com/foo/bar:v1.2.3,target=/foobar echo "foobar"
```