### PR TITLE
Shellcheck: Fix state tracking

### DIFF
--- a/src/Hadolint/Rule/Shellcheck.hs
+++ b/src/Hadolint/Rule/Shellcheck.hs
@@ -117,7 +117,7 @@ addVars vars Empty = do
 addVars vars Acc {..} = do
   let newOpts =
         Shell.ShellOpts
-          { shellName = Shell.shellName Shell.defaultShellOpts,
+          { shellName = Shell.shellName opts,
             envVars = Shell.envVars opts <> Set.fromList vars
           }
    in

--- a/test/Helpers.hs
+++ b/test/Helpers.hs
@@ -126,6 +126,14 @@ passesShellcheck checks =
   where
     matched = Seq.filter (\CheckFailure {code = RuleCode rc} -> "SC" `Text.isPrefixOf` rc) checks
 
+passesAllEnabled :: ( HasCallStack, ?config :: Configuration ) => Failures -> Assertion
+passesAllEnabled checks =
+  unless (null matched) $
+    assertFailure $
+      "I was expecting no errors. Found: \n" <> (Text.unpack . formatChecksNoColor $ checks)
+  where
+    matched = Seq.filter (\CheckFailure {..} -> code `notElem` Hadolint.ignoreRules ?config) checks
+
 assertFormatter ::
   (HasCallStack, ?noColor :: Bool) =>
   OutputFormat ->

--- a/test/RegressionSpec.hs
+++ b/test/RegressionSpec.hs
@@ -2,6 +2,7 @@ module RegressionSpec (spec) where
 
 import Data.Default
 import qualified Data.Text as Text
+import Hadolint (Configuration (..))
 import Helpers
 import Test.HUnit hiding (Label)
 import Test.Hspec
@@ -36,3 +37,25 @@ spec = do
        in assertChecks
             dockerFile
             (assertBool "No Warnings or Errors should be triggered," . null)
+
+    it "`ARG` or `ENV` does not reset shell name given by SHELL instruction or shell pragma" $ do
+      let ?config = def { ignoreRules = [ "DL3057" ] }
+      let dockerfile =
+            Text.unlines
+              [ "# escape=`",
+                "# hadolint shell=powershell",
+                "",
+                "ARG WINDOWS_VERSION=ltsc2022",
+                "FROM mcr.microsoft.com/windows/servercore:\"${WINDOWS_VERSION}\" AS jre-and-war",
+                "# $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324",
+                "SHELL [\"powershell\", \"-Command\", \"$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';\"]",
+                "",
+                "ARG JAVA_ZIP_URL=\"Provided by docker-bake.hcl\"",
+                "ARG jdkTemp='C:\\jdktemp'",
+                "ARG localArchive=\"${jdkTemp}\\jdk.zip\"",
+                "RUN New-Item -ItemType Directory -Path $env:jdkTemp | Out-Null ; `",
+                "    Invoke-WebRequest $env:JAVA_ZIP_URL -OutFile $env:localArchive"
+              ]
+       in do
+        assertChecks dockerfile passesShellcheck
+        assertChecks dockerfile passesAllEnabled


### PR DESCRIPTION
### What I did

Fix state tracking in Shellcheck rule.
There was a bug in the state tracking of the Shellcheck rule where an `ARG` instruction would reset the shell name to the default shell. This would overwrite the `# hadolint shell` pragma and the `SHELL` instruction, leading Shellcheck to be executed for non-bashlike shells. This ultimatively leads to Shellcheck falsely alerting on things that it shouldn't alert on.

related-to: hadolint/hadolint#1228

### How to verify it

The following dockerfile should not produce shellcheck warnings:

```dockerfile
# escape=`
# hadolint shell=powershell

ARG WINDOWS_VERSION=ltsc2022
FROM mcr.microsoft.com/windows/servercore:"${WINDOWS_VERSION}" AS jre-and-war
# $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]

ARG JAVA_ZIP_URL="Provided by docker-bake.hcl"
ARG jdkTemp='C:\jdktemp'
ARG localArchive="${jdkTemp}\jdk.zip"

RUN New-Item -ItemType Directory -Path $env:jdkTemp | Out-Null ; `
    Invoke-WebRequest $env:JAVA_ZIP_URL -OutFile $env:localArchive
```