### PR TITLE
Hadolint Embedded: Fix output interface

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -90,7 +90,17 @@ jobs:
             --with-hc-pkg="$GHCPATH/wasm32-wasi-ghc-pkg" \
             --with-hsc2hs="$GHCPATH/wasm32-wasi-hsc2hs" \
             --with-haddock="$GHCPATH/wasm32-wasi-haddock" \
-            build
+            build exe:hadolint-embedded
+
+          mv \
+            $(cabal \
+                --with-compiler="$GHCPATH/wasm32-wasi-ghc" \
+                --with-hc-pkg="$GHCPATH/wasm32-wasi-ghc-pkg" \
+                --with-hsc2hs="$GHCPATH/wasm32-wasi-hsc2hs" \
+                --with-haddock="$GHCPATH/wasm32-wasi-haddock" \
+                list-bin exe:hadolint-embedded) \
+            website/hadolint.wasm
+
           $(wasm32-wasi-ghc --print-libdir)/post-link.mjs \
             -i website/hadolint.wasm \
             -o website/js/ghc_wasm_jsffi.js

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -52,6 +52,7 @@ jobs:
 
       - name: Build
         run: |
+          cabal check
           cabal configure --enable-tests
           cabal build
 

--- a/app/embedded.hs
+++ b/app/embedded.hs
@@ -73,7 +73,7 @@ doLint res =
 
 showResult :: Format.Result Text.Text DockerfileError -> IO ()
 showResult result = do
-  Hadolint.printResults Hadolint.Json True Nothing [ result ]
+  Hadolint.write ["-"] [Hadolint.Json] True Nothing [ result ]
 
 jsStringToText :: JSString -> Text.Text
 jsStringToText = Text.pack . fromJSString

--- a/hadolint.cabal
+++ b/hadolint.cabal
@@ -226,11 +226,11 @@ executable hadolint-embedded
   ghc-options:
     -Wall -Wcompat -Wincomplete-record-updates
     -Wincomplete-uni-patterns -Wredundant-constraints
-    -no-hs-main -optl-mexec-model=reactor -optl-Wl,--export=setup -o website/hadolint.wasm
+    -no-hs-main -optl-mexec-model=reactor -optl-Wl,--export=setup
 
   build-depends:
       base                  >=4.20.1    && <5
-    , ghc-experimental
+    , ghc-experimental      >=9.1003.0  && <9.1201
     , containers            >=0.7       && <0.8
     , data-default          >=0.8.0     && <0.9
     , hadolint


### PR DESCRIPTION
### What I did

Fixup Hadolint embedded version to match the new output interface.

Fix Hadolint cabal file to pass `cabal check`

Fixup website build workflow. The fixed cabal project file causes the output of the compiler to be placed in some subdirectory. The WASM artifact needs to be moved to the correct subdirectory before the website can be successfully published.
