### PR TITLE
Dependencies: Bump language-docker to v16.0.0

### DIFF
--- a/hadolint.cabal
+++ b/hadolint.cabal
@@ -154,7 +154,7 @@ library
     , foldl                 >=1.4.18   && <1.5
     , gitrev                >=1.3.1    && <1.4
     , HsYAML                >=0.2.1    && <0.3
-    , language-docker       >=15.0.0   && <16
+    , language-docker       >=16.0.0   && <17
     , megaparsec            >=9.0.0    && <9.8
     , mtl                   >=2.3.1    && <2.4
     , network-uri           >=2.6.4    && <2.7

--- a/src/Hadolint/Rule/DL3010.hs
+++ b/src/Hadolint/Rule/DL3010.hs
@@ -25,7 +25,7 @@ rule = veryCustomRule check (emptyState Empty) markFailures
     message = "Use `ADD` for extracting archives into an image"
 
     check _ _ (From _) = emptyState Empty
-    check line st (Copy (CopyArgs srcs tgt) (CopyFlags _ _ _ NoSource _)) =
+    check line st (Copy (CopyArgs srcs tgt) (CopyFlags _ _ _ _ NoSource _)) =
       st |> modify (rememberArchives line srcs tgt)
     check _ st (Run (RunArgs args _))
       | Acc archives _ <- state st,

--- a/src/Hadolint/Rule/DL3022.hs
+++ b/src/Hadolint/Rule/DL3022.hs
@@ -20,7 +20,7 @@ rule = customRule check (emptyState Empty)
 
     check _ st (From BaseImage {alias = Just (ImageAlias als)}) = st |> modify (incAndAddName als)
     check _ st (From BaseImage {}) = st |> modify incCount
-    check line st (Copy (CopyArgs _ _) (CopyFlags _ _ _ (CopySource s) _))
+    check line st (Copy (CopyArgs _ _) (CopyFlags _ _ _ _ (CopySource s) _))
       | ":" `Text.isInfixOf` dropQuotes s = st
       | isMember s (state st) = st
       | otherwise = case Read.decimal s of

--- a/src/Hadolint/Rule/DL3023.hs
+++ b/src/Hadolint/Rule/DL3023.hs
@@ -11,7 +11,7 @@ rule = customRule check (emptyState Nothing)
     message = "`COPY --from` cannot reference its own `FROM` alias"
 
     check _ st f@(From _) = st |> replaceWith (Just f) -- Remember the last FROM instruction found
-    check line st@(State _ (Just fromInstr)) (Copy (CopyArgs _ _) (CopyFlags _ _ _ (CopySource stageName) _))
+    check line st@(State _ (Just fromInstr)) (Copy (CopyArgs _ _) (CopyFlags _ _ _ _ (CopySource stageName) _))
       | aliasMustBe (/= stageName) fromInstr = st
       | otherwise = st |> addFail CheckFailure {..}
     -- cannot copy from the same stage!

--- a/src/Hadolint/Rule/DL3026.hs
+++ b/src/Hadolint/Rule/DL3026.hs
@@ -19,7 +19,7 @@ rule allowed = customRule check (emptyState Set.empty)
        in if doCheck (state st) image
             then newState
             else newState |> addFail CheckFailure {..}
-    check line st (Copy _ (CopyFlags _ _ _ (CopySource src) _)) =
+    check line st (Copy _ (CopyFlags _ _ _ _ (CopySource src) _)) =
       let img = fromString ( Data.Text.unpack src )
        in if doCheck (state st) img
             then st

--- a/src/Hadolint/Rule/DL3049.hs
+++ b/src/Hadolint/Rule/DL3049.hs
@@ -34,7 +34,7 @@ missingLabelRule label = veryCustomRule check (emptyState Empty) markFailure
     message = "Label `" <> label <> "` is missing."
     check line state (From img) =
       state |> modify (currentStage (StageID img line))
-    check _ state (Copy (CopyArgs _ _) (CopyFlags _ _ _ (CopySource src) _)) =
+    check _ state (Copy (CopyArgs _ _) (CopyFlags _ _ _ _ (CopySource src) _)) =
       state |> modify (markSilentByAlias src)
     check _ state (Label pairs)
       | label `elem` fmap fst pairs =

--- a/src/Hadolint/Rule/DL3067.hs
+++ b/src/Hadolint/Rule/DL3067.hs
@@ -10,7 +10,7 @@ rule = simpleRule code severity message check
     severity = DLWarningC
     message = "Do not copy an entire filesystem from another stage"
 
-    check (Copy (CopyArgs sources target) (CopyFlags _ _ _ (CopySource _) _)) =
+    check (Copy (CopyArgs sources target) (CopyFlags _ _ _ _ (CopySource _) _)) =
       not $ any isRootSource sources && isRootTarget target
     check _ = True
 {-# INLINEABLE rule #-}


### PR DESCRIPTION
### What I did

Bump language-docker dependency to v16.0.0.
Fixup breaking changes.

This updates the dockerfile parser to accept new syntax elements. Since this also changes the AST, some places need to be fixed up to match the new type definitions and patterns.

### How to verify it

Hadolint compiles and `cabal test` runs clean.