### PR TITLE
Dependencies: Bump HsYAML to v0.2.1.6

### DIFF
--- a/hadolint.cabal
+++ b/hadolint.cabal
@@ -156,7 +156,7 @@ library
     , filepath              >=1.5.4    && <1.6
     , foldl                 >=1.4.18   && <1.5
     , gitrev                >=1.3.1    && <1.4
-    , HsYAML                >=0.2.1    && <0.3
+    , HsYAML                >=0.2.1.6  && <0.3
     , language-docker       >=16.0.0   && <17
     , megaparsec            >=9.0.0    && <9.8
     , mtl                   >=2.3.1    && <2.4


### PR DESCRIPTION
Bump HsYAML to v0.2.1.6. This fixes a misrepoting of the license.