### PR TITLE
DL3066: Fix false positive when UID is an argument

### DIFF
--- a/src/Hadolint/Rule/DL3066.hs
+++ b/src/Hadolint/Rule/DL3066.hs
@@ -1,19 +1,31 @@
 module Hadolint.Rule.DL3066 (rule) where
 
 import qualified Data.Char as Char
+import qualified Data.Set as Set
 import qualified Data.Text as Text
 import Hadolint.Rule
 import Language.Docker.Syntax
 
+
+data Acc
+  = Acc { args :: Set.Set Text.Text }
+  | Empty
+  deriving (Show)
+
+
 rule :: Rule args
-rule = simpleRule code severity message check
+rule = customRule check (emptyState Empty)
   where
     code = "DL3066"
     severity = DLInfoC
     message = "Non-numeric user-id may not be resolvable by host system"
 
-    check (User u) = Text.all Char.isDigit $ getUid u
-    check _ = True
+    check line st (User u)
+      | Text.all Char.isDigit $ getUid u = st
+      | uidIsDefinedArg (state st) u = st
+      | otherwise = st |> addFail CheckFailure {..}
+    check _ st (Arg arg _) = st |> modify (registerArg arg)
+    check _ st _ = st
 {-# INLINEABLE rule #-}
 
 getUid :: Text.Text -> Text.Text
@@ -23,3 +35,19 @@ getUid t
   where
     u [] = ""
     u (h:_) = h
+
+uidIsDefinedArg :: Acc -> Text.Text -> Bool
+uidIsDefinedArg Empty _ = False
+uidIsDefinedArg (Acc args) u = any (`varInUid` u) args
+  where
+    varInUid :: Text.Text -> Text.Text -> Bool
+    varInUid var uid =
+      ( Text.pack "${" <> var <> Text.pack "}" ) `Text.isInfixOf` uid
+        || ( Text.pack "$" <> var ) `Text.isInfixOf` uid
+
+registerArg :: Text.Text -> Acc -> Acc
+registerArg arg Empty =
+  Acc { args = Set.singleton arg }
+registerArg arg (Acc args) =
+  Acc { args = Set.insert arg args }
+

--- a/test/Hadolint/Rule/DL3066Spec.hs
+++ b/test/Hadolint/Rule/DL3066Spec.hs
@@ -1,6 +1,7 @@
 module Hadolint.Rule.DL3066Spec (spec) where
 
 import Data.Default
+import qualified Data.Text as Text
 import Helpers
 import Test.Hspec
 
@@ -23,3 +24,7 @@ spec = do
 
     it "not ok: non-numeric UID and GID" $ do
       ruleCatches rule "USER foobar:barfoo"
+
+    it "ok: UID is non-numeric, but is a defined ARG" $ do
+      let dockerfile = Text.unlines [ "ARG APP_UID", "FROM foobar:barfoo", "USER ${APP_UID}" ]
+       in ruleCatchesNot rule dockerfile


### PR DESCRIPTION
### What I did

Fix possible false positive when the UID for the USER instruction is given as an argument with an ARG instruction.
In this case, the UID will be injected build-time and Hadolint can't tell if it's all-numeric or not.
It's then best not to alert.

### How I did it

### How to verify it

This should no longer get flagged with DL3066:

```dockerfile
ARG APP_UID
FROM foobar:barfoo

USER ${APP_UID}
```