### PR TITLE
DL3066: Only warn on last USER instruction

### DIFF
--- a/src/Hadolint/Rule/DL3066.hs
+++ b/src/Hadolint/Rule/DL3066.hs
@@ -1,6 +1,8 @@
 module Hadolint.Rule.DL3066 (rule) where
 
 import qualified Data.Char as Char
+import qualified Data.IntMap.Strict as Map
+import qualified Data.Sequence as Seq
 import qualified Data.Set as Set
 import qualified Data.Text as Text
 import Hadolint.Rule
@@ -8,25 +10,47 @@ import Language.Docker.Syntax
 
 
 data Acc
-  = Acc { args :: Set.Set Text.Text }
+  = Acc
+      { stageLine :: Linenumber,
+        lines :: Map.IntMap Linenumber,
+        args :: Set.Set Text.Text
+      }
   | Empty
   deriving (Show)
 
 
 rule :: Rule args
-rule = customRule check (emptyState Empty)
+rule = veryCustomRule check (emptyState Empty) mark
   where
     code = "DL3066"
     severity = DLInfoC
     message = "Non-numeric user-id may not be resolvable by host system"
 
+    check line st (From _) = st |> modify forgetStage |> modify (rememberStage line)
     check line st (User u)
-      | Text.all Char.isDigit $ getUid u = st
-      | uidIsDefinedArg (state st) u = st
-      | otherwise = st |> addFail CheckFailure {..}
+      | Text.all Char.isDigit $ getUid u = st |> modify forgetStage
+      | uidIsDefinedArg (state st) u = st |> modify forgetStage
+      | otherwise = st |> modify (rememberLine line)
     check _ st (Arg arg _) = st |> modify (registerArg arg)
     check _ st _ = st
+
+    mark (State fails (Acc _ lines _)) = Map.foldl' (Seq.|>) fails (fmap fail lines)
+    mark st = failures st
+
+    fail line = CheckFailure {..}
 {-# INLINEABLE rule #-}
+
+rememberStage :: Linenumber -> Acc -> Acc
+rememberStage line Empty = Acc line Map.empty Set.empty
+rememberStage line (Acc _ lines args) = Acc line lines args
+
+forgetStage :: Acc -> Acc
+forgetStage Empty = Empty
+forgetStage (Acc stage lines args) = Acc stage (lines |> Map.delete stage) args
+
+rememberLine :: Linenumber -> Acc -> Acc
+rememberLine line Empty = Acc 0 (Map.singleton 0 line) Set.empty
+rememberLine line (Acc stage lines args) = Acc stage (lines |> Map.insert stage line) args
 
 getUid :: Text.Text -> Text.Text
 getUid t
@@ -38,7 +62,7 @@ getUid t
 
 uidIsDefinedArg :: Acc -> Text.Text -> Bool
 uidIsDefinedArg Empty _ = False
-uidIsDefinedArg (Acc args) u = any (`varInUid` u) args
+uidIsDefinedArg (Acc _ _ args) u = any (`varInUid` u) args
   where
     varInUid :: Text.Text -> Text.Text -> Bool
     varInUid var uid =
@@ -46,8 +70,5 @@ uidIsDefinedArg (Acc args) u = any (`varInUid` u) args
         || ( Text.pack "$" <> var ) `Text.isInfixOf` uid
 
 registerArg :: Text.Text -> Acc -> Acc
-registerArg arg Empty =
-  Acc { args = Set.singleton arg }
-registerArg arg (Acc args) =
-  Acc { args = Set.insert arg args }
-
+registerArg arg Empty = Acc 0 Map.empty (Set.singleton arg)
+registerArg arg (Acc line lines args) = Acc line lines (Set.insert arg args)

--- a/test/Hadolint/Rule/DL3066Spec.hs
+++ b/test/Hadolint/Rule/DL3066Spec.hs
@@ -14,17 +14,59 @@ spec = do
   describe "DL3066 Non-numeric user-id may not be resolvable by host system" $ do
 
     it "ok: numeric UID" $ do
-      ruleCatchesNot rule "USER 12345"
+      let dockerfile = Text.unlines [ "FROM foo:bar", "USER 1234" ]
+      ruleCatchesNot rule dockerfile
 
     it "ok: numeric UID and GID" $ do
-      ruleCatchesNot rule "USER 1234:5678"
+      let dockerfile = Text.unlines [ "FROM foo:bar", "USER 1234:5678" ]
+      ruleCatchesNot rule dockerfile
 
     it "not ok: non-numeric UID" $ do
-      ruleCatches rule "USER foobar"
+      let dockerfile = Text.unlines [ "FROM foo:bar", "USER foobar" ]
+      ruleCatches rule dockerfile
 
     it "not ok: non-numeric UID and GID" $ do
-      ruleCatches rule "USER foobar:barfoo"
+      let dockerfile = Text.unlines [ "FROM foo:bar", "USER foobar:barfoo" ]
+      ruleCatches rule dockerfile
 
     it "ok: UID is non-numeric, but is a defined ARG" $ do
       let dockerfile = Text.unlines [ "ARG APP_UID", "FROM foobar:barfoo", "USER ${APP_UID}" ]
        in ruleCatchesNot rule dockerfile
+
+    it "ok: UID is non-numeric in any but last build stage" $ do
+      let dockerfile =
+            Text.unlines
+              [ "FROM foo:bar AS build",
+                "USER foobar",
+                "FROM foobar:barfoo",
+                "USER 1234"
+              ]
+       in ruleCatchesNot rule dockerfile
+
+    it "not ok: UID is numeric not in last build stage" $ do
+      let dockerfile =
+            Text.unlines
+              [ "FROM foo:bar AS build",
+                "USER 1234",
+                "FROM foobar:barfoo",
+                "USER foobar"
+              ]
+       in ruleCatches rule dockerfile
+
+    it "ok: UID is non-numeric but USER with numeric UID follows" $ do
+      let dockerfile =
+            Text.unlines
+              [ "FROM foo:bar",
+                "USER foobar",
+                "USER 1234"
+              ]
+       in ruleCatchesNot rule dockerfile
+
+    it "not ok: UID is numeric but USER with non-numeric UID follows" $ do
+      let dockerfile =
+            Text.unlines
+              [ "FROM foo:bar",
+                "USER 1234",
+                "USER foobar"
+              ]
+       in ruleCatches rule dockerfile


### PR DESCRIPTION
### What I did

Only warn in last stage on the last USER instruction when a non-numeric UID is used.
Otherwise the probability to catch a false-positive is too high as it's quite common and legitimate to use the root user during build stages or during package installation etc.

related-to: hadolint/hadolint#1202

### How I did it

DL3066 now tracks which stage it is in and if the instruction it wants to warn on is the last `USER` instruction or not.

### How to verify it

This kind of dockerfile should now be fine:

```dockerfile
FROM debian:trixie
[...]
USER root                   # don't warn here
RUN apt-get install ...
[...]
FROM debian:trixie
USER 1234                   # the usage of numeric UID is enforced here
```