### PR TITLE
docs: Fix docker run command in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,9 +310,9 @@ To pass a custom configuration file (using relative or absolute path) to
 a container, use the following command:
 
 ```bash
-docker run --rm -i -v /your/path/to/hadolint.yaml:/.config/hadolint.yaml hadolint/hadolint < Dockerfile
+docker run --rm -i -v /your/path/to/hadolint.yaml:/.hadolint.yaml hadolint/hadolint < Dockerfile
 # OR
-docker run --rm -i -v /your/path/to/hadolint.yaml:/.config/hadolint.yaml ghcr.io/hadolint/hadolint < Dockerfile
+docker run --rm -i -v /your/path/to/hadolint.yaml:/.hadolint.yaml ghcr.io/hadolint/hadolint < Dockerfile
 ```
 
 In addition to config files, Hadolint can be configured with environment


### PR DESCRIPTION
### What I did

Fix the docker run command in the readme file to work with any hadolint docker image flavor.

The three image falvors differ in their notion of $HOME. In the scratch based image, $HOME refers to / because it's the only directory that will always exist, while in the Alpine and Debian based images $HOME refers to /root because they have a fully set up shell environment for their default user (root).
This causes the documented docker run command to place the mount target for the config file in the wrong location on one of these image flavors.

To fix this, the documentation should instruct users to mount the config file under `/.hadolint.yaml` where it will be found in all three flavors equally.

related-to: hadolint/hadolint#652

### How to verify it

<img width="1415" height="1356" alt="Screenshot at 2026-08-07 15-08-15" src="https://github.com/user-attachments/assets/4a3db734-422d-49ef-8cec-f3051892313e" />
