### PR TITLE
Use cmdHasAllArgs to ensure all command arguments are present

### DIFF
--- a/src/Hadolint/Rule/DL3009.hs
+++ b/src/Hadolint/Rule/DL3009.hs
@@ -73,7 +73,7 @@ forgotToCleanup args
   | otherwise = False
   where
     hasCleanup =
-      any (Shell.cmdHasArgs "rm" ["-rf", "/var/lib/apt/lists/*"]) (Shell.presentCommands args)
+      any (Shell.cmdHasAllArgs "rm" ["-rf", "/var/lib/apt/lists/*"]) (Shell.presentCommands args)
 
 hasUpdate :: Shell.ParsedShell -> Bool
 hasUpdate args = any isPackageUpdate (Shell.presentCommands args)

--- a/src/Hadolint/Rule/DL3032.hs
+++ b/src/Hadolint/Rule/DL3032.hs
@@ -24,6 +24,6 @@ dl3032 = simpleRule code severity message check
     check _ = True
 
     yumInstall = Shell.cmdHasArgs "yum" ["install"]
-    yumClean args = Shell.cmdHasArgs "yum" ["clean", "all"] args
-      || Shell.cmdHasArgs "rm" ["-rf", "/var/cache/yum/*"] args
+    yumClean args = Shell.cmdHasAllArgs "yum" ["clean", "all"] args
+      || Shell.cmdHasAllArgs "rm" ["-rf", "/var/cache/yum/*"] args
 {-# INLINEABLE dl3032 #-}

--- a/src/Hadolint/Rule/DL3040.hs
+++ b/src/Hadolint/Rule/DL3040.hs
@@ -32,8 +32,8 @@ dl3040 = simpleRule code severity message check
 
     dnfInstall cmdName args = ( cmdName `elem` dnfCmds )
       && Shell.cmdHasArgs cmdName installCmds args
-    dnfClean cmdName args = Shell.cmdHasArgs cmdName ["clean", "all"] args
-      || Shell.cmdHasArgs "rm" ["-rf", "/var/cache/libdnf5*"] args
+    dnfClean cmdName args = Shell.cmdHasAllArgs cmdName ["clean", "all"] args
+      || Shell.cmdHasAllArgs "rm" ["-rf", "/var/cache/libdnf5"] args
     dnfCmds = ["dnf", "microdnf"]
     installCmds = ["install", "in", "upgrade", "up", "upgrade-minimal", "up-min", "reinstall", "rei"]
 {-# INLINEABLE dl3040 #-}

--- a/src/Hadolint/Rule/DL3060.hs
+++ b/src/Hadolint/Rule/DL3060.hs
@@ -68,7 +68,7 @@ yarnInstall :: Shell.Command -> Bool
 yarnInstall = Shell.cmdHasArgs "yarn" ["install"]
 
 yarnCacheClean :: Shell.Command -> Bool
-yarnCacheClean = Shell.cmdHasArgs "yarn" ["cache", "clean"]
+yarnCacheClean = Shell.cmdHasAllArgs "yarn" ["cache", "clean"]
 
 isCleanBeforeInstall :: Shell.ParsedShell -> Bool
 isCleanBeforeInstall args =

--- a/src/Hadolint/Shell.hs
+++ b/src/Hadolint/Shell.hs
@@ -205,6 +205,14 @@ cmdsHaveArgs expectedNames expectedArgs (Command n args _)
   | n `notElem` expectedNames = False
   | otherwise = not $ null [arg | CmdPart arg _ <- args, arg `elem` expectedArgs]
 
+cmdHasAllArgs :: Text.Text -> [Text.Text] -> Command -> Bool
+cmdHasAllArgs expectedName = cmdsHaveAllArgs [expectedName]
+
+cmdsHaveAllArgs :: [Text.Text] -> [Text.Text] -> Command -> Bool
+cmdsHaveAllArgs expectedNames expectedArgs (Command n args _)
+  | n `notElem` expectedNames = False
+  | otherwise = all (`elem` [arg | CmdPart arg _ <- args]) expectedArgs
+
 cmdHasPrefixArg :: Text.Text -> Text.Text -> Command -> Bool
 cmdHasPrefixArg expectedName expectedArg (Command n args _)
   | expectedName /= n = False

--- a/test/Hadolint/Rule/DL3009Spec.hs
+++ b/test/Hadolint/Rule/DL3009Spec.hs
@@ -211,3 +211,22 @@ spec = do
        in do
             ruleCatchesNot "DL3009" $ Text.unlines dockerFile
             onBuildRuleCatchesNot "DL3009" $ Text.unlines dockerFile
+
+    it "ok with strict all-args matching for aptitude cleanup" $ do
+      let dockerFile :: [Text]
+          dockerFile =
+            [ "RUN aptitude update && aptitude install python && rm -rf /var/lib/apt/lists/*",
+              "RUN rm -rf /foo/bar && aptitude update && aptitude install python && rm -rf /var/lib/apt/lists/*",
+              "RUN aptitude update && rm -rf /foo/bar && aptitude install python && rm -rf /var/lib/apt/lists/*"
+            ]
+      mapM_ (ruleCatchesNot "DL3009") dockerFile
+      mapM_ (onBuildRuleCatchesNot "DL3009") dockerFile
+
+    it "not ok with strict all-args matching for aptitude cleanup" $ do
+      let dockerFile :: [Text]
+          dockerFile =
+            [ "RUN aptitude update && aptitude install python && rm -rf /var/cache/libdnf5",
+              "RUN aptitude update && aptitude install python && rm -rf /var/cache/yum/*"
+            ]
+      mapM_ (ruleCatches "DL3009") dockerFile
+      mapM_ (onBuildRuleCatches "DL3009") dockerFile

--- a/test/Hadolint/Rule/DL3032Spec.hs
+++ b/test/Hadolint/Rule/DL3032Spec.hs
@@ -24,3 +24,19 @@ spec = do
     it "not ok with clean before install" $ do
       ruleCatchesNot "DL3032" "RUN yum install -y mariadb-10.4 && yum clean all"
       ruleCatches "DL3032" "RUN yum clean all && yum install -y"
+
+    it "strict all-args matching for yum cleanup" $ do
+      ruleCatches "DL3032" "RUN yum install -y bash && yum clean"
+      ruleCatches "DL3032" "RUN yum install -y bash && yum clean cache"
+      ruleCatchesNot "DL3032" "RUN yum install -y bash && yum clean all"
+      ruleCatches "DL3032" "RUN yum install -y bash && rm -rf /var/lib/apt/lists/*"
+      ruleCatchesNot "DL3032" "RUN yum install -y bash && rm -rf /var/cache/yum/*"
+      ruleCatches "DL3032" "RUN yum install -y bash && rm -rf /var/cache/libdnf5"
+      ruleCatchesNot "DL3032" "RUN rm -rf /foo/bar && yum install -y bash && rm -rf /var/cache/yum/*"
+      onBuildRuleCatches "DL3032" "RUN yum install -y bash && yum clean"
+      onBuildRuleCatches "DL3032" "RUN yum install -y bash && yum clean cache"
+      onBuildRuleCatchesNot "DL3032" "RUN yum install -y bash && yum clean all"
+      onBuildRuleCatches "DL3032" "RUN yum install -y bash && rm -rf /var/lib/apt/lists/*"
+      onBuildRuleCatchesNot "DL3032" "RUN yum install -y bash && rm -rf /var/cache/yum/*"
+      onBuildRuleCatches "DL3032" "RUN yum install -y bash && rm -rf /var/cache/libdnf5"
+      onBuildRuleCatchesNot "DL3032" "RUN rm -rf /foo/bar && yum install -y bash && rm -rf /var/cache/yum/*"

--- a/test/Hadolint/Rule/DL3040Spec.hs
+++ b/test/Hadolint/Rule/DL3040Spec.hs
@@ -29,13 +29,13 @@ spec = do
       onBuildRuleCatchesNot "DL3040" "RUN microdnf install -y mariadb-10.4 && microdnf clean all"
       onBuildRuleCatchesNot "DL3040" "RUN notdnf install mariadb"
 
-    it "ok with rm /var/cache/yum" $ do
-      ruleCatchesNot "DL3040" "RUN dnf install -y mariadb-10.4 && rm -rf /var/cache/yum/*"
-      ruleCatchesNot "DL3040" "RUN dnf in -y mariadb-10.4 && rm -rf /var/cache/yum/*"
-      ruleCatchesNot "DL3040" "RUN microdnf install -y mariadb-10.4 && rm -rf /var/cache/yum/*"
-      onBuildRuleCatchesNot "DL3040" "RUN dnf install -y mariadb-10.4 && rm -rf /var/cache/yum/*"
-      onBuildRuleCatchesNot "DL3040" "RUN dnf in -y mariadb-10.4 && rm -rf /var/cache/yum/*"
-      onBuildRuleCatchesNot "DL3040" "RUN microdnf install -y mariadb-10.4 && rm -rf /var/cache/yum/*"
+    it "not ok with rm /var/cache/yum" $ do
+      ruleCatches "DL3040" "RUN dnf install -y mariadb-10.4 && rm -rf /var/cache/yum/*"
+      ruleCatches "DL3040" "RUN dnf in -y mariadb-10.4 && rm -rf /var/cache/yum/*"
+      ruleCatches "DL3040" "RUN microdnf install -y mariadb-10.4 && rm -rf /var/cache/yum/*"
+      onBuildRuleCatches "DL3040" "RUN dnf install -y mariadb-10.4 && rm -rf /var/cache/yum/*"
+      onBuildRuleCatches "DL3040" "RUN dnf in -y mariadb-10.4 && rm -rf /var/cache/yum/*"
+      onBuildRuleCatches "DL3040" "RUN microdnf install -y mariadb-10.4 && rm -rf /var/cache/yum/*"
 
     it "not ok with clean before install" $ do
       ruleCatches "DL3040" "RUN microdnf clean all && dnf install -y mariadb-10.4"
@@ -69,6 +69,22 @@ spec = do
       onBuildRuleCatches "DL3040" "RUN dnf -y upgrade"
       onBuildRuleCatches "DL3040" "RUN dnf -y up"
 
+    it "strict all-args matching for dnf cleanup" $ do
+      ruleCatches "DL3040" "RUN dnf install -y bash && dnf clean"
+      ruleCatches "DL3040" "RUN dnf install -y bash && dnf clean cache"
+      ruleCatchesNot "DL3040" "RUN dnf install -y bash && dnf clean all"
+      ruleCatches "DL3040" "RUN dnf install -y bash && rm -rf /var/lib/apt/lists/*"
+      ruleCatchesNot "DL3040" "RUN dnf install -y bash && rm -rf /var/cache/libdnf5"
+      ruleCatches "DL3040" "RUN dnf install -y bash && rm -rf /var/cache/yum/*"
+      ruleCatchesNot "DL3040" "RUN rm -rf /foo/bar && dnf install -y bash && rm -rf /var/cache/libdnf5"
+      onBuildRuleCatches "DL3040" "RUN dnf install -y bash && dnf clean"
+      onBuildRuleCatches "DL3040" "RUN dnf install -y bash && dnf clean cache"
+      onBuildRuleCatchesNot "DL3040" "RUN dnf install -y bash && dnf clean all"
+      onBuildRuleCatches "DL3040" "RUN dnf install -y bash && rm -rf /var/lib/apt/lists/*"
+      onBuildRuleCatchesNot "DL3040" "RUN dnf install -y bash && rm -rf /var/cache/libdnf5"
+      onBuildRuleCatches "DL3040" "RUN dnf install -y bash && rm -rf /var/cache/yum/*"
+      onBuildRuleCatchesNot "DL3040" "RUN rm -rf /foo/bar && dnf install -y bash && rm -rf /var/cache/libdnf5"
+
     it "different install command variants" $ do
       ruleCatches "DL3040" "RUN dnf -y install"
       ruleCatches "DL3040" "RUN dnf -y in"
@@ -86,3 +102,19 @@ spec = do
       ruleCatchesNot "DL3040" "RUN dnf -y up-min && dnf clean all"
       ruleCatchesNot "DL3040" "RUN dnf -y reinstall && dnf clean all"
       ruleCatchesNot "DL3040" "RUN dnf -y rei && dnf clean all"
+      onBuildRuleCatches "DL3040" "RUN dnf -y install"
+      onBuildRuleCatches "DL3040" "RUN dnf -y in"
+      onBuildRuleCatches "DL3040" "RUN dnf -y upgrade"
+      onBuildRuleCatches "DL3040" "RUN dnf -y up"
+      onBuildRuleCatches "DL3040" "RUN dnf -y upgrade-minimal"
+      onBuildRuleCatches "DL3040" "RUN dnf -y up-min"
+      onBuildRuleCatches "DL3040" "RUN dnf -y reinstall"
+      onBuildRuleCatches "DL3040" "RUN dnf -y rei"
+      onBuildRuleCatchesNot "DL3040" "RUN dnf -y install && dnf clean all"
+      onBuildRuleCatchesNot "DL3040" "RUN dnf -y in && dnf clean all"
+      onBuildRuleCatchesNot "DL3040" "RUN dnf -y upgrade && dnf clean all"
+      onBuildRuleCatchesNot "DL3040" "RUN dnf -y up && dnf clean all"
+      onBuildRuleCatchesNot "DL3040" "RUN dnf -y upgrade-minimal && dnf clean all"
+      onBuildRuleCatchesNot "DL3040" "RUN dnf -y up-min && dnf clean all"
+      onBuildRuleCatchesNot "DL3040" "RUN dnf -y reinstall && dnf clean all"
+      onBuildRuleCatchesNot "DL3040" "RUN dnf -y rei && dnf clean all"

--- a/test/Hadolint/Rule/DL3060Spec.hs
+++ b/test/Hadolint/Rule/DL3060Spec.hs
@@ -94,3 +94,23 @@ spec = do
        in do
             ruleCatchesNot "DL3060" dockerFile
             onBuildRuleCatches "DL3060" dockerFile
+
+    it "ok with strict all-args matching for yarn cache clean" $
+      let dockerFile =
+            Text.unlines
+              [ "RUN yarn install foo && yarn cache clean"
+              ]
+       in do
+            ruleCatchesNot "DL3060" dockerFile
+            onBuildRuleCatchesNot "DL3060" dockerFile
+
+    it "not ok with strict all-args matching for yarn cache clean" $
+      let dockerFile :: [Text.Text]
+          dockerFile =
+            [ "RUN yarn install foo && yarn cache",
+              "RUN yarn install foo && yarn cache dir"
+            ]
+       in do
+            mapM_ (ruleCatches "DL3060") dockerFile
+            mapM_ (onBuildRuleCatches "DL3060") dockerFile
+


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

### What I did

This replaces checks for "command with **one** of these arguments" with checks for "command with **all** of these arguments".

Changed rules:
- DL3009:
    - the cleanup command must now be "rm" with both "-rf" and the folder path, not just one of them
- DL3032
    - the cleanup command must now be one of:
        - "yum" with both "clean" and "all" flags, or
        - "rm" with both "-rf" and the folder path
- DL3040
    - the cleanup command must now be one of:
        - "dnf" or "microdnf" with both "clean" and "all" flags, or
        - "rm" with both "-rf" and the folder path
        - for cleanup with "rm" corrected the folder path:
            - old: "/var/cache/libdnf5*" (trailing "*")
            - new: "/var/cache/libdnf5"
- DL3060
    - the cleanup command must now be "yarn" with both "cache" and "clean" flags

### Why I did it

**Example of a problem with cmdHasArgs:**

`Shell.cmdHasArgs "rm" ["-rf", "/foo"]` matches "rm -rf /bar" because argument "-rf" alone is enough.

**Example of a resulting false positive for rule DL3040:**

`RUN rm -rf /foo && dnf install -y bash && dnf clean all` triggers:
_DL3040 "`dnf clean all` missing after dnf command"_
because "rm -rf" is seen as dnf cleanup before "dnf install" despite the deleted folder not being related to dnf.

### How I did it

1. Added `cmdHasAllArgs`/`cmdsHaveAllArgs` where all expectedNames should be present, not just one.
2. Searched for calls to `cmdHasArgs`/`cmdsHaveArgs` with several expectedNames and decided which needed all expectedNames.
3. Replaced those calls to `cmdHasArgs`/`cmdsHaveArgs` with `cmdHasAllArgs`/`cmdsHaveAllArgs`.
4. Added/updated tests:
    - Added specific tests for the new behavior of rules.
    - For DL3040:
        - Inverted the "ok with rm /var/cache/yum" test which was actually wrong before
        - Added a few "onBuildRuleCatches"/"onBuildRuleCatchesNot" tests for symmetry with existing "ruleCatches"/"ruleCatchesNot" tests.

### How to verify it

Cherry-pick just the test changes from this PR and run `cabal test`.

The 5 failing tests are wrong:
1. test/Hadolint/Rule/DL3009Spec.hs:231:14: passes the rule with "rm -rf" of the wrong folder
2. test/Hadolint/Rule/DL3032Spec.hs:29:7: passes the rule with only "yum clean" not "yum clean all"
3. test/Hadolint/Rule/DL3040Spec.hs:33:7: passes the rule with "rm -rf" of the wrong folder
4. test/Hadolint/Rule/DL3040Spec.hs:73:7: passes the rule with only "dnf clean" not "dnf clean all"
5. test/Hadolint/Rule/DL3060Spec.hs:114:20: passes the rule with only "yarn cache" not "yarn cache clean"

Then apply all the other changes from this PR and run `cabal test` again. The tests will now pass.

### Related issues

- Fixes #1250
- Fixes #1179