### PR TITLE
DL4006: match shell by basename, not full exact path

### DIFF
--- a/src/Hadolint/Rule/DL4006.hs
+++ b/src/Hadolint/Rule/DL4006.hs
@@ -32,8 +32,7 @@ rule = customRule check (emptyState False)
         null
           [ True
             | cmd@(Shell.Command name arguments _) <- Shell.presentCommands script,
-              validShell <- ["/bin/bash", "/bin/zsh", "/bin/ash", "bash", "zsh", "ash"],
-              name == validShell,
+              Shell.shellBasename name `elem` ["bash", "zsh", "ash"],
               Shell.hasFlag "o" cmd,
               arg <- Shell.arg <$> arguments,
               arg == "pipefail"

--- a/src/Hadolint/Shell.hs
+++ b/src/Hadolint/Shell.hs
@@ -114,6 +114,14 @@ shellcheck (ShellOpts sh env) (ParsedShell txt _ _) =
 nonPosixShells :: [Text.Text]
 nonPosixShells = ["pwsh", "powershell", "cmd"]
 
+-- | Returns the last path segment of a shell command name, so that
+-- "/usr/bin/bash" and "/bin/bash" both resolve to "bash" just like a bare
+-- "bash" would. This lets shell-name matching (e.g. detecting bash/zsh/ash
+-- for the "-o pipefail" check) work regardless of which absolute path a
+-- shell happens to be installed under.
+shellBasename :: Text.Text -> Text.Text
+shellBasename = last . Text.splitOn "/"
+
 hasUnsupportedShebang :: Text.Text -> Bool
 hasUnsupportedShebang script =
   "#!" `Text.isPrefixOf` script &&

--- a/test/Hadolint/Rule/DL4006Spec.hs
+++ b/test/Hadolint/Rule/DL4006Spec.hs
@@ -51,6 +51,23 @@ spec = do
               "RUN wget -O - https://some.site | wc -l file > /number"
             ]
        in ruleCatchesNot "DL4006" $ Text.unlines dockerFile
+    -- Regression test for #977: bash (and zsh/ash) should be recognized by
+    -- their basename, regardless of the absolute path they're found under
+    -- (e.g. systems where /bin is a symlink to /usr/bin).
+    it "don't warn when bash is invoked via a non-standard absolute path" $
+      let dockerFile =
+            [ "FROM scratch as build",
+              "SHELL [\"/usr/bin/bash\", \"-o\", \"pipefail\", \"-c\"]",
+              "RUN wget -O - https://some.site | wc -l file > /number"
+            ]
+       in ruleCatchesNot "DL4006" $ Text.unlines dockerFile
+    it "don't warn when zsh is invoked via a non-standard absolute path" $
+      let dockerFile =
+            [ "FROM scratch as build",
+              "SHELL [\"/usr/local/bin/zsh\", \"-o\", \"pipefail\", \"-c\"]",
+              "RUN wget -O - https://some.site | wc -l file > /number"
+            ]
+       in ruleCatchesNot "DL4006" $ Text.unlines dockerFile
     it "don't warn on powershell" $
       let dockerFile =
             [ "FROM scratch as build",


### PR DESCRIPTION
### What I did

Fixed DL4006 false-positives when the SHELL directive names a shell via a path other than the exact hardcoded strings `/bin/bash`, `/bin/zsh`, `/bin/ash`, `bash`, `zsh`, `ash` - for example `/usr/bin/bash` (common on distros where `/bin` is a symlink to `/usr/bin`, as in the linked issue):

```Dockerfile
FROM docker.io/tensorflow/tensorflow:latest-gpu
WORKDIR /usr/local/src
SHELL ["/usr/bin/bash", "-o", "pipefail", "-c"]
RUN curl -fsSL http://example.com/foo.tar.gz | tar zx
```

Previously this incorrectly triggered:
```
DL4006 warning: Set the SHELL option -o pipefail before RUN with a pipe in it. ...
```
even though `-o pipefail` is set correctly.

### How I did it

`hasPipefailOption` in `src/Hadolint/Rule/DL4006.hs` required an exact string match of the SHELL command's `name` against a small fixed list of complete strings. Any other valid path pointing at bash/zsh/ash (not just `/usr/bin/bash` - any prefix, really) failed to match.

Added `Shell.shellBasename` in `src/Hadolint/Shell.hs`, which takes the last `/`-separated segment of a command name (so `/bin/bash`, `/usr/bin/bash`, and a bare `bash` all resolve to `"bash"`), and match against that instead of the full path. This only changes *how* the shell name is matched - which shells are considered pipefail-capable (bash/zsh/ash) is unchanged, so `/bin/sh` still correctly triggers the warning (sh/dash doesn't support `-o pipefail`).

I didn't touch the existing (separate, unexported) `basename` helper in `DL3010.hs` - that one operates on `ADD`/`COPY` destination file paths, a different domain from shell command names, even though the string-splitting logic looks similar.

### How to verify it

- `cabal test` - all 744 examples pass (0 failures), including 15 in `DL4006Spec` (13 existing + 2 new)
- Added two regression test cases to `test/Hadolint/Rule/DL4006Spec.hs`: `/usr/bin/bash` and `/usr/local/bin/zsh` with `-o pipefail` set should not warn
- Manually verified against the exact Dockerfile from the issue with a built `hadolint` binary: exits 0, no DL4006 warning
- Manually verified the negative case still works: `SHELL ["/bin/sh", "-o", "pipefail", "-c"]` still correctly triggers DL4006 (sh doesn't support pipefail)

Fixes #977