### PR TITLE
Hadolint Online: Fix GHC WASM install

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,13 @@ jobs:
   build:
     name: Build WASM and JSFFI artifacts
     runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        include:
+          cabal: 3.14.2.0
+          ghc: wasm32-wasi-9.10.3.20260731
+
     steps:
 
       - name: Install System Dependencies
@@ -43,17 +50,12 @@ jobs:
           git clone https://gitlab.haskell.org/haskell-wasm/ghc-wasm-meta.git
           SKIP_GHC=1 ghc-wasm-meta/setup.sh
           source ~/.ghc-wasm/env
+
           ghcup config add-release-channel \
             https://gitlab.haskell.org/haskell-wasm/ghc-wasm-meta/-/raw/master/ghcup-wasm-0.0.9.yaml
 
-      - name: Install GHC
-        run: |
-          source ~/.ghc-wasm/env
-          ghcup install cabal --set 3.14.2.0
-          ghcup install ghc --set wasm32-wasi-9.10.3.20260403 -- \
-              --host=x86_64-linux \
-              --with-intree-gmp \
-              --with-system-libffi
+          ghcup install cabal --set {{ matrix.cabal }}
+          ghcup install ghc --set {{ matrix.ghc }} -- $CONFIGURE_ARGS
 
       - name: Checkout
         uses: actions/checkout@v7
@@ -64,12 +66,9 @@ jobs:
         working-directory: hadolint
         run: |
           cabal --version
-          export GHCPATH="/usr/local/.ghcup/ghc/wasm32-wasi-9.10.3.20260403/bin"
+          export GHCPATH="/usr/local/.ghcup/ghc/{{ matrix.ghc }}/bin"
           source ~/.ghc-wasm/env
           export PATH="$GHCPATH:$PATH"
-
-          which clang
-          clang --version
 
           # Fix up paths to GHC and utilities, because Cabal somehow mixes up
           # the regular GHC and wasm32-wasi-ghc versions


### PR DESCRIPTION
Fix GHC WASM install in Hadolint Online build pipeline
See also:
https://gitlab.haskell.org/ghc/ghc/-/work_items/27577