### PR TITLE
fix(release): use macos-15-intel runner for x86_64 macOS builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -176,7 +176,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: macos-15
+          - os: macos-15-intel
             target: macos-x86_64
           - os: macos-15
             target: macos-arm64


### PR DESCRIPTION
macos-15 runner is Apple Silicon (ARM64), so both x86_64 and arm64 builds produce arm64 binaries. Use macos-15-intel for the x86_64 target so it actually compiles for Intel Macs.

Fixes #1223.