### PR TITLE
CI: Fix Macos Cache and image name

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -140,8 +140,8 @@ jobs:
       - name: Cache store
         uses: actions/cache@v6
         with:
-          path: ~/.cabal/store
-          key: ${{ matrix.os }}-${{ hashFiles('cabal.project.freeze') }}
+          path: ${{ steps.setup-haskell.outputs.cabal-store }}
+          key: ${{ matrix.os }}-${{ matrix.target }}-${{ hashFiles('cabal.project.freeze') }}
 
       - name: Build
         run: |
@@ -176,7 +176,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: macos-15
+          - os: macos-15-intel
             target: macos-x86_64
           - os: macos-15
             target: macos-arm64
@@ -197,7 +197,7 @@ jobs:
         uses: actions/cache@v6
         with:
           path: ${{ steps.setup-haskell.outputs.cabal-store }}
-          key: ${{ matrix.os }}-${{ hashFiles('cabal.project.freeze') }}
+          key: ${{ matrix.os }}-${{ matrix.target }}-${{ hashFiles('cabal.project.freeze') }}
 
       - name: Build binaries
         run: |
@@ -245,7 +245,7 @@ jobs:
         uses: actions/cache@v6
         with:
           path: ${{ steps.setup-haskell.outputs.cabal-store }}
-          key: ${{ matrix.os }}-${{ hashFiles('cabal.project.freeze') }}
+          key: ${{ matrix.os }}-${{ matrix.target }}-${{ hashFiles('cabal.project.freeze') }}
 
       - name: Build binaries
         run: |

--- a/hadolint.cabal
+++ b/hadolint.cabal
@@ -15,6 +15,8 @@ license-file:       LICENSE
 build-type:         Simple
 extra-source-files: README.md
 
+tested-with: GHC == 9.10.3
+
 source-repository head
   type:     git
   location: git@github.com:hadolint/hadolint.git


### PR DESCRIPTION
Fix Macos build image name

Fix Macos build being able to poison its cache across architectures

Add tested versions field to Cabal file

related-to: hadolint/hadolint#1223