### PR TITLE
Reduce Dependencies

### DIFF
--- a/hadolint.cabal
+++ b/hadolint.cabal
@@ -150,12 +150,10 @@ library
     , containers            >=0.7      && <0.8
     , cryptohash-sha1       >=0.11.101 && <0.12
     , data-default          >=0.8.0    && <0.9
-    , deepseq               >=1.5.0    && <1.6
     , directory             >=1.3.8    && <1.4
     , email-validate        >=2.3.2    && <2.4
     , filepath              >=1.5.4    && <1.6
     , foldl                 >=1.4.18   && <1.5
-    , gitrev                >=1.3.1    && <1.4
     , HsYAML                >=0.2.1.6  && <0.3
     , language-docker       >=16.0.0   && <17
     , megaparsec            >=9.0.0    && <9.8
@@ -163,7 +161,6 @@ library
     , network-uri           >=2.6.4    && <2.7
     , optparse-applicative  >=0.18.1   && <0.20
     , parallel              >=3.2.2    && <3.3
-    , parsec                >=3.1.18   && <3.2
     , prettyprinter         >=1.7.1    && <1.8
     , semver                >=0.4.0    && <0.5
     , ShellCheck            >=0.11.0   && <0.12
@@ -172,7 +169,6 @@ library
     , text                  >=2.1.2    && <2.2
     , time                  >=1.14     && <1.15
     , timerep               >=2.1.0    && <2.2
-    , void                  >=0.7.3    && <0.8
     , xml-conduit           >=1.10.0   && <1.11
 
   default-language:   GHC2021

--- a/src/Hadolint/Pragma.hs
+++ b/src/Hadolint/Pragma.hs
@@ -9,9 +9,9 @@ module Hadolint.Pragma
 
 import Data.Functor.Identity (Identity)
 import Data.Text (Text)
-import Data.Void (Void)
 import Hadolint.Rule (RuleCode (RuleCode))
 import Language.Docker.Syntax
+import Language.Docker.Parser (DockerfileError)
 import qualified Control.Foldl as Foldl
 import qualified Data.IntMap.Strict as Map
 import qualified Data.Set as Set
@@ -59,31 +59,31 @@ parseStageIgnorePragma = Megaparsec.parseMaybe stageIgnoreParser
 parseGlobalIgnorePragma :: Text -> Maybe [Text]
 parseGlobalIgnorePragma = Megaparsec.parseMaybe globalIgnoreParser
 
-ignoreParser :: Megaparsec.Parsec Void Text [Text]
+ignoreParser :: Megaparsec.Parsec DockerfileError Text [Text]
 ignoreParser = hadolintPragma >> ignore
 
-stageIgnoreParser :: Megaparsec.Parsec Void Text [Text]
+stageIgnoreParser :: Megaparsec.Parsec DockerfileError Text [Text]
 stageIgnoreParser = hadolintPragma >> stage >> ignore
 
-globalIgnoreParser :: Megaparsec.Parsec Void Text [Text]
+globalIgnoreParser :: Megaparsec.Parsec DockerfileError Text [Text]
 globalIgnoreParser = hadolintPragma >> global >> ignore
 
-hadolintPragma :: Megaparsec.Parsec Void Text Text
+hadolintPragma :: Megaparsec.Parsec DockerfileError Text Text
 hadolintPragma = spaces >> string "hadolint" >> spaces1
 
-stage :: Megaparsec.Parsec Void Text Text
+stage :: Megaparsec.Parsec DockerfileError Text Text
 stage = string "stage" >> spaces1
 
-global :: Megaparsec.Parsec Void Text Text
+global :: Megaparsec.Parsec DockerfileError Text Text
 global = string "global" >> spaces1
 
-ignore :: Megaparsec.Parsec Void Text [Text]
+ignore :: Megaparsec.Parsec DockerfileError Text [Text]
 ignore = string "ignore" >> spaces >> string "=" >> spaces >> ruleList
 
-ruleList :: Megaparsec.Parsec Void Text [Text]
+ruleList :: Megaparsec.Parsec DockerfileError Text [Text]
 ruleList = Megaparsec.sepBy1 ruleName ( spaces >> string "," >> spaces )
 
-ruleName :: Megaparsec.ParsecT Void Text Identity (Megaparsec.Tokens Text)
+ruleName :: Megaparsec.ParsecT DockerfileError Text Identity (Megaparsec.Tokens Text)
 ruleName =
   Megaparsec.takeWhile1P Nothing (\c -> c `elem` Set.fromList "DLSC0123456789")
   <* inlineComment
@@ -91,26 +91,26 @@ ruleName =
 parseShell :: Text -> Maybe Text
 parseShell = Megaparsec.parseMaybe shellParser
 
-shellParser :: Megaparsec.Parsec Void Text Text
+shellParser :: Megaparsec.Parsec DockerfileError Text Text
 shellParser = hadolintPragma >> string "shell" >> spaces >> string "=" >> spaces >> shellName
 
-shellName :: Megaparsec.ParsecT Void Text Identity (Megaparsec.Tokens Text)
+shellName :: Megaparsec.ParsecT DockerfileError Text Identity (Megaparsec.Tokens Text)
 shellName =
   Megaparsec.takeWhile1P Nothing (\c -> c `notElem` Set.fromList "\n\t ")
   <* inlineComment
 
-inlineComment :: Megaparsec.Parsec Void Text (Maybe Text)
+inlineComment :: Megaparsec.Parsec DockerfileError Text (Maybe Text)
 inlineComment =
   spaces >> Megaparsec.optional ( string "#" >> Megaparsec.takeWhileP Nothing (/= '\n') )
 
 string :: Megaparsec.Tokens Text
-  -> Megaparsec.ParsecT Void Text Identity (Megaparsec.Tokens Text)
+  -> Megaparsec.ParsecT DockerfileError Text Identity (Megaparsec.Tokens Text)
 string = Megaparsec.string
 
-spaces :: Megaparsec.ParsecT Void Text Identity (Megaparsec.Tokens Text)
+spaces :: Megaparsec.ParsecT DockerfileError Text Identity (Megaparsec.Tokens Text)
 spaces = Megaparsec.takeWhileP Nothing space
 
-spaces1 :: Megaparsec.ParsecT Void Text Identity (Megaparsec.Tokens Text)
+spaces1 :: Megaparsec.ParsecT DockerfileError Text Identity (Megaparsec.Tokens Text)
 spaces1 = Megaparsec.takeWhile1P Nothing space
 
 space :: Char -> Bool

--- a/src/Hadolint/Rule.hs
+++ b/src/Hadolint/Rule.hs
@@ -1,6 +1,5 @@
 module Hadolint.Rule where
 
-import Control.DeepSeq (NFData)
 import Data.Default
 import Data.String (IsString (..))
 import Data.Text (Text, unpack)
@@ -24,7 +23,7 @@ data DLSeverity
   | DLInfoC
   | DLStyleC
   | DLIgnoreC
-  deriving (Eq, Ord, Show, Generic, NFData)
+  deriving (Eq, Ord, Show, Generic)
 
 instance Yaml.FromYAML DLSeverity where
   parseYAML = withSeverity pure


### PR DESCRIPTION
Remove some unnecessary dependencies.

1) deepseq

This was used to make the DLSeverity type fully evaluatable. But that property was both trivial as DLSeverity is basically just an enum and the property was not relied upon anywhere.

2) gitrev

No longer used as the version info doesn't contain Git information anymore as this makes Hadolint unbuildable by GHC WASM.

3) parsec

Not used anywhere. Megaparsec is used instead.

4) void

Used as error type for the parser that deals with pragma comments. These comments are parsed by Hadolint itself rather than language-docker, since they aren't part of Dockerfile syntax, but specific annoations for Hadolint.
But since language-docker is a dependency anyways, it make more sense to reuse DockerfileError as error type here as well.
