### PR TITLE
Formatters: Add GitLab Code Quality Format

### DIFF
--- a/hadolint.cabal
+++ b/hadolint.cabal
@@ -33,6 +33,7 @@ library
     Hadolint.Formatter.Checkstyle
     Hadolint.Formatter.Codacy
     Hadolint.Formatter.Codeclimate
+    Hadolint.Formatter.CodeQuality
     Hadolint.Formatter.Format
     Hadolint.Formatter.Gnu
     Hadolint.Formatter.JUnit
@@ -246,6 +247,7 @@ test-suite hadolint-unit-tests
     Hadolint.Config.ConfigurationSpec
     Hadolint.Config.EnvironmentSpec
     Hadolint.Config.SpecHook
+    Hadolint.Formatter.CodeQualitySpec
     Hadolint.Formatter.GnuSpec
     Hadolint.Formatter.ParseErrorSpec
     Hadolint.Formatter.JUnitSpec

--- a/src/Hadolint/Formatter.hs
+++ b/src/Hadolint/Formatter.hs
@@ -12,6 +12,7 @@ import Language.Docker.Parser (DockerfileError)
 import qualified Hadolint.Formatter.Checkstyle as FormatCheckstyle
 import qualified Hadolint.Formatter.Codacy as FormatCodacy
 import qualified Hadolint.Formatter.Codeclimate as FormatCodeclimate
+import qualified Hadolint.Formatter.CodeQuality as FormatCodeQuality
 import qualified Hadolint.Formatter.Gnu as FormatGnu
 import qualified Hadolint.Formatter.JUnit as FormatJUnit
 import qualified Hadolint.Formatter.Json as FormatJson
@@ -34,6 +35,7 @@ hWrite handle format nocolor filePathInReport allResults =
     Codacy -> FormatCodacy.hWrite handle allResults
     CodeclimateJson -> FormatCodeclimate.hWrite handle allResults filePathInReport
     GitLabCodeclimateJson -> FormatCodeclimate.hWriteGitLab handle allResults filePathInReport
+    GitLabCodeQualityJson -> FormatCodeQuality.hWrite handle allResults filePathInReport
     Gnu -> FormatGnu.hWrite handle allResults
     JUnit -> FormatJUnit.hWrite handle allResults filePathInReport
     Json -> FormatJson.hWrite handle allResults

--- a/src/Hadolint/Formatter/CodeQuality.hs
+++ b/src/Hadolint/Formatter/CodeQuality.hs
@@ -1,0 +1,128 @@
+-- Code Quality output formatter
+--
+-- GitLab CI has deprecated their CodeClimate based report format in GitLab v17.3 and plans to
+-- remove it in v19.0. The CodeClimate based report format is going to be replaced by this Code
+-- Quality report format, which is basically a simplified version.
+--
+-- See:
+--   - https://docs.gitlab.com/update/deprecations/#codeclimate-based-code-quality-scanning-will-be-removed
+--   - https://docs.gitlab.com/ci/testing/code_quality/#code-quality-report-format
+
+module Hadolint.Formatter.CodeQuality
+  ( hWrite )
+where
+
+
+import qualified Control.Foldl as Foldl
+import qualified Crypto.Hash.SHA1 as SHA1
+import Data.Aeson hiding (Result)
+import qualified Data.ByteString.Lazy as B
+import qualified Data.ByteString.Base16 as B16
+import qualified Data.ByteString.Char8 as Char8
+import Data.Sequence (Seq)
+import qualified Data.Text as Text
+import Hadolint.Formatter.Format (Result (..), errorPosition)
+import Hadolint.Rule (CheckFailure (..), DLSeverity (..), RuleCode (..))
+import System.IO
+import Text.Megaparsec (TraversableStream)
+import Text.Megaparsec.Error
+import Text.Megaparsec.Pos (sourceLine, unPos)
+import Text.Megaparsec.Stream (VisualStream)
+
+data Issue = Issue
+  { checkName :: Text.Text,
+    description :: Text.Text,
+    location :: Location,
+    impact :: Text.Text
+  }
+
+data FingerprintIssue = FingerprintIssue
+  { issue :: Issue,
+    fingerprint :: Char8.ByteString
+  }
+
+data Location = Location
+  { path :: Text.Text,
+    line :: Int
+  }
+
+instance ToJSON Location where
+  toJSON Location {..} =
+    object
+      [ "path" .= path,
+        "lines" .= object [ "begin" .= line ]
+      ]
+
+instance ToJSON Issue where
+  toJSON Issue {..} =
+    object
+      [ "check_name" .= checkName,
+        "description" .= description,
+        "location" .= location,
+        "severity" .= impact
+      ]
+
+instance ToJSON FingerprintIssue where
+  toJSON FingerprintIssue {..} =
+    object
+      [ "fingerprint" .= Char8.unpack fingerprint,
+        "check_name" .= checkName issue,
+        "description" .= description issue,
+        "location" .= location issue,
+        "severity" .= impact issue
+      ]
+
+errorToIssue :: (VisualStream s, TraversableStream s, ShowErrorComponent e) => Text.Text -> ParseErrorBundle s e -> Issue
+errorToIssue filename err =
+  Issue
+    { checkName = "DL1000",
+      description = Text.pack $ errorBundlePretty err,
+      location = Location filename line,
+      impact = severityText DLErrorC
+    }
+  where
+    pos = errorPosition err
+    line = unPos (sourceLine pos)
+
+checkToIssue :: Text.Text -> CheckFailure -> Issue
+checkToIssue filename CheckFailure {..} =
+  Issue
+    { checkName = unRuleCode code,
+      description = message,
+      location = Location filename line,
+      impact = severityText severity
+    }
+
+severityText :: DLSeverity -> Text.Text
+severityText severity =
+  case severity of
+    DLErrorC -> "blocker"
+    DLWarningC -> "major"
+    DLInfoC -> "minor"
+    DLStyleC -> "info"
+    _ -> ""
+
+generateFingerprint :: Issue -> Char8.ByteString
+generateFingerprint = B16.encode . SHA1.hashlazy . encode
+
+issueToFingerprintIssue :: Issue -> FingerprintIssue
+issueToFingerprintIssue i =
+  FingerprintIssue
+    { issue = i,
+      fingerprint = generateFingerprint i
+    }
+
+formatResult :: (VisualStream s, TraversableStream s, ShowErrorComponent e) => Result s e -> Maybe FilePath -> Seq FingerprintIssue
+formatResult (Result filename errors checks) Nothing =
+  issueToFingerprintIssue <$>
+    (errorToIssue filename <$> errors) <> (checkToIssue filename <$> checks)
+formatResult (Result _ errors checks) (Just filePathInReport) =
+  issueToFingerprintIssue <$>
+    (errorToIssue ( Text.pack filePathInReport ) <$> errors) <> (checkToIssue ( Text.pack filePathInReport ) <$> checks)
+
+hWrite ::
+  (Foldable f, VisualStream s, TraversableStream s, ShowErrorComponent e) =>
+  Handle -> f (Result s e) -> Maybe FilePath -> IO ()
+hWrite handle results filePathInReport = B.hPutStr handle . encode $ flattened
+  where
+    flattened = Foldl.fold (Foldl.premap formatResult Foldl.mconcat) results filePathInReport

--- a/src/Hadolint/Formatter/Format.hs
+++ b/src/Hadolint/Formatter/Format.hs
@@ -32,6 +32,7 @@ data OutputFormat
   | Codacy
   | CodeclimateJson
   | GitLabCodeclimateJson
+  | GitLabCodeQualityJson
   | Gnu
   | JUnit
   | Json
@@ -45,6 +46,7 @@ instance Pretty OutputFormat where
   pretty Codacy = "codacy"
   pretty CodeclimateJson = "codeclimate"
   pretty GitLabCodeclimateJson = "gitlab_codeclimate"
+  pretty GitLabCodeQualityJson = "gitlab_codequality"
   pretty Gnu = "gnu"
   pretty JUnit = "junit"
   pretty Json = "json"
@@ -79,6 +81,7 @@ readMaybeOutputFormat "checkstyle" = Just Checkstyle
 readMaybeOutputFormat "codacy" = Just Codacy
 readMaybeOutputFormat "codeclimate" = Just CodeclimateJson
 readMaybeOutputFormat "gitlab_codeclimate" = Just GitLabCodeclimateJson
+readMaybeOutputFormat "gitlab_codequality" = Just GitLabCodeQualityJson
 readMaybeOutputFormat "gnu" = Just Gnu
 readMaybeOutputFormat "junit" = Just JUnit
 readMaybeOutputFormat "json" = Just Json

--- a/test/Hadolint/Formatter/CodeQualitySpec.hs
+++ b/test/Hadolint/Formatter/CodeQualitySpec.hs
@@ -1,0 +1,118 @@
+module Hadolint.Formatter.CodeQualitySpec ( spec ) where
+
+
+import Data.Aeson
+import qualified Data.ByteString.Lazy.Char8 as BSC
+import qualified Data.List.NonEmpty as NonEmpty
+import qualified Data.Sequence as Seq
+import Helpers
+import Hadolint
+  ( CheckFailure (..),
+    DLSeverity (..),
+    OutputFormat (..),
+    getShortVersion,
+  )
+import Hadolint.Formatter (write)
+import Hadolint.Formatter.Format (Result (..))
+import System.IO.Silently (capture)
+import Test.Hspec
+import qualified Data.Map as Map
+import qualified Data.Text as Text
+import qualified Data.Time as Time
+
+
+spec :: SpecWith ()
+spec = do
+  let ?noColor = True
+  let mkIssue rule severity msg line path fingerprint =
+        object
+          [ "fingerprint" .= String fingerprint,
+            "check_name" .= String rule,
+            "description" .= String msg,
+            "severity" .= String severity,
+            "location" .= object [ "path" .= String path, "lines" .= object [ "begin" .= Number line ] ]
+          ]
+
+  describe "Formatter: GitLab Code Quality JSON" $ do
+    it "print empty results" $ do
+      let checkFails = []
+          expectation = Array []
+      assertFormatterJson GitLabCodeQualityJson checkFails expectation
+
+    it "print several issues with default path" $ do
+      let checkFails =
+            [ CheckFailure
+                { code = "DL3000",
+                  severity = DLErrorC,
+                  message = "error msg",
+                  line = 1
+                },
+              CheckFailure
+                { code = "DL3001",
+                  severity = DLWarningC,
+                  message = "warning msg",
+                  line = 2
+                },
+              CheckFailure
+                { code = "DL3009",
+                  severity = DLInfoC,
+                  message = "info msg",
+                  line = 3
+                },
+              CheckFailure
+                { code = "DL3015",
+                  severity = DLStyleC,
+                  message = "style msg",
+                  line = 4
+                }
+            ]
+          results = NonEmpty.fromList [Result "Dockerfile" mempty (Seq.fromList checkFails)]
+          customPath = Nothing
+          expectation =
+            Array
+              [ mkIssue "DL3000" "blocker" "error msg" 1 "Dockerfile" "8c24ad9492ded635f713f3c78923d5510b111f40",
+                mkIssue "DL3001" "major" "warning msg" 2 "Dockerfile" "87776f32f22334316c9631f286591c50bc9e94f8",
+                mkIssue "DL3009" "minor" "info msg" 3 "Dockerfile" "740874fcb748f021198f3f562f5f1408d319cc1a",
+                mkIssue "DL3015" "info" "style msg" 4 "Dockerfile" "cb499eec1a275148cb6f736b4086a3adea064b89"
+              ]
+      (cap, _) <- capture (write [] [GitLabCodeQualityJson] ?noColor customPath results)
+      decode (BSC.pack cap) `shouldBe` Just expectation
+
+    it "print several issues with custom path" $ do
+      let checkFails =
+            [ CheckFailure
+                { code = "DL3000",
+                  severity = DLErrorC,
+                  message = "error msg",
+                  line = 1
+                },
+              CheckFailure
+                { code = "DL3001",
+                  severity = DLWarningC,
+                  message = "warning msg",
+                  line = 2
+                },
+              CheckFailure
+                { code = "DL3009",
+                  severity = DLInfoC,
+                  message = "info msg",
+                  line = 3
+                },
+              CheckFailure
+                { code = "DL3015",
+                  severity = DLStyleC,
+                  message = "style msg",
+                  line = 4
+                }
+            ]
+          results = NonEmpty.fromList [Result "<string>" mempty (Seq.fromList checkFails)]
+          customPath = Just "path/to/custom/Dockerfile"
+          expectation =
+            Array
+              [ mkIssue "DL3000" "blocker" "error msg" 1 "path/to/custom/Dockerfile" "146a5e52d3679c0a06b6f9194a65dce5e508daa3",
+                mkIssue "DL3001" "major" "warning msg" 2 "path/to/custom/Dockerfile" "5bf0f9deb716d98f5be8989c6e7050ba0e8af399",
+                mkIssue "DL3009" "minor" "info msg" 3 "path/to/custom/Dockerfile" "e9079fa0a99b607182c15dca9b65932dfd45c627",
+                mkIssue "DL3015" "info" "style msg" 4 "path/to/custom/Dockerfile" "07d17ce9a67fd5cd2160ded51848c7e9583c52fe"
+              ]
+      (cap, _) <- capture (write [] [GitLabCodeQualityJson] ?noColor customPath results)
+      decode (BSC.pack cap) `shouldBe` Just expectation


### PR DESCRIPTION
### What I did

Add new GitLab Code Quality output format.
GitLab has deprecated the CodeClimate format in GitLab v17.3 and removed it in v19.0.
As replacement, it expects linters to produce the simplified Code Quality format.
To Facilitate integration with GitLab CI, Hadolint needs to be able to produce this new output format.

related-to: hadolint/hadolint#1247

### How to verify it

`hadolint -f gitlab_codequality` should produce output that is compatible with [the GitLab Code Quality format](https://docs.gitlab.com/ci/testing/code_quality/#code-quality-report-format)